### PR TITLE
Partially switch to reactive quarkus

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -16,7 +16,7 @@
     <quarkus.platform.version>2.13.0.Final</quarkus.platform.version>
     <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:22.0-java17</quarkus.native.builder-image>
     <quarkus.jib.base-jvm-image>eclipse-temurin:17-jre</quarkus.jib.base-jvm-image> <!-- irrelevant for -Pnative -->
-    <jwt.version>4.0.0</jwt.version>
+    <jwt.version>4.2.1</jwt.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
 
@@ -55,7 +55,11 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-resteasy-jackson</artifactId>
+      <artifactId>quarkus-resteasy-reactive</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-reactive-jackson</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -79,15 +83,15 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-rest-client-jackson</artifactId>
+      <artifactId>quarkus-rest-client-reactive-jackson</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-rest-client</artifactId>
+      <artifactId>quarkus-rest-client-reactive</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-keycloak-admin-client</artifactId>
+      <artifactId>quarkus-keycloak-admin-client-reactive</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/backend/src/main/java/org/cryptomator/hub/api/AuthorityResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/AuthorityResource.java
@@ -4,14 +4,14 @@ import org.cryptomator.hub.entities.Authority;
 import org.cryptomator.hub.entities.Group;
 import org.cryptomator.hub.entities.User;
 import org.eclipse.microprofile.openapi.annotations.Operation;
-import org.jboss.resteasy.annotations.cache.NoCache;
-import org.jboss.resteasy.annotations.jaxrs.QueryParam;
+import org.jboss.resteasy.reactive.NoCache;
 
 import javax.annotation.security.RolesAllowed;
 import javax.validation.constraints.NotBlank;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import java.util.List;
 

--- a/backend/src/main/java/org/cryptomator/hub/api/UsersResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/UsersResource.java
@@ -6,8 +6,7 @@ import org.cryptomator.hub.entities.User;
 import org.eclipse.microprofile.jwt.JsonWebToken;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
-import org.jboss.resteasy.annotations.cache.NoCache;
-import org.jboss.resteasy.annotations.jaxrs.QueryParam;
+import org.jboss.resteasy.reactive.NoCache;
 
 import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
@@ -16,6 +15,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.net.URI;

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -16,7 +16,7 @@ hub.keycloak.local-url=http://localhost:8180
 hub.keycloak.realm=cryptomator
 
 quarkus.resteasy-reactive.path=/api
-%test.quarkus.resteasy.path=/
+%test.quarkus.resteasy-reactive.path=/
 
 quarkus.http.port=8080
 

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -15,7 +15,7 @@ hub.keycloak.public-url=http://localhost:8180
 hub.keycloak.local-url=http://localhost:8180
 hub.keycloak.realm=cryptomator
 
-quarkus.resteasy.path=/api
+quarkus.resteasy-reactive.path=/api
 %test.quarkus.resteasy.path=/
 
 quarkus.http.port=8080

