### PR TITLE
re-add ConfigSourceFactory

### DIFF
--- a/backend/src/main/java/org/cryptomator/hub/config/HubConfig.java
+++ b/backend/src/main/java/org/cryptomator/hub/config/HubConfig.java
@@ -16,15 +16,13 @@ public class HubConfig implements ConfigSource {
 
 	private static final Logger LOG = Logger.getLogger(HubConfig.class);
 	private static final String HUB_CONFIGSOURCE_NAME = "HubConfig";
-	private static final String HUB_CONFIGPATH_PROPERTY_KEY = "hub.config.path";
 
 	private final HubConfigPersistence persistence;
 	private final Properties config;
 
-	public HubConfig() {
-		var configPath = System.getProperty(HUB_CONFIGPATH_PROPERTY_KEY);
+	public HubConfig(String configPath) {
 		if (configPath == null) {
-			throw new IllegalStateException("Property " + HUB_CONFIGPATH_PROPERTY_KEY + " not set.");
+			throw new IllegalStateException("Hub config path not set.");
 		}
 
 		LOG.info("Hub config persists to " + configPath);

--- a/backend/src/main/java/org/cryptomator/hub/config/HubConfigSourceFactory.java
+++ b/backend/src/main/java/org/cryptomator/hub/config/HubConfigSourceFactory.java
@@ -1,0 +1,19 @@
+package org.cryptomator.hub.config;
+
+import io.smallrye.config.ConfigSourceContext;
+import io.smallrye.config.ConfigSourceFactory;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+
+import java.util.List;
+
+public class HubConfigSourceFactory implements ConfigSourceFactory {
+
+	private static final String HUBCONFIG_PROPERTY_KEY = "hub.config.path";
+
+	@Override
+	public Iterable<ConfigSource> getConfigSources(ConfigSourceContext configSourceContext) {
+		var configPath = configSourceContext.getValue(HUBCONFIG_PROPERTY_KEY);
+		var hubConfig = new HubConfig(configPath.getValue());
+		return List.of(hubConfig);
+	}
+}

--- a/backend/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceFactory
+++ b/backend/src/main/resources/META-INF/services/io.smallrye.config.ConfigSourceFactory
@@ -1,0 +1,1 @@
+org.cryptomator.hub.config.HubConfigSourceFactory

--- a/backend/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource
+++ b/backend/src/main/resources/META-INF/services/org.eclipse.microprofile.config.spi.ConfigSource
@@ -1,1 +1,0 @@
-org.cryptomator.hub.config.HubConfig

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -8,6 +8,9 @@ quarkus.http.port=9090
 quarkus.oidc.application-type=service
 quarkus.oidc.client-id=cryptomator-hub
 
+hub.config.path=hub.properties
+%test.hub.config.path=target/hub-test.properties
+
 # Keycloak dev service
 %dev.quarkus.keycloak.devservices.enabled=true
 %dev.quarkus.keycloak.devservices.create-realm=false


### PR DESCRIPTION
This is a second attempt of #3:

We want our ConfigSource to read configurations from sources with lower ordinals. MP Config does not support this yet (see eclipse/microprofile-config#470), but Smallrye Config makes this possible via ConfigSourceFactories.

@infeo used this approach already, but due to problems with non-singleton config instances (one per class loader), we decided to use a less complex (but also less capable) approach.

Now the situation changed, as being able to read existing configs is nonnegotiable for proper unit tests.