### PR TITLE
Adding the role "user" to newly created users by setting it as default

### DIFF
--- a/backend/src/main/resources/dev-realm.json
+++ b/backend/src/main/resources/dev-realm.json
@@ -4,18 +4,12 @@
   "displayName": "Cryptomator Hub",
   "enabled": true,
   "sslRequired": "external",
+  "defaultRole": {
+    "name": "user",
+    "description": "User"
+  },
   "roles": {
     "realm": [
-      {
-        "name": "user",
-        "description": "User",
-        "composite": true,
-        "composites": {
-          "realm": [
-            "default-roles-cryptomator"
-          ]
-        }
-      },
       {
         "name": "admin",
         "description": "Administrator",


### PR DESCRIPTION
This allows newly created users to access the user-protected REST API

Fixes #82