### PR TITLE
AdminJWTs are valid when they are issued in the future in defined leeway

### DIFF
--- a/backend/src/test/java/org/cryptomator/hub/filters/VaultAdminOnlyFilterProviderTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/filters/VaultAdminOnlyFilterProviderTest.java
@@ -17,6 +17,10 @@ import org.mockito.Mockito;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.UriInfo;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 
 @QuarkusTest
 @FlywayTest(value = @DataSource(url = "jdbc:h2:mem:test"), additionalLocations = {"classpath:org/cryptomator/hub/flyway"})
@@ -24,11 +28,7 @@ class VaultAdminOnlyFilterProviderTest {
 
 	private static final String NO_VAULT_ID_TOKEN = "eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCJ9.e30.vT0jNCotwtzr37JNM_C6uZFCw3GvVjcikn-CVrDociILPiXBXA8i7dWFwBnUQkDBcFbouh-eUB_wEWgqe9WTG2rT66_c1G2LZUQcCsKdWJdTyK4ZxLXLYOYhNOHtqShI";
 	private static final String INVALID_VAULT_ID_TOKEN = "eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCIsInZhdWx0SWQiOjI1fQ.e30.YxqmX5xeOviP9WldQV870zhPEF4PRaZrW0TaoWzm4lvkEmacIUt3OIoH0grAeh_gtJNRg4WfnqFNTgUx40-yDOtBLzyoeubfrMgb0-agN1898Mbr4ZhD1xqor0lBDrmc";
-	private static final String NO_DATES_TOKEN_VAULT_2 = "eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCIsInZhdWx0SWQiOiJ2YXVsdDIifQ.e30.gRKW5JvCZ2th1tpigYTPdP_0v0ChwfoTg-Bpt8YsFujteAp6MBUtNhHQ5_O9yUl_8_Uj0S3F4ztVveIL_U37JMO0q41K_QQ68Nkhf7qlHX2tk2EyzIVXyttwYnwuubeO";
-	private static final String NO_ISSUED_DATE_TOKEN_VAULT_2 = "eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCIsInZhdWx0SWQiOiJ2YXVsdDIifQ.eyJleHAiOjE1MTYyMzkwMzAsIm5iZiI6MTUxNjIzOTAwMH0.AKnDRHfm9TSrNDWNM_OYHMWyCZFEekpmwqpOlpEjH4jnygcb5nT6e_kPgORN0yua0fn6GoDLNeZnvsAQriHPFZbidYnPL7OzLgx1b3gPnL5ntdAtmDJY-TcCsPGgkCeG";
-	private static final String NO_NOT_BEFORE_DATE_TOKEN_VAULT_2 = "eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCIsInZhdWx0SWQiOiJ2YXVsdDIifQ.eyJpYXQiOjE1MTYyMzkwMTUsImV4cCI6MTUxNjIzOTAzMH0.hTUUOsGR6_45JDliD8td1CMyLqiTxMtfgJqx23_UtZI4A8p13uAAESy_aE6YxF3unGliyB8FuBE5q8tZkYBGXb3oWgubCtG1_LvxNednmw_tczXkge1aG_LWsiuLl53E";
-	private static final String NO_EXPIRES_DATE_TOKEN_VAULT_2 = "eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCIsInZhdWx0SWQiOiJ2YXVsdDIifQ.eyJpYXQiOjE1MTYyMzkwMTUsIm5iZiI6MTUxNjIzOTAwMH0.J7EX_yuYLoQSakCIl-c4-uSpw3idn2CJdr51_B968d06K87Z_lFzvOSq6aqS0NJvsdDOOfCdCID5zQDgFI2ROUeMqy2jpwjpGqioikCgNNBSwiq6VlfAsAxKZ-MGY36y";
-
+	private static final String NO_IAT_TOKEN_VAULT_2 = "eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCIsInZhdWx0SWQiOiJ2YXVsdDIifQ.e30.gRKW5JvCZ2th1tpigYTPdP_0v0ChwfoTg-Bpt8YsFujteAp6MBUtNhHQ5_O9yUl_8_Uj0S3F4ztVveIL_U37JMO0q41K_QQ68Nkhf7qlHX2tk2EyzIVXyttwYnwuubeO";
 	private VaultAdminOnlyFilterProvider vaultAdminOnlyFilterProvider;
 	private ContainerRequestContext context;
 	private UriInfo uriInfo;
@@ -38,13 +38,6 @@ class VaultAdminOnlyFilterProviderTest {
 		vaultAdminOnlyFilterProvider = Mockito.spy(new VaultAdminOnlyFilterProvider());
 		context = Mockito.mock(ContainerRequestContext.class);
 		uriInfo = Mockito.mock(UriInfo.class);
-
-		// Decorate verifier to use fixed time
-		Mockito.doAnswer(invocationOnMock -> {
-			Algorithm algorithm = invocationOnMock.getArgument(0);
-			var verifier = (JWTVerifier.BaseVerification) vaultAdminOnlyFilterProvider.verification(algorithm);
-			return verifier.build(VaultAdminOnlyFilterProviderTestConstants.NOW);
-		}).when(vaultAdminOnlyFilterProvider).buildVerifier(Mockito.any());
 	}
 
 	@Nested
@@ -53,56 +46,53 @@ class VaultAdminOnlyFilterProviderTest {
 
 		private static final String PUBLIC_KEY_VAULT_2 = "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEC1uWSXj2czCDwMTLWV5BFmwxdM6PX9p+Pk9Yf9rIf374m5XP1U8q79dBhLSIuaojsvOT39UUcPJROSD1FqYLued0rXiooIii1D3jaW6pmGVJFhodzC31cy5sfOYotrzF";
 
+		private static final DecodedJWT VALID_VAULT2 = JWT.decode(VaultAdminOnlyFilterProviderTestConstants.VALID_TOKEN_VAULT_2);
+
 		@Test
-		@DisplayName("validate valid vaultAdminAuthorizationJWT")
-		public void testValidVaultAdminAuthorizationJWT() {
-			vaultAdminOnlyFilterProvider.verify(verifier(), JWT.decode(VaultAdminOnlyFilterProviderTestConstants.VALID_TOKEN_VAULT_2));
+		@DisplayName("validate future IAT in leeway vaultAdminAuthorizationJWT")
+		public void testFutureIATInLeewayVaultAdminAuthorizationJWT() {
+			vaultAdminOnlyFilterProviderVerifierFor(VaultAdminOnlyFilterProviderTestConstants.NOW.plus(VaultAdminOnlyFilterProvider.REQUEST_LEEWAY_IN_SECONDS - 1, ChronoUnit.SECONDS));
+			vaultAdminOnlyFilterProvider.verify(verifier(), VALID_VAULT2);
 		}
 
 		@Test
-		@DisplayName("validate expired vaultAdminAuthorizationJWT")
-		public void testExpiredVaultAdminAuthorizationJWT() {
-			Assertions.assertThrows(VaultAdminTokenExpiredException.class, () -> vaultAdminOnlyFilterProvider.verify(verifier(), JWT.decode(VaultAdminOnlyFilterProviderTestConstants.EXPIRED_TOKEN_VAULT_2)));
+		@DisplayName("validate after IAT in leeway vaultAdminAuthorizationJWT")
+		public void testAfterIATInLeewayVaultAdminAuthorizationJWT() {
+			vaultAdminOnlyFilterProviderVerifierFor(VaultAdminOnlyFilterProviderTestConstants.NOW.minus(VaultAdminOnlyFilterProvider.REQUEST_LEEWAY_IN_SECONDS - 1, ChronoUnit.SECONDS));
+			vaultAdminOnlyFilterProvider.verify(verifier(), VALID_VAULT2);
 		}
 
 		@Test
-		@DisplayName("validate future issue at vaultAdminAuthorizationJWT")
-		public void testFutureIssueAtVaultAdminAuthorizationJWT() {
-			Assertions.assertThrows(VaultAdminTokenNotYetValidException.class, () -> vaultAdminOnlyFilterProvider.verify(verifier(), JWT.decode(VaultAdminOnlyFilterProviderTestConstants.FUTURE_ISSUE_AT_TOKEN_VAULT_2)));
+		@DisplayName("validate future IAT out leeway vaultAdminAuthorizationJWT")
+		public void testFutureIATOutLeewayVaultAdminAuthorizationJWT() {
+			vaultAdminOnlyFilterProviderVerifierFor(VaultAdminOnlyFilterProviderTestConstants.NOW.plus(VaultAdminOnlyFilterProvider.REQUEST_LEEWAY_IN_SECONDS + 1, ChronoUnit.SECONDS));
+			Assertions.assertThrows(VaultAdminValidationFailedException.class, () -> vaultAdminOnlyFilterProvider.verify(verifier(), VALID_VAULT2));
 		}
 
 		@Test
-		@DisplayName("validate future not before vaultAdminAuthorizationJWT")
-		public void testFutureNotBeforeVaultAdminAuthorizationJWT() {
-			Assertions.assertThrows(VaultAdminTokenNotYetValidException.class, () -> vaultAdminOnlyFilterProvider.verify(verifier(), JWT.decode(VaultAdminOnlyFilterProviderTestConstants.FUTURE_NOT_BEFORE_TOKEN_VAULT_2)));
+		@DisplayName("validate after IAT out leeway vaultAdminAuthorizationJWT")
+		public void testAfterIATOutLeewayAdminAuthorizationJWT() {
+			vaultAdminOnlyFilterProviderVerifierFor(VaultAdminOnlyFilterProviderTestConstants.NOW.minus(VaultAdminOnlyFilterProvider.REQUEST_LEEWAY_IN_SECONDS + 1, ChronoUnit.SECONDS));
+			Assertions.assertThrows(VaultAdminValidationFailedException.class, () -> vaultAdminOnlyFilterProvider.verify(verifier(), VALID_VAULT2));
 		}
 
 		@Test
-		@DisplayName("validate no dates in vaultAdminAuthorizationJWT")
+		@DisplayName("validate no IAT in vaultAdminAuthorizationJWT")
 		public void testMalformedVaultAdminAuthorizationJWTNoDates() {
-			Assertions.assertThrows(VaultAdminValidationFailedException.class, () -> vaultAdminOnlyFilterProvider.verify(verifier(), JWT.decode(NO_DATES_TOKEN_VAULT_2)));
-		}
-
-		@Test
-		@DisplayName("validate no issued date in vaultAdminAuthorizationJWT")
-		public void testMalformedVaultAdminAuthorizationJWTNoIssueDate() {
-			Assertions.assertThrows(VaultAdminValidationFailedException.class, () -> vaultAdminOnlyFilterProvider.verify(verifier(), JWT.decode(NO_ISSUED_DATE_TOKEN_VAULT_2)));
-		}
-
-		@Test
-		@DisplayName("validate no not before date in vaultAdminAuthorizationJWT")
-		public void testMalformedVaultAdminAuthorizationJWTNoNotBeforeDate() {
-			Assertions.assertThrows(VaultAdminValidationFailedException.class, () -> vaultAdminOnlyFilterProvider.verify(verifier(), JWT.decode(NO_NOT_BEFORE_DATE_TOKEN_VAULT_2)));
-		}
-
-		@Test
-		@DisplayName("validate no expires date in vaultAdminAuthorizationJWT")
-		public void testMalformedVaultAdminAuthorizationJWTNoExpiresDate() {
-			Assertions.assertThrows(VaultAdminValidationFailedException.class, () -> vaultAdminOnlyFilterProvider.verify(verifier(), JWT.decode(NO_EXPIRES_DATE_TOKEN_VAULT_2)));
+			Assertions.assertThrows(VaultAdminValidationFailedException.class, () -> vaultAdminOnlyFilterProvider.verify(verifier(), JWT.decode(NO_IAT_TOKEN_VAULT_2)));
 		}
 
 		private com.auth0.jwt.interfaces.JWTVerifier verifier() {
 			return vaultAdminOnlyFilterProvider.buildVerifier(Algorithm.ECDSA384(VaultAdminOnlyFilterProvider.decodePublicKey(PUBLIC_KEY_VAULT_2), null));
+		}
+
+		private void vaultAdminOnlyFilterProviderVerifierFor(Instant instant) {
+			// Decorate verifier to use fixed time
+			Mockito.doAnswer(invocationOnMock -> {
+				Algorithm algorithm = invocationOnMock.getArgument(0);
+				var verifier = (JWTVerifier.BaseVerification) vaultAdminOnlyFilterProvider.verification(algorithm, instant);
+				return verifier.build(Clock.fixed(instant, ZoneId.of("UTC")));
+			}).when(vaultAdminOnlyFilterProvider).buildVerifier(Mockito.any());
 		}
 	}
 

--- a/backend/src/test/java/org/cryptomator/hub/filters/VaultAdminOnlyFilterProviderTestConstants.java
+++ b/backend/src/test/java/org/cryptomator/hub/filters/VaultAdminOnlyFilterProviderTestConstants.java
@@ -6,14 +6,13 @@ import java.time.ZoneId;
 
 final class VaultAdminOnlyFilterProviderTestConstants {
 
-	static final String VALID_TOKEN_VAULT_2 = "eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCIsInZhdWx0SWQiOiJ2YXVsdDIifQ.eyJpYXQiOjE1MTYyMzkwMTUsImV4cCI6MTUxNjIzOTAzMCwibmJmIjoxNTE2MjM5MDAwfQ.LkN_iQqdmZyvGXAIKYwJZF0zWsscRpfWQr1OEmj-gdqA5yVkn0t1nROSpKk2OErTrqBSf2b5Kap8yPSw3yHBqYLUIpfVCxrfu0IpKM_K_Y31m-XAX5173__5yDOr_k35";
-	static final String VALID_TOKEN_VAULT_3000 = "eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCIsInZhdWx0SWQiOiJ2YXVsdDMwMDAifQ.eyJpYXQiOjE1MTYyMzkwMTUsImV4cCI6MTUxNjIzOTAzMCwibmJmIjoxNTE2MjM5MDAwfQ.IYQH9NofEy2A1qYzR4Lg720aJ93AhWXGyc8kF9oOIr7LuFDg-_ZN-0euV34hzcKtWpGkfgPbuazl-7GS1VxDIGcDLG9J6bnQ3hnPpWOYAcxWW-UMqiXJ6tbgryemzhq1";
-	static final String EXPIRED_TOKEN_VAULT_2 = "eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCIsInZhdWx0SWQiOiJ2YXVsdDIifQ.eyJpYXQiOjE1MTYyMzkwMDAsImV4cCI6MTUxNjIzOTAxNSwibmJmIjoxNTE2MjM4OTg1fQ.2U342-dfpLV4oN3ZdcKsEpS04xMduuIlViotcczr3_fNy96B4wHOn-I1LibOT_Y6IoFUaoZBiDxzYQSup9S7R2EEUnFGN9bPBBvXwvuT30B8caUebWrvXGTm63kPFCy8";
-	static final String FUTURE_ISSUE_AT_TOKEN_VAULT_2 = "eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCIsInZhdWx0SWQiOiJ2YXVsdDIifQ.eyJpYXQiOjE1MTYyMzkwMzAsImV4cCI6MTUxNjIzOTA0NSwibmJmIjoxNTE2MjM5MDE1fQ.j2FVj1Q3l9vrqgWUluCK_9S_LZnBwuu1KSRJM1_edXnN8jaIhpay7LaUKIPErVUksk49D9ssrWuYDGXZUr45ToGmtjvnbe__pxm8SJbriJbQ-YK3ZQE3im6dNLQYqrUl";
-	static final String FUTURE_NOT_BEFORE_TOKEN_VAULT_2 = "eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCIsInZhdWx0SWQiOiJ2YXVsdDIifQ.eyJpYXQiOjE1MTYyMzkwNDUsImV4cCI6MTUxNjIzOTA2MCwibmJmIjoxNTE2MjM5MDMwfQ.ptjbTDc-QNgCK9ex5gGCkGhkdXxpoox4vBh7YpIdlrxG52V1q1nS7sYHFthA3ZrTkh5JeuDt7LGMpu26LWwCYd1wesrmjoLTqAfWNkiJVXawCWEf8N76Ms0N1V2OPobE";
+	// { "alg": "ES384", "typ": "JWT", "vaultId": "vault2" } { "iat": 1516239015 (2018-01-18T01:30:15) }
+	static final String VALID_TOKEN_VAULT_2 = "eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCIsInZhdWx0SWQiOiJ2YXVsdDIifQ.eyJpYXQiOjE1MTYyMzkwMTV9.QYG_3b8d-Hglp68UAX3-Sn679TCb2v4alS6ruExL_gUr3Nrk1zCV5Gqjr5_h0rTsYL8t-bQh9u7NHkAuxcA5wdFTH0fEc45-2RGsMj0Mz4Cduv7WmOEMh28z-J5QTvlS";
+
+	// { "alg": "ES384", "typ": "JWT", "vaultId": "vault3000" } { "iat": 1516239015 (2018-01-18T01:30:15) }
+	static final String VALID_TOKEN_VAULT_3000 = "eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCIsInZhdWx0SWQiOiJ2YXVsdDMwMDAifQ.eyJpYXQiOjE1MTYyMzkwMTV9.GpYk3tflY1K-rdWLT8wFeNAabW_Q0tQCaSe8It6Fr0xqPMxnrhbukONrrNPGSlhjlrmpVtl3DABaiO8921o7hpsaqQQVFvRFmYWpsajOl_2pi7YhJmKCrdyaTswBGAo3";
 	static final String INVALID_SIGNATURE_TOKEN = "eyJ0eXAiOiJKV1QiLCJhbGciOiJFUzM4NCIsInZhdWx0SWQiOiJ2YXVsdDIifQ.e30.cGZDCqzJQgcBHNVPcmBc8JfeGzUf3CHUrwSAMwOA0Dcy9aUZvsAm1dr1MKzuPW_UFHRfMnNi2EwASOA6t-vPWvPFolAHFn5REt2Y9Aw9mIz-qxSBLpz6OMZD16tysQcd";
 	static final String MALFORMED_TOKEN = "hello world";
-
-	static final Clock NOW = Clock.fixed(Instant.ofEpochSecond(1516239020), ZoneId.of("UTC"));
+	static final Instant NOW  = Instant.ofEpochSecond(1516239015); // 2018-01-18T01:30:15
 
 }

--- a/frontend/src/common/backend.ts
+++ b/frontend/src/common/backend.ts
@@ -29,7 +29,6 @@ axiosAuth.interceptors.request.use(async request => {
   }
 });
 
-const vaultAdminAuthorizationJWTLeeway = 15;
 /* DTOs */
 
 export type VaultDto = {
@@ -236,8 +235,7 @@ class VaultService {
 
   private async buildVaultAdminAuthorizationJWT(vaultId: string, vaultKeys: VaultKeys): Promise<string> {
     let vaultIdHeader: VaultIdHeader = { alg: 'ES384', b64: true, typ: 'JWT', vaultId: vaultId };
-    let nowInSeconds = this.secondsSinceEpoch();
-    let jwtPayload = { exp: nowInSeconds + vaultAdminAuthorizationJWTLeeway, nbf: nowInSeconds - vaultAdminAuthorizationJWTLeeway, iat: nowInSeconds };
+    let jwtPayload = { iat: this.secondsSinceEpoch() };
     return vaultKeys.signVaultEditRequest(vaultIdHeader, jwtPayload);
   }
 


### PR DESCRIPTION
Before the leeway calculation was in the client, now it is on the server side. Furthermore when the IAT was in the future, it failed before. Now the client provides only a IAT and we allow it to be in the future.

https://github.com/cryptomator/hub/blob/4aeaf04d19ad4841ff761defe92874c9711ff541/backend/src/main/java/org/cryptomator/hub/filters/VaultAdminOnlyFilterProvider.java#L78-L81

is required because if we use `.acceptIssuedAt(REQUEST_LEEWAY_IN_SECONDS)` the issue is valid until forever. That is why we need to validate it our self.