### PR TITLE
Update user and related data on login

### DIFF
--- a/backend/src/main/java/org/cryptomator/hub/KeycloakRemoteUserProvider.java
+++ b/backend/src/main/java/org/cryptomator/hub/KeycloakRemoteUserProvider.java
@@ -28,6 +28,15 @@ public class KeycloakRemoteUserProvider implements RemoteUserProvider {
 	SyncerConfig syncerConfig;
 
 	@Override
+	public User user(String id) {
+		try (Keycloak keycloak = Keycloak.getInstance(syncerConfig.getKeycloakUrl(), syncerConfig.getKeycloakRealm(), syncerConfig.getUsername(), syncerConfig.getPassword(), syncerConfig.getKeycloakClientId())) {
+			return Optional.ofNullable(keycloak.realm(syncerConfig.getKeycloakRealm()).users().get(id).toRepresentation()) //
+					.map(this::mapToUser) //
+					.orElse(null);
+		}
+	}
+
+	@Override
 	public List<User> users() {
 		try (Keycloak keycloak = Keycloak.getInstance(syncerConfig.getKeycloakUrl(), syncerConfig.getKeycloakRealm(), syncerConfig.getUsername(), syncerConfig.getPassword(), syncerConfig.getKeycloakClientId())) {
 			return users(keycloak.realm(syncerConfig.getKeycloakRealm()));

--- a/backend/src/main/java/org/cryptomator/hub/RemoteUserProvider.java
+++ b/backend/src/main/java/org/cryptomator/hub/RemoteUserProvider.java
@@ -8,6 +8,13 @@ import java.util.List;
 public interface RemoteUserProvider {
 
 	/**
+	 * Gets a single user with the given id
+	 * @param id the user id
+	 * @return the user or null, if a user with the given id does not exists
+	 */
+	User user(String id);
+
+	/**
 	 * Get all remote users
 	 * @return List of users
 	 */

--- a/backend/src/main/java/org/cryptomator/hub/api/UsersResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/UsersResource.java
@@ -2,6 +2,7 @@ package org.cryptomator.hub.api;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.cryptomator.hub.RemoteUserProvider;
+import org.cryptomator.hub.RemoteUserPuller;
 import org.cryptomator.hub.entities.AccessToken;
 import org.cryptomator.hub.entities.Device;
 import org.cryptomator.hub.entities.User;
@@ -34,15 +35,18 @@ public class UsersResource {
 	JsonWebToken jwt;
 
 	@Inject
+	RemoteUserPuller remoteUserPuller;
+
+	@Inject
 	RemoteUserProvider remoteUserProvider;
 
 	@PUT
 	@Path("/me")
 	@RolesAllowed("user")
 	@Operation(summary = "sync the logged-in user from the remote user provider to hub")
-	@APIResponse(responseCode = "201", description = "user created")
+	@APIResponse(responseCode = "201", description = "user created") //TODO: depending on the state, the user may already exist!
 	public Response syncMe() {
-		// TODO sync this user from the remote user provider against hub to explicitly update e.g. group membership after user was logged in
+		remoteUserPuller.syncSingleUser(jwt.getSubject());
 		return Response.created(URI.create(".")).build();
 	}
 

--- a/backend/src/test/java/org/cryptomator/hub/api/UsersResourceTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/UsersResourceTest.java
@@ -3,16 +3,19 @@ package org.cryptomator.hub.api;
 import com.radcortez.flyway.test.annotation.DataSource;
 import com.radcortez.flyway.test.annotation.FlywayTest;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectMock;
 import io.quarkus.test.security.TestSecurity;
 import io.quarkus.test.security.oidc.Claim;
 import io.quarkus.test.security.oidc.OidcSecurity;
 import io.restassured.RestAssured;
+import org.cryptomator.hub.RemoteUserPuller;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mockito;
 
 import static io.restassured.RestAssured.when;
 import static org.hamcrest.CoreMatchers.hasItems;
@@ -37,9 +40,13 @@ public class UsersResourceTest {
 	})
 	public class AsAuthorzedUser1 {
 
+		@InjectMock
+		RemoteUserPuller remoteUserPuller;
+
 		@Test
 		@DisplayName("PUT /users/me returns 201")
 		public void testSyncMe() {
+			Mockito.doNothing().when(remoteUserPuller).syncSingleUser(Mockito.anyString());
 			when().put("/users/me")
 					.then().statusCode(201);
 		}

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -107,7 +107,7 @@ router.beforeEach((to, from, next) => {
     next();
   } else {
     const relativePath = to.fullPath.startsWith('/') ? to.fullPath.substring(1) : to.fullPath;
-    const redirectUri = `${frontendBaseURL}${relativePath}`;
+    const redirectUri = `${frontendBaseURL}${relativePath}?login=true`;
     authPromise.then(async auth => {
       await auth.loginIfRequired(redirectUri);
       next();


### PR DESCRIPTION
Closes #110 

Thie PR implements the `UserResource::syncMe` method. The single-user-sync is implemented in the `RemoteUserPuller` due to already existing code. All group data is synchronized, because the user can be part of a new, not synced group. The synchronization itself is transactional annotated.

The syncMe method is called, when the user is freshly logged in. This is noted by adding the query parameter `login=true` to the redirect-url after successful keycloak login

Remark: There are two pending TODOS, would be wonderful if those can be fixed. Additionally, the `RemoteUserPuller::syncSingleUser(...)` lacks testing.