### PR TITLE
Separate Hub and Cryptomator OIDC client to reduce the scopes of access

### DIFF
--- a/backend/src/main/java/org/cryptomator/hub/api/ConfigResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/ConfigResource.java
@@ -26,7 +26,11 @@ public class ConfigResource {
 
 	@Inject
 	@ConfigProperty(name = "quarkus.oidc.client-id", defaultValue = "")
-	String keycloakClientId;
+	String keycloakClientIdHub;
+
+	@Inject
+	@ConfigProperty(name = "hub.keycloak.oidc.cryptomator-client-id", defaultValue = "")
+	String keycloakClientIdCryptomator;
 
 	@Inject
 	@ConfigProperty(name = "quarkus.oidc.auth-server-url")
@@ -45,7 +49,7 @@ public class ConfigResource {
 		var authUri = replacePrefix(oidcConfData.getAuthorizationUri(), trimTrailingSlash(internalRealmUrl), publicRealmUri);
 		var tokenUri = replacePrefix(oidcConfData.getTokenUri(), trimTrailingSlash(internalRealmUrl), publicRealmUri);
 
-		return new ConfigDto(keycloakPublicUrl, keycloakRealm, keycloakClientId, authUri, tokenUri, Instant.now().truncatedTo(ChronoUnit.MILLIS));
+		return new ConfigDto(keycloakPublicUrl, keycloakRealm, keycloakClientIdHub, keycloakClientIdCryptomator, authUri, tokenUri, Instant.now().truncatedTo(ChronoUnit.MILLIS));
 	}
 
 	//visible for testing
@@ -69,8 +73,9 @@ public class ConfigResource {
 	}
 
 	public record ConfigDto(@JsonProperty("keycloakUrl") String keycloakUrl, @JsonProperty("keycloakRealm") String keycloakRealm,
-							@JsonProperty("keycloakClientId") String keycloakClientId, @JsonProperty("keycloakAuthEndpoint") String authEndpoint,
-							@JsonProperty("keycloakTokenEndpoint") String tokenEndpoint, @JsonProperty("serverTime") Instant serverTime) {
+							@JsonProperty("keycloakClientIdHub") String keycloakClientIdHub, @JsonProperty("keycloakClientIdCryptomator") String keycloakClientIdCryptomator,
+							@JsonProperty("keycloakAuthEndpoint") String authEndpoint, @JsonProperty("keycloakTokenEndpoint") String tokenEndpoint,
+							@JsonProperty("serverTime") Instant serverTime) {
 	}
 
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -22,6 +22,7 @@ quarkus.http.port=8080
 
 quarkus.oidc.application-type=service
 quarkus.oidc.client-id=cryptomatorhub
+hub.keycloak.oidc.cryptomator-client-id=cryptomator
 
 # Keycloak dev service
 %dev.quarkus.keycloak.devservices.realm-path=dev-realm.json

--- a/backend/src/main/resources/dev-realm.json
+++ b/backend/src/main/resources/dev-realm.json
@@ -98,7 +98,6 @@
       "name": "Cryptomator Hub",
       "enabled": true,
       "redirectUris": [
-        "http://127.0.0.1/*",
         "http://localhost:8080/*",
         "http://localhost:3000/*"
       ],
@@ -138,6 +137,25 @@
           }
         }
       ]
+    },
+    {
+      "clientId": "cryptomator",
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "name": "Cryptomator App",
+      "enabled": true,
+      "redirectUris": [
+        "http://127.0.0.1/*"
+      ],
+      "webOrigins": [
+        "+"
+      ],
+      "bearerOnly": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "pkce.code.challenge.method": "S256"
+      }
     }
   ],
   "browserSecurityHeaders": {

--- a/frontend/src/common/auth.ts
+++ b/frontend/src/common/auth.ts
@@ -8,7 +8,7 @@ class Auth {
     const keycloak = new Keycloak({
       url: cfg.keycloakUrl,
       realm: cfg.keycloakRealm,
-      clientId: cfg.keycloakClientId
+      clientId: cfg.keycloakClientIdHub
     });
     keycloak.onTokenExpired = () => keycloak.updateToken(30); //TODO: show notification with .catch(() => notify-user-somehow);
     await keycloak.init({

--- a/frontend/src/common/config.ts
+++ b/frontend/src/common/config.ts
@@ -17,7 +17,8 @@ const axios = AxiosStatic.create({
 export type ConfigDto = {
   keycloakRealm: string;
   keycloakUrl: string;
-  keycloakClientId: string;
+  keycloakClientIdHub: string;
+  keycloakClientIdCryptomator: string;
   keycloakAuthEndpoint: string;
   keycloakTokenEndpoint: string;
   serverTime: string;

--- a/frontend/src/common/vaultconfig.ts
+++ b/frontend/src/common/vaultconfig.ts
@@ -17,7 +17,7 @@ export class VaultConfig {
     const kid = `hub+${absBackendBaseURL}vaults/${vaultId}`;
 
     const hubConfig: VaultConfigHeaderHub = {
-      clientId: cfg.keycloakClientId,
+      clientId: cfg.keycloakClientIdCryptomator,
       authEndpoint: cfg.keycloakAuthEndpoint,
       tokenEndpoint: cfg.keycloakTokenEndpoint,
       devicesResourceUrl: `${absBackendBaseURL}devices/`,


### PR DESCRIPTION
This will result in "breaking" changes, but existing installations can be updated. We will describe this at the time of release and the update of the setup wizard on the website will also be published then.

To updating an existing deployments the following steps are required:
1. remove in the `cryptomatorhub` client in `Valid redirect URIs` the following URL: `http://127.0.0.1`
2. create a new `cryptomator` (cryptomator is the id) `Open Id connect` client with only `Standard flow` enabled and set `Valid redirect URIs` to `http://127.0.0.1`
4. regenerate the Kubernetes- or Docker-Compose deployment file using the hub setup wizard of the Cryptomator website
4. for each vault already downloaded, re-download the vault template and overwrite the `vault.cryptomator` file at the destination with the newly downloaded `vault.cryptomator` of the template.