### PR TITLE
Add Update Description to VaultDetails

### DIFF
--- a/frontend/src/common/backend.ts
+++ b/frontend/src/common/backend.ts
@@ -198,6 +198,11 @@ class VaultService {
     }).catch(err => rethrowAndConvertIfExpected(err, 403));
   }
 
+  public async updateDescription(vaultId: string, newDescription: String) {
+    return axiosAuth.put(`/vaults/${vaultId}/description`, newDescription)
+      .catch((error) => rethrowAndConvertIfExpected(error, 404));
+  }
+
   public async addUser(vaultId: string, userId: string, vaultKeys: VaultKeys): Promise<AxiosResponse<void>> {
     let vaultAdminAuthorizationJWT = await this.buildVaultAdminAuthorizationJWT(vaultId, vaultKeys);
     return axiosAuth.put(`/vaults/${vaultId}/users/${userId}`, null, { headers: { 'Cryptomator-Vault-Admin-Authorization': vaultAdminAuthorizationJWT } })

--- a/frontend/src/i18n/de-DE.json
+++ b/frontend/src/i18n/de-DE.json
@@ -11,6 +11,7 @@
   "common.reload": "Bitte lade die Seite neu.",
   "common.remove": "Entfernen",
   "common.retry": "Wiederholen",
+  "common.save": "Speichern",
   "common.share": "Teilen",
   "common.unexpectedError": "Unerwarteter Fehler: {0}",
 
@@ -100,6 +101,7 @@
   "vaultDetails.manageVault": "Tresor verwalten",
   "vaultDetails.description.header": "Beschreibung",
   "vaultDetails.description.empty": "Keine Beschreibung vorhanden.",
+  "vaultDetails.description.placeholder": "Kurze Beschreibung dieses Tresors",
   "vaultDetails.information.header": "Information",
   "vaultDetails.information.created": "Erstellt",
   "vaultDetails.sharedWith.title": "Geteilt mit",

--- a/frontend/src/i18n/en-US.json
+++ b/frontend/src/i18n/en-US.json
@@ -12,6 +12,7 @@
   "common.reload": "Please reload the page.",
   "common.remove": "Remove",
   "common.retry": "Retry",
+  "common.save": "Save",
   "common.share": "Share",
   "common.unexpectedError": "Unexpected Error: {0}",
 
@@ -101,6 +102,7 @@
   "vaultDetails.manageVault": "Manage Vault",
   "vaultDetails.description.header": "Description",
   "vaultDetails.description.empty": "No description provided.",
+  "vaultDetails.description.placeholder": "Short description of this vault",
   "vaultDetails.information.header": "Information",
   "vaultDetails.information.created": "Created",
   "vaultDetails.sharedWith.title": "Shared with",


### PR DESCRIPTION
Fixes #101.

Currently, the draft only contains the frontend code. I'm hesitating with the backend code because I'm not sure how to achieve this "properly".

Suggestions:
- Change existing PUT on `/{vaultId}` to `createOrUpdate()`.
- Add new PUT on `/{vaultId}/description`.