--- a/backend/src/test/java/org/cryptomator/hub/api/VaultResourceTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/VaultResourceTest.java
@@ -448,7 +448,7 @@ public class VaultResourceTest {
 
 		@Test
 		@Order(1)
-		@DisplayName("PUT /vaults/vault2/users/user9999 returns 401")
+		@DisplayName("PUT /vaults/vault2/users/user9999 returns 404")
 		public void addNonExistingUser() {
 			given().header(VaultAdminOnlyFilterProvider.VAULT_ADMIN_AUTHORIZATION, vault2AdminJWT)
 					.when().put("/vaults/{vaultId}/users/{userId}", "vault2", "user9999")
@@ -457,7 +457,7 @@ public class VaultResourceTest {
 
 		@Test
 		@Order(2)
-		@DisplayName("PUT /vaults/vault9999/users/user2 returns 401")
+		@DisplayName("PUT /vaults/vault9999/users/user2 returns 404")
 		public void addUserToNonExistingVault() throws NoSuchAlgorithmException, InvalidKeySpecException {
 			var algorithmVault = Algorithm.ECDSA384((ECPrivateKey) getPrivateKey("MIG2AgEAMBAGByqGSM49AgEGBSuBBAAiBIGeMIGbAgEBBDCAHpFQ62QnGCEvYh/pE9QmR1C9aLcDItRbslbmhen/h1tt8AyMhskeenT+rAyyPhGhZANiAAQLW5ZJePZzMIPAxMtZXkEWbDF0zo9f2n4+T1h/2sh/fviblc/VTyrv10GEtIi5qiOy85Pf1RRw8lE5IPUWpgu553SteKigiKLUPeNpbqmYZUkWGh3MLfVzLmx85ii2vMU="));
 			var vaultAdminJWT = JWT.create().withHeader(Map.of("vaultId", "vault9999")).withIssuedAt(Instant.now()).sign(algorithmVault);
@@ -469,7 +469,7 @@ public class VaultResourceTest {
 
 		@Test
 		@Order(3)
-		@DisplayName("PUT /vaults/vault2/users/user9999 returns 404")
+		@DisplayName("PUT /vaults/vault2/users/user9999 returns 401")
 		public void addNonExistingUserUnauthenticated() {
 			when().put("/vaults/{vaultId}/users/{userId}", "vault2", "user9999")
 					.then().statusCode(401);

--- a/backend/src/test/java/org/cryptomator/hub/api/VaultResourceTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/VaultResourceTest.java
@@ -448,7 +448,7 @@ public class VaultResourceTest {
 
 		@Test
 		@Order(1)
-		@DisplayName("PUT /vaults/vault2/members/user9999 returns 401")
+		@DisplayName("PUT /vaults/vault2/users/user9999 returns 401")
 		public void addNonExistingUser() {
 			given().header(VaultAdminOnlyFilterProvider.VAULT_ADMIN_AUTHORIZATION, vault2AdminJWT)
 					.when().put("/vaults/{vaultId}/users/{userId}", "vault2", "user9999")
@@ -457,7 +457,7 @@ public class VaultResourceTest {
 
 		@Test
 		@Order(2)
-		@DisplayName("PUT /vaults/vault9999/members/user2 returns 401")
+		@DisplayName("PUT /vaults/vault9999/users/user2 returns 401")
 		public void addUserToNonExistingVault() throws NoSuchAlgorithmException, InvalidKeySpecException {
 			var algorithmVault = Algorithm.ECDSA384((ECPrivateKey) getPrivateKey("MIG2AgEAMBAGByqGSM49AgEGBSuBBAAiBIGeMIGbAgEBBDCAHpFQ62QnGCEvYh/pE9QmR1C9aLcDItRbslbmhen/h1tt8AyMhskeenT+rAyyPhGhZANiAAQLW5ZJePZzMIPAxMtZXkEWbDF0zo9f2n4+T1h/2sh/fviblc/VTyrv10GEtIi5qiOy85Pf1RRw8lE5IPUWpgu553SteKigiKLUPeNpbqmYZUkWGh3MLfVzLmx85ii2vMU="));
 			var vaultAdminJWT = JWT.create().withHeader(Map.of("vaultId", "vault9999")).withIssuedAt(Instant.now()).sign(algorithmVault);
@@ -469,7 +469,7 @@ public class VaultResourceTest {
 
 		@Test
 		@Order(3)
-		@DisplayName("PUT /vaults/vault2/members/user9999 returns 404")
+		@DisplayName("PUT /vaults/vault2/users/user9999 returns 404")
 		public void addNonExistingUserUnauthenticated() {
 			when().put("/vaults/{vaultId}/users/{userId}", "vault2", "user9999")
 					.then().statusCode(401);

--- a/backend/src/test/java/org/cryptomator/hub/api/VaultResourceTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/VaultResourceTest.java
@@ -448,14 +448,35 @@ public class VaultResourceTest {
 
 		@Test
 		@Order(1)
-		@DisplayName("PUT /vaults/vault2/members/user9999 returns 404")
+		@DisplayName("PUT /vaults/vault2/members/user9999 returns 401")
 		public void addNonExistingUser() {
-			when().put("/vaults/{vaultId}/members/{userId}", "vault2", "user9999")
+			given().header(VaultAdminOnlyFilterProvider.VAULT_ADMIN_AUTHORIZATION, vault2AdminJWT)
+					.when().put("/vaults/{vaultId}/users/{userId}", "vault2", "user9999")
 					.then().statusCode(404);
 		}
 
 		@Test
 		@Order(2)
+		@DisplayName("PUT /vaults/vault9999/members/user2 returns 401")
+		public void addUserToNonExistingVault() throws NoSuchAlgorithmException, InvalidKeySpecException {
+			var algorithmVault = Algorithm.ECDSA384((ECPrivateKey) getPrivateKey("MIG2AgEAMBAGByqGSM49AgEGBSuBBAAiBIGeMIGbAgEBBDCAHpFQ62QnGCEvYh/pE9QmR1C9aLcDItRbslbmhen/h1tt8AyMhskeenT+rAyyPhGhZANiAAQLW5ZJePZzMIPAxMtZXkEWbDF0zo9f2n4+T1h/2sh/fviblc/VTyrv10GEtIi5qiOy85Pf1RRw8lE5IPUWpgu553SteKigiKLUPeNpbqmYZUkWGh3MLfVzLmx85ii2vMU="));
+			var vaultAdminJWT = JWT.create().withHeader(Map.of("vaultId", "vault9999")).withIssuedAt(Instant.now()).sign(algorithmVault);
+
+			given().header(VaultAdminOnlyFilterProvider.VAULT_ADMIN_AUTHORIZATION, vaultAdminJWT)
+					.when().put("/vaults/{vaultId}/users/{userId}", "vault9999", "user2")
+					.then().statusCode(404);
+		}
+
+		@Test
+		@Order(3)
+		@DisplayName("PUT /vaults/vault2/members/user9999 returns 404")
+		public void addNonExistingUserUnauthenticated() {
+			when().put("/vaults/{vaultId}/users/{userId}", "vault2", "user9999")
+					.then().statusCode(401);
+		}
+
+		@Test
+		@Order(4)
 		@DisplayName("GET /vaults/vault2/members does not contain user2")
 		public void getAccess1() {
 			given().header(VaultAdminOnlyFilterProvider.VAULT_ADMIN_AUTHORIZATION, vault2AdminJWT)
@@ -465,7 +486,7 @@ public class VaultResourceTest {
 		}
 
 		@Test
-		@Order(3)
+		@Order(5)
 		@DisplayName("GET /vaults/vault2/devices-requiring-access-grant does not contains device2")
 		public void testGetDevicesRequiringAccess1() {
 			given().header(VaultAdminOnlyFilterProvider.VAULT_ADMIN_AUTHORIZATION, vault2AdminJWT)
@@ -475,7 +496,7 @@ public class VaultResourceTest {
 		}
 
 		@Test
-		@Order(4)
+		@Order(6)
 		@DisplayName("PUT /vaults/vault2/members/user2 returns 201")
 		public void addUser1() {
 			given().header(VaultAdminOnlyFilterProvider.VAULT_ADMIN_AUTHORIZATION, vault2AdminJWT)
@@ -484,7 +505,7 @@ public class VaultResourceTest {
 		}
 
 		@Test
-		@Order(5)
+		@Order(7)
 		@DisplayName("GET /vaults/vault2/members does contain user2")
 		public void getMembers2() {
 			given().header(VaultAdminOnlyFilterProvider.VAULT_ADMIN_AUTHORIZATION, vault2AdminJWT)
@@ -494,7 +515,7 @@ public class VaultResourceTest {
 		}
 
 		@Test
-		@Order(6)
+		@Order(8)
 		@DisplayName("GET /vaults/vault2/devices-requiring-access-grant contains device2")
 		public void testGetDevicesRequiringAccess2() {
 			given().header(VaultAdminOnlyFilterProvider.VAULT_ADMIN_AUTHORIZATION, vault2AdminJWT)
@@ -504,7 +525,7 @@ public class VaultResourceTest {
 		}
 
 		@Test
-		@Order(7)
+		@Order(9)
 		@DisplayName("PUT /vaults/vault2/keys/device2 returns 201")
 		public void testGrantAccess1() {
 			given().header(VaultAdminOnlyFilterProvider.VAULT_ADMIN_AUTHORIZATION, vault2AdminJWT)
@@ -514,7 +535,7 @@ public class VaultResourceTest {
 		}
 
 		@Test
-		@Order(8)
+		@Order(10)
 		@DisplayName("GET /vaults/vault2/devices-requiring-access-grant contains not device2")
 		public void testGetDevicesRequiringAccess3() {
 			given().header(VaultAdminOnlyFilterProvider.VAULT_ADMIN_AUTHORIZATION, vault2AdminJWT)
@@ -524,7 +545,7 @@ public class VaultResourceTest {
 		}
 
 		@Test
-		@Order(9)
+		@Order(11)
 		@DisplayName("PUT /devices/device9999 returns 201")
 		public void testCreateDevice2() {
 			var deviceDto = new DeviceResource.DeviceDto("device9999", "Computer 9999", "publickey9999", "user2", Set.of(), Instant.parse("2020-02-20T20:20:20Z"));
@@ -536,7 +557,7 @@ public class VaultResourceTest {
 		}
 
 		@Test
-		@Order(10)
+		@Order(12)
 		@DisplayName("GET /vaults/vault2/devices-requiring-access-grant contains not device9999")
 		public void testGetDevicesRequiringAccess4() {
 			given().header(VaultAdminOnlyFilterProvider.VAULT_ADMIN_AUTHORIZATION, vault2AdminJWT)
@@ -546,7 +567,7 @@ public class VaultResourceTest {
 		}
 
 		@Test
-		@Order(11)
+		@Order(13)
 		@DisplayName("DELETE /vaults/vault2/members/user2 returns 204")
 		public void removeUser2() {
 			given().header(VaultAdminOnlyFilterProvider.VAULT_ADMIN_AUTHORIZATION, vault2AdminJWT)
@@ -555,7 +576,7 @@ public class VaultResourceTest {
 		}
 
 		@Test
-		@Order(12)
+		@Order(14)
 		@DisplayName("GET /vaults/vault2/access does not contain user2")
 		public void getMembers3() {
 			given().header(VaultAdminOnlyFilterProvider.VAULT_ADMIN_AUTHORIZATION, vault2AdminJWT)


### PR DESCRIPTION
Reactive quarkus is now the default. Old libs are legacy but not yet deprecated.

In this PR we switch the REST part of the backend to the new reactive libs. If [mutiny](https://smallrye.io/smallrye-mutiny/) will be the effective standard in the future, we will change our database abstraction layer using e.g. `quarkus-hibernate-reactive-panache` too. Then we change our code base to pass the retrieved `Uni` or `Multi` in a reactive way from the database to the Rest endpoint.