### PR TITLE
Keycloak theme finetuning

### DIFF
--- a/keycloak/themes/cryptomator/common/resources/css/tailwind.css
+++ b/keycloak/themes/cryptomator/common/resources/css/tailwind.css
@@ -1,3 +1,27 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  a:not([type='button']) {
+    @apply text-primary;
+  }
+  a:not([type='button']):hover {
+    @apply underline;
+  }
+  ol {
+    @apply list-decimal pl-5 mb-6;
+  }
+  ol > li {
+    @apply text-sm font-medium text-gray-700;
+  }
+  li > * {
+    @apply mb-2;
+  }
+  li > br {
+    @apply hidden;
+  }
+  input[type='checkbox'] {
+    @apply h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary;
+  }
+}

--- a/keycloak/themes/cryptomator/common/resources/css/tailwind.css
+++ b/keycloak/themes/cryptomator/common/resources/css/tailwind.css
@@ -9,6 +9,9 @@
   a:not([type='button']):hover {
     @apply underline;
   }
+  hr {
+    @apply my-6;
+  }
   ol {
     @apply list-decimal pl-5 mb-6;
   }
@@ -24,4 +27,41 @@
   input[type='checkbox'] {
     @apply h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary;
   }
+  input[type='radio'] {
+    @apply h-4 w-4 border-gray-300 text-primary focus:ring-primary;
+  }
+}
+
+#kc-terms-text > p {
+  @apply mb-6;
+}
+
+#reset-login {
+  @apply font-body text-sm ml-1;
+}
+
+#reset-login > div {
+  @apply inline-block relative;
+}
+
+#reset-login > div:hover > span {
+  @apply block;
+}
+
+#reset-login > div > span {
+  @apply hidden absolute z-50;
+  @apply rounded shadow-md bg-white text-gray-500 w-40 p-2;
+  @apply transform -translate-x-1/2 left-1/2;
+}
+
+#try-another-way {
+  @apply block text-center mt-3;
+}
+
+#kc-webauthn-authenticator {
+  @apply pointer-events-none;
+}
+
+#kc-webauthn-authenticator-label {
+  @apply text-gray-900;
 }

--- a/keycloak/themes/cryptomator/login/theme.properties
+++ b/keycloak/themes/cryptomator/login/theme.properties
@@ -2,13 +2,13 @@
 parent=base
 import=common/cryptomator
 
-styles=css/tailwind.min.css css/fonts.css node_modules/@fortawesome/fontawesome-free/css/brands.min.css
+styles=css/tailwind.min.css css/fonts.css node_modules/@fortawesome/fontawesome-free/css/all.min.css
 stylesCommon=
 
 meta=viewport==width=device-width,initial-scale=1
 
 ## Body & Wrapper
-kcHtmlClass=h-full bg-gradient-to-b from-sky-dark via-sky-medium to-sky-light bg-fixed text-base
+kcHtmlClass=h-full bg-gradient-to-b from-sky-dark via-sky-medium to-sky-light bg-fixed text-base text-gray-900
 kcBodyClass=min-h-full bg-transparent bg-none md:bg-hills bg-repeat-y bg-center bg-cover bg-fixed font-body
 kcLoginClass=min-h-screen flex flex-col justify-center sm:px-6 lg:px-8 py-24 -translate-y-24
 
@@ -18,27 +18,44 @@ kcHeaderClass=bg-cryptobot bg-no-repeat bg-center bg-contain text-transparent h-
 ## Form
 kcFormClass=
 kcFormCardClass=sm:mx-auto sm:w-full sm:max-w-md bg-white py-8 px-4 shadow sm:rounded-lg sm:p-8 shadow-md shadow-tertiary
-kcFormHeaderClass=text-center text-xl tracking-tight font-medium text-gray-500 font-headline
-kcFormGroupClass=mt-6
-kcLabelClass=block text-sm font-medium text-gray-700
-kcInputClass=shadow-sm focus:ring-primary focus:border-primary block w-full sm:text-sm border-gray-300 rounded-md invalid:border-red-500
-kcInputErrorMessageClass=mt-2 text-sm text-red-600
-kcFormSettingClass=mt-6
+kcFormHeaderClass=text-center text-xl tracking-tight font-medium text-gray-500 font-headline mb-6
+kcFormGroupClass=[&:not(:last-child)]:mb-6
+kcLabelClass=inline-block text-sm text-gray-700 mb-1
+kcLabelWrapperClass=text-sm text-gray-700
+kcInputClass=block w-full rounded-md shadow-sm border-gray-300 invalid:border-red-500 sm:text-sm focus:ring-primary focus:border-primary
+kcInputErrorMessageClass=block text-sm text-red-600 mt-1
+kcInputWrapperClass=text-sm text-gray-700
+kcFormSettingClass=flex justify-between items-center text-sm text-gray-700
 kcFormOptionsClass=my-6
 kcFormOptionsWrapperClass=text-center
 kcSignUpClass=mt-6 text-sm text-center
