### PR TITLE
Fix vault unlock db query which can provide the wrong encrypted key

### DIFF
--- a/backend/src/main/java/org/cryptomator/hub/entities/AccessToken.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/AccessToken.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 			FROM Vault v
 			INNER JOIN v.effectiveMembers u
 			INNER JOIN u.devices d
-			INNER JOIN d.accessTokens a
+			INNER JOIN d.accessTokens a ON a.id.deviceId = d.id AND a.id.vaultId = v.id
 			WHERE v.id = :vaultId
 				AND u.id = :userId
 				AND d.id = :deviceId

--- a/backend/src/test/java/org/cryptomator/hub/entities/EntityIntegrationTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/entities/EntityIntegrationTest.java
@@ -2,19 +2,27 @@ package org.cryptomator.hub.entities;
 
 import com.radcortez.flyway.test.annotation.DataSource;
 import com.radcortez.flyway.test.annotation.FlywayTest;
+import io.agroal.api.AgroalDataSource;
+import io.quarkus.panache.common.Parameters;
 import io.quarkus.test.junit.QuarkusTest;
 import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import javax.inject.Inject;
 import javax.persistence.PersistenceException;
 import javax.transaction.Transactional;
+import java.sql.SQLException;
+import java.util.List;
 
 @QuarkusTest
 @FlywayTest(value = @DataSource(url = "jdbc:h2:mem:test"), additionalLocations = {"classpath:org/cryptomator/hub/flyway"})
 @DisplayName("Persistent Entities")
 public class EntityIntegrationTest {
+
+	@Inject
+	AgroalDataSource dataSource;
 
 	@Transactional(Transactional.TxType.REQUIRES_NEW)
 	public static void tx(Runnable validation) {
@@ -55,4 +63,26 @@ public class EntityIntegrationTest {
 		});
 	}
 
+	@Test
+	@DisplayName("Retrieve the correct token when a device has access to multiple vaults")
+	public void testGetCorrectTokenForDeviceWithAcessToMultipleVaults() throws SQLException {
+		try (var s = dataSource.getConnection().createStatement()) {
+			s.execute("""
+					INSERT INTO "access_token" ("device_id", "vault_id", "jwe") VALUES ('device3', 'vault1', 'jwe4');
+					""");
+
+			List<AccessToken> tokens = AccessToken
+					.<AccessToken>find("#AccessToken.get", Parameters.with("deviceId", "device3")
+							.and("vaultId", "vault1")
+							.and("userId", "user1"))
+					.stream().toList();
+
+			var token = tokens.get(0);
+
+			Assertions.assertEquals(1, tokens.size());
+			Assertions.assertEquals("vault1", token.vault.id);
+			Assertions.assertEquals("device3", token.device.id);
+			Assertions.assertEquals("jwe4", token.jwe);
+		}
+	}
 }


### PR DESCRIPTION
By default hibernate translates the unlock query including a composite key to the following

```
select
	accesstoke4_."device_id" as device_i1_0_,
	accesstoke4_."vault_id" as vault_id2_0_,
	accesstoke4_."jwe" as jwe3_0_
from
	"vault" vault0_
		inner join
	"effective_vault_access" effectivem1_
	on vault0_."id"=effectivem1_."vault_id"
		inner join
	"authority" authority2_
	on effectivem1_."authority_id"=authority2_."id"
		inner join
	"device" devices3_
	on authority2_."id"=devices3_."owner_id"
		inner join
	"access_token" accesstoke4_
	on devices3_."id"=accesstoke4_."device_id"
where
		vault0_."id"=?
  and authority2_."id"=?
  and devices3_."id"=? limit ?
```

The query with a "user1" with "device1" and access to "vault1" and "vault2" will result in by setting vault0_."id"='vault1', authority2_."id"='user1'  and devices3_."id"='device1':
```
#,device_i1_0_,vault_id2_0_,jwe3_0_
1,device1,vault1,jwe1
2,device1,vault2,jwe2
```

The problem here is that the "vault_id" is ignored in the "access_token" table join which results in tuples including all vaults accessible by this device. By this fix, the new generated query looks like this which also honors the "vault_id" in the join expression:

```
select
	accesstoke4_."device_id" as device_i1_0_,
	accesstoke4_."vault_id" as vault_id2_0_,
	accesstoke4_."jwe" as jwe3_0_
from
	"vault" vault0_
		inner join
	"effective_vault_access" effectivem1_
	on vault0_."id"=effectivem1_."vault_id"
		inner join
	"authority" authority2_
	on effectivem1_."authority_id"=authority2_."id"
		inner join
	"device" devices3_
	on authority2_."id"=devices3_."owner_id"
		inner join
	"access_token" accesstoke4_
	on devices3_."id"=accesstoke4_."device_id"
		and (
				   accesstoke4_."device_id"=devices3_."id"
			   and accesstoke4_."vault_id"=vault0_."id"
		   )
where
		vault0_."id"=?
  and authority2_."id"=?
  and devices3_."id"=? limit ?
```

Edit: I have also checked all other joins involving the "access_token" table.