### PR TITLE
Updating user and associated data at login except group memberships

### DIFF
--- a/backend/src/main/java/org/cryptomator/hub/api/UsersResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/UsersResource.java
@@ -39,10 +39,20 @@ public class UsersResource {
 	@PUT
 	@Path("/me")
 	@RolesAllowed("user")
+	@Transactional
 	@Operation(summary = "sync the logged-in user from the remote user provider to hub")
-	@APIResponse(responseCode = "201", description = "user created")
+	@APIResponse(responseCode = "201", description = "user created or updated")
 	public Response syncMe() {
-		// TODO sync this user from the remote user provider against hub to explicitly update e.g. group membership after user was logged in
+		var userId = jwt.getSubject();
+		User user = User.findById(userId);
+		if (user == null) {
+			user = new User();
+			user.id = userId;
+		}
+		user.name = jwt.getName();
+		user.pictureUrl = jwt.getClaim("picture");
+		user.email = jwt.getClaim("email");
+		user.persist();
 		return Response.created(URI.create(".")).build();
 	}
 

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -121,7 +121,7 @@ router.beforeEach((to, from, next) => {
     authPromise.then(async auth => {
       if (auth.isAuthenticated()) {
         await backend.users.syncMe();
-        delete to.query.sync_me;
+        delete to.query.sync_me; // remove sync_me query parameter to avoid endless recursion
         next({ path: to.path, query: to.query, params: to.params, replace: true });
       } else {
         next();

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -107,7 +107,7 @@ router.beforeEach((to, from, next) => {
     next();
   } else {
     const relativePath = to.fullPath.startsWith('/') ? to.fullPath.substring(1) : to.fullPath;
-    const redirectUri = `${frontendBaseURL}${relativePath}`;
+    const redirectUri = `${frontendBaseURL}${relativePath}?sync_me=true`;
     authPromise.then(async auth => {
       await auth.loginIfRequired(redirectUri);
       next();
@@ -117,12 +117,16 @@ router.beforeEach((to, from, next) => {
 
 // SECOND update user data (requires auth)
 router.beforeEach((to, from, next) => {
-  if ('login' in to.query) {
+  if ('sync_me' in to.query) {
     authPromise.then(async auth => {
       if (auth.isAuthenticated()) {
         await backend.users.syncMe();
+        delete to.query.sync_me;
+        next({ path: to.path, query: to.query, params: to.params, replace: true });
+      } else {
+        next();
       }
-    }).finally(() => {
+    }).catch(() => {
       next();
     });
   } else {


### PR DESCRIPTION
We decided to keep the implementation of #110 as simple as possible. All information to update the user is already available in the access token (JWT) signed by Kecloak so we can use it to update the logged-in user. Group membership can be added to the claims only by name or path not the ID so isn't useful to update membership. Created #134 for this part.

Fixes #110 Closes #132