-
 ### main class used for all buttons
-kcButtonClass=w-full inline-flex justify-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-500 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary
+kcButtonClass=w-full inline-flex justify-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm text-gray-500 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary
 ### classes defining priority of the button - primary or default (there is typically only one priority button for the form)
 kcButtonPrimaryClass=border-transparent text-white bg-primary hover:!bg-primary-l1
 kcButtonDefaultClass=btn-default
 ### classes defining size of the button
 kcButtonLargeClass=!px-6 !py-3 text-lg
 kcButtonBlockClass=
+### classes for form accessibility
+kcSrOnlyClass=sr-only
 
-## Social providers
-kcFormSocialAccountListClass=mt-6 gap-3 flex justify-center
+## Alert
+kcAlertClass=flex gap-2 rounded-md [&.alert-warning]:bg-yellow-50 [&.alert-error]:bg-red-50 [&.alert-success]:bg-green-50 [&.alert-info]:bg-blue-50 p-4 mb-6
+kcAlertTitleClass=text-sm text-gray-700
+kcFeedbackErrorIcon=fas fa-exclamation-circle text-red-400
+kcFeedbackWarningIcon=fas fa-exclamation-triangle text-yellow-400
+kcFeedbackSuccessIcon=fas fa-check-circle text-green-400
+kcFeedbackInfoIcon=fas fa-info-circle text-blue-400
+
+## Info
+kcInfoAreaWrapperClass=border-t border-primary text-gray-700 pt-4 px-4 sm:px-8 -mx-4 sm:-mx-8
+
+## Reset Flow
+kcResetFlowIcon=fas fa-share-from-square
+
+## Social Providers
+kcFormSocialAccountListClass=flex justify-center gap-3
 kcFormSocialAccountListGridClass=!grid grid-cols-3 gap-3
 kcFormSocialAccountListButtonClass=inline-flex items-center justify-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 hover:text-primary focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary hover:no-underline
 kcFormSocialAccountGridItem=
@@ -46,8 +63,7 @@ kcFormSocialAccountNameClass=text-inherit
 kcFormSocialAccountLinkClass=
 kcFormSocialAccountSectionClass=space-y-4 text-center
 kcCommonLogoIdP=mr-2
-
-### Font Awesome Glyphs
+### Logos
 kcLogoIdP-facebook=fa-brands not-italic fa-facebook
 kcLogoIdP-google=fa-brands not-italic fa-google
 kcLogoIdP-github=fa-brands not-italic fa-github
@@ -61,6 +77,3 @@ kcLogoIdP-stackoverflow=fa-brands not-italic fa-stack-overflow
 kcLogoIdP-twitter=fa-brands not-italic fa-twitter
 kcLogoIdP-openshift-v4=fa-brands not-italic fa-redhat
 kcLogoIdP-openshift-v3=fa-brands not-italic fa-redhat
-
-##### css classes for form accessability
-kcSrOnlyClass=sr-only

--- a/keycloak/themes/cryptomator/login/theme.properties
+++ b/keycloak/themes/cryptomator/login/theme.properties
@@ -8,9 +8,9 @@ stylesCommon=
 meta=viewport==width=device-width,initial-scale=1
 
 ## Body & Wrapper
-kcHtmlClass=bg-gradient-to-b from-sky-dark via-sky-medium to-sky-light text-base bg-fixed
-kcBodyClass=min-h-screen bg-transparent bg-none md:bg-hills bg-repeat-y bg-center bg-cover font-body bg-fixed
-kcLoginClass=min-h-full flex flex-col justify-center sm:px-6 lg:px-8 py-24 -translate-y-24
+kcHtmlClass=h-full bg-gradient-to-b from-sky-dark via-sky-medium to-sky-light bg-fixed text-base
+kcBodyClass=min-h-full bg-transparent bg-none md:bg-hills bg-repeat-y bg-center bg-cover bg-fixed font-body
+kcLoginClass=min-h-screen flex flex-col justify-center sm:px-6 lg:px-8 py-24 -translate-y-24
 
 ## Header
 kcHeaderClass=bg-cryptobot bg-no-repeat bg-center bg-contain text-transparent h-24 sr-hidden my-8

