### PR TITLE
Fixed history mode

### DIFF
--- a/backend/src/main/java/org/cryptomator/hub/filters/VueHistoryModeFilter.java
+++ b/backend/src/main/java/org/cryptomator/hub/filters/VueHistoryModeFilter.java
@@ -1,7 +1,5 @@
 package org.cryptomator.hub.filters;
 
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
@@ -13,31 +11,15 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 /**
- * A global http filter which redirects all 404-responses to the frontend app root. Necessary for using <a href="https://v3.router.vuejs.org/guide/essentials/history-mode.html#example-server-configurations">history mode in the vue router</a>
- * <p>
- * Implemention taken from <a href="https://quarkus.io/blog/quarkus-and-web-ui-development-mode/#handle-angular-routes">https://quarkus.io/blog/quarkus-and-web-ui-development-mode/#handle-angular-routes</a>
+ * A http filter which redirects all requests to subresources of /app to the frontend index.html. Necessary for using <a href="https://v3.router.vuejs.org/guide/essentials/history-mode.html#example-server-configurations">history mode in the vue router</a>
  */
-@WebFilter(urlPatterns = "/*")
+@WebFilter(urlPatterns = "/app/*")
 public class VueHistoryModeFilter extends HttpFilter {
-
-	@ConfigProperty(name = "quarkus.resteasy.path")
-	String apiPathPrefix;
 
 	public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException, ServletException {
 		HttpServletRequest request = (HttpServletRequest) req;
 		HttpServletResponse response = (HttpServletResponse) res;
-		chain.doFilter(request, response);
-
-		// exclude requests to the ReST API from filtering:
-		String contextRelativePath = request.getRequestURI().substring(request.getContextPath().length());
-		if (response.getStatus() == 404 && !contextRelativePath.startsWith(apiPathPrefix)) {
-			try {
-				response.setStatus(200);
-				request.getRequestDispatcher("/").forward(request, response);
-			} finally {
-				response.getOutputStream().close();
-			}
-		}
+		request.getRequestDispatcher("/index.html").forward(request, response);
 	}
 
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -9,9 +9,6 @@ hub.keycloak.public-url=http://localhost:8180
 hub.keycloak.local-url=http://localhost:8180
 hub.keycloak.realm=cryptomator
 
-quarkus.resteasy.path=/api
-%test.quarkus.resteasy.path=/
-
 quarkus.http.port=8080
 
 quarkus.oidc.application-type=service

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -9,6 +9,9 @@ hub.keycloak.public-url=http://localhost:8180
 hub.keycloak.local-url=http://localhost:8180
 hub.keycloak.realm=cryptomator
 
+quarkus.resteasy.path=/api
+%test.quarkus.resteasy.path=/
+
 quarkus.http.port=8080
 
 quarkus.oidc.application-type=service

--- a/backend/src/test/java/org/cryptomator/hub/filters/VueHistoryModeFilterTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/filters/VueHistoryModeFilterTest.java
@@ -1,15 +1,12 @@
 package org.cryptomator.hub.filters;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import javax.servlet.FilterChain;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletException;
-import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
@@ -19,66 +16,17 @@ public class VueHistoryModeFilterTest {
 	private HttpServletRequest req = Mockito.mock(HttpServletRequest.class);
 	private HttpServletResponse res = Mockito.mock(HttpServletResponse.class);
 	private FilterChain chain = Mockito.mock(FilterChain.class);
-
 	private VueHistoryModeFilter filter = new VueHistoryModeFilter();
 
-	@BeforeEach
-	public void setup() {
-		filter.apiPathPrefix = "/api";
-	}
-
-	@ParameterizedTest(name = "path = {0}")
-	@ValueSource(strings = {"/ctx/api", "/ctx/api/foo?k=v", "/ctx/api/foo/bar/", "/ctx/api/"})
-	@DisplayName("don't filter requests to /ctx/api/*")
-	public void testDoNotFilterApi(String reqUri) throws ServletException, IOException {
-		Mockito.doReturn(reqUri).when(req).getRequestURI();
-		Mockito.doReturn("/ctx").when(req).getContextPath();
-		Mockito.doReturn(404).when(res).getStatus();
-
-		filter.doFilter(req, res, chain);
-
-		Mockito.verify(chain).doFilter(req, res);
-		Mockito.verify(req).getRequestURI();
-		Mockito.verify(req).getContextPath();
-		Mockito.verify(res).getStatus();
-		Mockito.verifyNoMoreInteractions(res, req, chain);
-	}
-
-	@ParameterizedTest(name = "statuscode = {0}")
-	@ValueSource(ints = {200, 201, 301, 401, 403})
-	@DisplayName("don't filter non-404 responses")
-	public void testDoNotFilterNon404(int status) throws ServletException, IOException {
-		Mockito.doReturn("/ctx/foo").when(req).getRequestURI();
-		Mockito.doReturn("/ctx").when(req).getContextPath();
-		Mockito.doReturn(status).when(res).getStatus();
-
-		filter.doFilter(req, res, chain);
-
-		Mockito.verify(chain).doFilter(req, res);
-		Mockito.verify(req).getRequestURI();
-		Mockito.verify(req).getContextPath();
-		Mockito.verify(res).getStatus();
-		Mockito.verifyNoMoreInteractions(res, req, chain);
-	}
-
-	@ParameterizedTest(name = "path = {0}")
-	@ValueSource(strings = {"/ctx", "/ctx/foo?k=v", "/ctx/foo/bar/"})
-	@DisplayName("filter 404 response to non-api resources")
-	public void testDoFilterNonApi(String reqUri) throws ServletException, IOException {
+	@Test
+	@DisplayName("redirect /app/* subresources to index.html")
+	public void testFilter() throws ServletException, IOException {
 		var dispatcher = Mockito.mock(RequestDispatcher.class);
-		var out = Mockito.mock(ServletOutputStream.class);
-		Mockito.doReturn(reqUri).when(req).getRequestURI();
-		Mockito.doReturn("/ctx").when(req).getContextPath();
-		Mockito.doReturn(404).when(res).getStatus();
-		Mockito.doReturn(dispatcher).when(req).getRequestDispatcher("/");
-		Mockito.doReturn(out).when(res).getOutputStream();
+		Mockito.doReturn(dispatcher).when(req).getRequestDispatcher("/index.html");
 
 		filter.doFilter(req, res, chain);
 
-		Mockito.verify(res).setStatus(200);
-		Mockito.verify(req).getRequestDispatcher("/");
 		Mockito.verify(dispatcher).forward(req, res);
-		Mockito.verify(out).close();
 	}
 
 }

--- a/frontend/src/common/config.ts
+++ b/frontend/src/common/config.ts
@@ -1,6 +1,6 @@
 import AxiosStatic from 'axios';
 
-export const frontendBaseURL = `${location.protocol}//${location.host}${import.meta.env.BASE_URL}`;
+export const frontendBaseURL = `${location.protocol}//${location.host}/app`;
 export const backendBaseURL = import.meta.env.DEV
   ? 'http://localhost:8080/api/'
   : new URL('/api/', location.href).href;

--- a/frontend/src/components/NotFoundComponent.vue
+++ b/frontend/src/components/NotFoundComponent.vue
@@ -18,7 +18,7 @@
             <p class="mt-1 text-base text-gray-500">Please check the URL in the address bar and try again.</p>
           </div>
           <div class="mt-10 flex space-x-3 sm:border-l sm:border-transparent sm:pl-6">
-            <a href="/vaults" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-primary focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"> Go back home </a>
+            <router-link to="/vaults" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-primary focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"> Go back home </router-link>
           </div>
         </div>
       </main>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -97,7 +97,7 @@ const routes: RouteRecordRaw[] = [
 ];
 
 const router = createRouter({
-  history: createWebHistory(),
+  history: createWebHistory('/app/'),
   routes: routes
 });
 


### PR DESCRIPTION
Making the backend work with "History Mode" routing was a PITA and very fragile. When building native images with GraalVM, due to slight behavioural differences, the servlet filter responsible for routing every 404 response to the index.html failed to initialize with obscure error messages (`Failed to load config value of type class java.lang.String for: quarkus.resteasy.path`).

Furthermore, waiting for a 404 response means that the response was already written, leading to a very sad attempt to try and rewrite it: Status code and (Content Type) headers were already sent, leading browsers to treat the index.html as plaintext. In some browsers (didn't verify if this is consistent behaviour) non-html content leads to CSP errors.

This PR inverts the matching logic: Instead of "all but /api/* needs to be routed by the frontend router", we created a dedicated subresource called `/app/*` for frontend routes.

While the index.html is still generated at `/`, the Vue router is configured with `/app` as its base path.

This simplifies the VueHistoryModeFilter, as it can now rely on "positive" matching rules without exceptions. The http status code and content type is now correctly determined as if the user agent asked for index.html directly.