### PR TITLE
Simplify "history mode filter"

### DIFF
--- a/backend/src/main/java/org/cryptomator/hub/filters/VueHistoryModeFilter.java
+++ b/backend/src/main/java/org/cryptomator/hub/filters/VueHistoryModeFilter.java
@@ -1,4 +1,4 @@
-package org.cryptomator.hub;
+package org.cryptomator.hub.filters;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 

--- a/backend/src/test/java/org/cryptomator/hub/filters/VueHistoryModeFilterTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/filters/VueHistoryModeFilterTest.java
@@ -1,4 +1,4 @@
-package org.cryptomator.hub;
+package org.cryptomator.hub.filters;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;


### PR DESCRIPTION
This PR strips some exclusions from the filter, that existed due to copy-paste but aren't applicable to our application.

What we need the filter to do is this: For all requests except those to `/api/*`, we need to server the `index.html` to be served, if the normal filter chain results in a 404 response.

Furthermore the class is moved and unit tests are added.