--- a/keycloak/themes/cryptomator/login/theme.properties
+++ b/keycloak/themes/cryptomator/login/theme.properties
@@ -1,5 +1,5 @@
 # based on https://github.com/keycloak/keycloak/blob/19.0.1/themes/src/main/resources/theme/keycloak/login/theme.properties
-parent=base
+parent=keycloak
 import=common/cryptomator
 
 styles=css/tailwind.min.css css/fonts.css node_modules/@fortawesome/fontawesome-free/css/all.min.css
@@ -15,22 +15,41 @@ kcLoginClass=min-h-screen flex flex-col justify-center sm:px-6 lg:px-8 py-24 -tr
 ## Header
 kcHeaderClass=bg-cryptobot bg-no-repeat bg-center bg-contain text-transparent h-24 sr-hidden my-8
 
+## Locale
+kcLocaleMainClass=
+kcLocaleListClass=
+kcLocaleItemClass=
+
 ## Form
-kcFormClass=
+kcFormClass=[&:not(:last-child)]:mb-6
 kcFormCardClass=sm:mx-auto sm:w-full sm:max-w-md bg-white py-8 px-4 shadow sm:rounded-lg sm:p-8 shadow-md shadow-tertiary
 kcFormHeaderClass=text-center text-xl tracking-tight font-medium text-gray-500 font-headline mb-6
 kcFormGroupClass=[&:not(:last-child)]:mb-6
+kcFormGroupErrorClass=
 kcLabelClass=inline-block text-sm text-gray-700 mb-1
 kcLabelWrapperClass=text-sm text-gray-700
 kcInputClass=block w-full rounded-md shadow-sm border-gray-300 invalid:border-red-500 sm:text-sm focus:ring-primary focus:border-primary
+kcInputHelperTextBeforeClass=
+kcInputHelperTextAfterClass=
+kcInputClassRadio=
+kcInputClassRadioInput=
+kcInputClassRadioLabel=
+kcInputClassCheckbox=
+kcInputClassCheckboxInput=
+kcInputClassCheckboxLabel=
+kcInputClassRadioCheckboxLabelDisabled=
 kcInputErrorMessageClass=block text-sm text-red-600 mt-1
 kcInputWrapperClass=text-sm text-gray-700
-kcFormSettingClass=flex justify-between items-center text-sm text-gray-700
 kcFormOptionsClass=my-6
 kcFormOptionsWrapperClass=text-center
+kcFormButtonsClass=
+kcFormSettingClass=flex justify-between items-center text-sm text-gray-700
+kcTextareaClass=
 kcSignUpClass=mt-6 text-sm text-center
+### user-profile grouping
+kcFormGroupHeader=
 ### main class used for all buttons
-kcButtonClass=w-full inline-flex justify-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm text-gray-500 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary
+kcButtonClass=w-full inline-flex justify-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm text-gray-500 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary [&:not(:last-child)]:mb-3
 ### classes defining priority of the button - primary or default (there is typically only one priority button for the form)
 kcButtonPrimaryClass=border-transparent text-white bg-primary hover:!bg-primary-l1
 kcButtonDefaultClass=btn-default
@@ -39,6 +58,31 @@ kcButtonLargeClass=!px-6 !py-3 text-lg
 kcButtonBlockClass=
 ### classes for form accessibility
 kcSrOnlyClass=sr-only
+### classes for select-authenticator form
+kcSelectAuthListClass=divide-y divide-gray-200
+kcSelectAuthListItemClass=flex gap-3 hover:bg-gray-50 cursor-pointer p-4
+kcSelectAuthListItemIconClass=text-gray-700
+kcSelectAuthListItemIconPropertyClass=fa-fw
+kcSelectAuthListItemBodyClass=flex flex-col gap-1
+kcSelectAuthListItemHeadingClass=text-primary
+kcSelectAuthListItemDescriptionClass=text-sm text-gray-500
+kcSelectAuthListItemFillClass=flex-grow
+kcSelectAuthListItemArrowClass=self-center
+kcSelectAuthListItemArrowIconClass=fas fa-angle-right text-gray-500
+kcSelectAuthListItemTitle=
+### classes for the authenticators
+kcAuthenticatorDefaultClass=fas fa-list
+kcAuthenticatorPasswordClass=fas fa-unlock
+kcAuthenticatorOTPClass=fas fa-mobile
+kcAuthenticatorWebAuthnClass=fas fa-key
+kcAuthenticatorWebAuthnPasswordlessClass=fas fa-key
+### classes for the OTP Login Form
+kcLoginOTPListClass=relative inline-flex cursor-pointer rounded-lg border bg-white p-4 shadow-sm focus:outline-none border-gray-300 hover:border-transparent hover:ring-2 hover:ring-primary
+kcLoginOTPListInputClass=
+kcLoginOTPListItemHeaderClass=
+kcLoginOTPListItemIconBodyClass=ml-1
+kcLoginOTPListItemIconClass=fas fa-mobile
+kcLoginOTPListItemTitleClass=ml-1
 
 ## Alert
 kcAlertClass=flex gap-2 rounded-md [&.alert-warning]:bg-yellow-50 [&.alert-error]:bg-red-50 [&.alert-success]:bg-green-50 [&.alert-info]:bg-blue-50 p-4 mb-6
@@ -53,6 +97,15 @@ kcInfoAreaWrapperClass=border-t border-primary text-gray-700 pt-4 px-4 sm:px-8 -
 
 ## Reset Flow
 kcResetFlowIcon=fas fa-share-from-square
+
+## WebAuthn
+kcWebAuthnKeyIcon=fas fa-key
+kcWebAuthnDefaultIcon=fas fa-key
+kcWebAuthnUnknownIcon=fas fa-key
+kcWebAuthnUSB=fas fa-usb
+kcWebAuthnNFC=fas fa-wifi
+kcWebAuthnBLE=fas fa-bluetooth-b
+kcWebAuthnInternal=fas fa-key
 
 ## Social Providers
 kcFormSocialAccountListClass=flex justify-center gap-3
@@ -77,3 +130,12 @@ kcLogoIdP-stackoverflow=fa-brands not-italic fa-stack-overflow
 kcLogoIdP-twitter=fa-brands not-italic fa-twitter
 kcLogoIdP-openshift-v4=fa-brands not-italic fa-redhat
 kcLogoIdP-openshift-v3=fa-brands not-italic fa-redhat
+
+## Recovery Codes
+kcRecoveryCodesWarning=
+kcRecoveryCodesList=
+kcRecoveryCodesActions=
+kcRecoveryCodesConfirmation=
+kcCheckClass=
+kcCheckInputClass=
+kcCheckLabelClass=

--- a/keycloak/themes/cryptomator/login/theme.properties
+++ b/keycloak/themes/cryptomator/login/theme.properties
@@ -8,8 +8,8 @@ stylesCommon=
 meta=viewport==width=device-width,initial-scale=1
 
 ## Body & Wrapper
-kcHtmlClass=h-full bg-gradient-to-b from-sky-dark via-sky-medium to-sky-light text-base
-kcBodyClass=h-full bg-transparent bg-none md:bg-hills bg-repeat-y bg-center bg-cover font-body
+kcHtmlClass=bg-gradient-to-b from-sky-dark via-sky-medium to-sky-light text-base bg-fixed
+kcBodyClass=min-h-screen bg-transparent bg-none md:bg-hills bg-repeat-y bg-center bg-cover font-body bg-fixed
 kcLoginClass=min-h-full flex flex-col justify-center sm:px-6 lg:px-8 py-24 -translate-y-24
 
 ## Header


### PR DESCRIPTION
I'm quite certain that there are far more screens that require finetuning but this could be considered a "good first batch". Fixes #153.

<img width="461" alt="Screen Shot 2022-09-27 at 16 48 54" src="https://user-images.githubusercontent.com/2924160/192560627-b243ef36-956a-4c53-977b-74ed2f48b67b.png">
<img width="459" alt="Screen Shot 2022-09-27 at 16 49 37" src="https://user-images.githubusercontent.com/2924160/192560634-774b159b-4e97-4331-92be-ff63a45cf046.png">
<img width="457" alt="Screen Shot 2022-09-27 at 16 50 10" src="https://user-images.githubusercontent.com/2924160/192560644-cd1b0eb6-a462-4c9b-b43d-1bcd0a500fa8.png">
<img width="460" alt="Screen Shot 2022-09-27 at 16 50 51" src="https://user-images.githubusercontent.com/2924160/192560661-5b34bd0e-48d6-4aa6-b074-d957f68db484.png">
<img width="459" alt="Screen Shot 2022-09-27 at 16 51 35" src="https://user-images.githubusercontent.com/2924160/192560664-fc6e0d88-7aa5-4d0f-acb6-c45063b6ddda.png">
