### PR TITLE
Use ENV variable to distinguish between self-hosted and managed instance

### DIFF
--- a/backend/src/main/java/org/cryptomator/hub/license/LicenseHolder.java
+++ b/backend/src/main/java/org/cryptomator/hub/license/LicenseHolder.java
@@ -75,19 +75,13 @@ public class LicenseHolder {
 	public boolean isExpired() {
 		return Optional.ofNullable(license) //
 				.map(l -> l.getExpiresAt().toInstant().isBefore(Instant.now())) //
-				.orElseGet(() -> {
-					if (!managedInstance) {
-						return CommunityLicenseConstants.IS_EXPIRED;
-					} else {
-						return ManagedInstanceNoLicenseConstants.IS_EXPIRED;
-					}
-				});
+				.orElse(false);
 	}
 
 	/**
 	 * Gets the number of available seats of the license
 	 *
-	 * @return Number of available seats, if license is not null. Otherwise {@value CommunityLicenseConstants#SEATS}.
+	 * @return Number of available seats, if license is not null. Otherwise {@value SelfHostedNoLicenseConstants#SEATS}.
 	 */
 	public long getAvailableSeats() {
 		return Optional.ofNullable(license) //
@@ -98,7 +92,7 @@ public class LicenseHolder {
 
 	public long getNoLicenseSeats() {
 		if (!managedInstance) {
-			return CommunityLicenseConstants.SEATS;
+			return SelfHostedNoLicenseConstants.SEATS;
 		} else {
 			return ManagedInstanceNoLicenseConstants.SEATS;
 		}
@@ -108,18 +102,16 @@ public class LicenseHolder {
 		return managedInstance;
 	}
 
-	public static class CommunityLicenseConstants {
+	public static class SelfHostedNoLicenseConstants {
 		public static final long SEATS = 5;
-		static final boolean IS_EXPIRED = false;
 
-		private CommunityLicenseConstants() {
+		private SelfHostedNoLicenseConstants() {
 			throw new IllegalStateException("Utility class");
 		}
 	}
 
 	public static class ManagedInstanceNoLicenseConstants {
 		public static final long SEATS = 0;
-		static final boolean IS_EXPIRED = false;
 
 		private ManagedInstanceNoLicenseConstants() {
 			throw new IllegalStateException("Utility class");

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -15,6 +15,8 @@ hub.keycloak.public-url=http://localhost:8180
 hub.keycloak.local-url=http://localhost:8180
 hub.keycloak.realm=cryptomator
 
+hub.managed-instance=false
+
 quarkus.resteasy-reactive.path=/api
 %test.quarkus.resteasy-reactive.path=/
 

--- a/backend/src/test/java/org/cryptomator/hub/api/BillingResourceManagedInstanceTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/BillingResourceManagedInstanceTest.java
@@ -1,0 +1,71 @@
+package org.cryptomator.hub.api;
+
+import com.radcortez.flyway.test.annotation.DataSource;
+import com.radcortez.flyway.test.annotation.FlywayTest;
+import io.agroal.api.AgroalDataSource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.quarkus.test.security.TestSecurity;
+import io.quarkus.test.security.oidc.Claim;
+import io.quarkus.test.security.oidc.OidcSecurity;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import java.sql.SQLException;
+import java.util.Map;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+
+@QuarkusTest
+@FlywayTest(value = @DataSource(url = "jdbc:h2:mem:test"), additionalLocations = {"classpath:org/cryptomator/hub/flyway"})
+@DisplayName("Resource /billing managed instance")
+@TestSecurity(user = "Admin", roles = {"admin"})
+@OidcSecurity(claims = {
+		@Claim(key = "sub", value = "admin")
+})
+@TestProfile(BillingResourceManagedInstanceTest.ManagedInstanceTestProfile.class)
+public class BillingResourceManagedInstanceTest {
+
+	@Inject
+	AgroalDataSource dataSource;
+
+	@BeforeAll
+	public static void beforeAll() {
+		RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+	}
+
+	public static class ManagedInstanceTestProfile implements QuarkusTestProfile {
+		@Override
+		public Map<String, String> getConfigOverrides() {
+			return Map.of("hub.managed-instance", "true");
+		}
+	}
+
+	@Test
+	@DisplayName("GET /billing returns 401 with empty license managed instance")
+	public void testGetEmptyManagedInstance() throws SQLException {
+		try (var s = dataSource.getConnection().createStatement()) {
+			s.execute("""
+					UPDATE "settings"
+					SET "hub_id" = '42', "license_key" = null
+					WHERE "id" = 0;
+					""");
+		}
+
+		when().get("/billing")
+				.then().statusCode(200)
+				.body("hubId", is("42"))
+				.body("hasLicense", is(false))
+				.body("email", nullValue())
+				.body("totalSeats", is(0))
+				.body("remainingSeats", is(0))
+				.body("issuedAt", nullValue())
+				.body("expiresAt", nullValue());
+	}
+}

--- a/backend/src/test/java/org/cryptomator/hub/api/BillingResourceTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/BillingResourceTest.java
@@ -56,8 +56,8 @@ public class BillingResourceTest {
 
 		@Test
 		@Order(1)
-		@DisplayName("GET /billing returns 200 with empty license")
-		public void testGetEmpty() throws SQLException {
+		@DisplayName("GET /billing returns 200 with empty license self-hosted")
+		public void testGetEmptySelfHosted() throws SQLException {
 			try (var s = dataSource.getConnection().createStatement()) {
 				s.execute("""
 						UPDATE "settings"

--- a/frontend/src/common/backend.ts
+++ b/frontend/src/common/backend.ts
@@ -150,6 +150,7 @@ export type BillingDto = {
   remainingSeats: number;
   issuedAt: Date;
   expiresAt: Date;
+  managedInstance: boolean;
 }
 
 export type VersionDto = {

--- a/frontend/src/components/AdminSettings.vue
+++ b/frontend/src/components/AdminSettings.vue
@@ -144,15 +144,19 @@
               <h3 class="text-lg font-medium leading-6 text-gray-900">
                 {{ t('admin.licenseInfo.title') }}
               </h3>
-              <p class="mt-1 text-sm text-gray-500">
+              <p v-if="!admin.managedInstance" class="mt-1 text-sm text-gray-500">
                 {{ t('admin.licenseInfo.communityLicense.description') }}
+              </p>
+              <p v-else class="mt-1 text-sm text-gray-500">
+                {{ t('admin.licenseInfo.managedNoLicense.description') }}
               </p>
             </div>
             <div class="mt-5 md:mt-0 md:col-span-2">
               <div class="grid grid-cols-6 gap-6">
                 <div class="col-span-6 sm:col-span-3">
-                  <label for="licenseType" class="block text-sm font-medium text-gray-700">{{ t('admin.licenseInfo.communityLicense.type.title') }}</label>
-                  <input id="licenseType" value="Community License" type="text" class="mt-1 focus:ring-primary focus:border-primary block w-full shadow-sm sm:text-sm border-gray-300 rounded-md bg-gray-200" readonly />
+                  <label for="licenseType" class="block text-sm font-medium text-gray-700">{{ t('admin.licenseInfo.type.title') }}</label>
+                  <input v-if="!admin.managedInstance" id="licenseType" value="Community License" type="text" class="mt-1 focus:ring-primary focus:border-primary block w-full shadow-sm sm:text-sm border-gray-300 rounded-md bg-gray-200" readonly />
+                  <input v-else id="licenseType" value="Managed" type="text" class="mt-1 focus:ring-primary focus:border-primary block w-full shadow-sm sm:text-sm border-gray-300 rounded-md bg-gray-200" readonly />
                 </div>
 
                 <div class="col-span-6 sm:col-span-3">
@@ -179,7 +183,7 @@
         <div class="flex justify-end items-center px-4 py-3 bg-gray-50 sm:px-6">
           <button type="button" class="flex-none inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-primary hover:bg-primary-d1 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary disabled:opacity-50 disabled:hover:bg-primary disabled:cursor-not-allowed" @click="manageSubscription()">
             <ArrowTopRightOnSquareIcon class="-ml-1 mr-2 h-5 w-5" aria-hidden="true" />
-            {{ t('admin.licenseInfo.communityLicense.upgradeLicense') }}
+            {{ t('admin.licenseInfo.upgradeLicense') }}
           </button>
         </div>
       </div>

--- a/frontend/src/components/AdminSettings.vue
+++ b/frontend/src/components/AdminSettings.vue
@@ -145,7 +145,7 @@
                 {{ t('admin.licenseInfo.title') }}
               </h3>
               <p v-if="!admin.managedInstance" class="mt-1 text-sm text-gray-500">
-                {{ t('admin.licenseInfo.communityLicense.description') }}
+                {{ t('admin.licenseInfo.selfHostedNoLicense.description') }}
               </p>
               <p v-else class="mt-1 text-sm text-gray-500">
                 {{ t('admin.licenseInfo.managedNoLicense.description') }}
@@ -183,7 +183,7 @@
         <div class="flex justify-end items-center px-4 py-3 bg-gray-50 sm:px-6">
           <button type="button" class="flex-none inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-primary hover:bg-primary-d1 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary disabled:opacity-50 disabled:hover:bg-primary disabled:cursor-not-allowed" @click="manageSubscription()">
             <ArrowTopRightOnSquareIcon class="-ml-1 mr-2 h-5 w-5" aria-hidden="true" />
-            {{ t('admin.licenseInfo.upgradeLicense') }}
+            {{ t('admin.licenseInfo.getLicense') }}
           </button>
         </div>
       </div>

--- a/frontend/src/i18n/de-DE.json
+++ b/frontend/src/i18n/de-DE.json
@@ -36,9 +36,10 @@
   "admin.licenseInfo.expiresAt.description.valid": "Deine Lizenz ist gültig.",
   "admin.licenseInfo.expiresAt.description.expired": "Deine Lizenz ist abgelaufen.",
   "admin.licenseInfo.manageSubscription": "Abonnement verwalten",
-  "admin.licenseInfo.communityLicense.description": "Vielen Dank, dass du Cryptomator Hub nutzt! Du hast die Community-Lizenz erhalten. Wenn du mehr Sitze benötigst, erweiter deine Lizenz.",
-  "admin.licenseInfo.communityLicense.type.title": "Typ",
-  "admin.licenseInfo.communityLicense.upgradeLicense": "Lizenz erhalten",
+  "admin.licenseInfo.type.title": "Typ",
+  "admin.licenseInfo.getLicense": "Lizenz erhalten",
+  "admin.licenseInfo.selfHostedNoLicense.description": "Vielen Dank, dass du Cryptomator Hub nutzt! Du hast die Community-Lizenz erhalten. Wenn du mehr Sitze benötigst, erweiter deine Lizenz.",
+  "admin.licenseInfo.managedNoLicense.description": "Vielen Dank, dass du Cryptomator Hub nutzt! Du hast aktuell keine aktive Lizenz.",
 
   "authenticateVaultAdminDialog.title": "Tresor verwalten",
   "authenticateVaultAdminDialog.description": "Gib das Vault-Admin-Passwort des Tresors ein, um ihn zu verwalten.",

--- a/frontend/src/i18n/en-US.json
+++ b/frontend/src/i18n/en-US.json
@@ -38,10 +38,9 @@
   "admin.licenseInfo.expiresAt.description.expired": "Your license has expired.",
   "admin.licenseInfo.manageSubscription": "Manage Subscription",
   "admin.licenseInfo.type.title": "Type",
-  "admin.licenseInfo.upgradeLicense": "Get License",
-  "admin.licenseInfo.communityLicense.description": "Thank you for using Cryptomator Hub! You have been granted the Community License. If you need more seats, upgrade your license.",
+  "admin.licenseInfo.getLicense": "Get License",
+  "admin.licenseInfo.selfHostedNoLicense.description": "Thank you for using Cryptomator Hub! You have been granted the Community License. If you need more seats, upgrade your license.",
   "admin.licenseInfo.managedNoLicense.description": "Thank you for using Cryptomator Hub! You currently have no active license.",
-  
 
   "authenticateVaultAdminDialog.title": "Manage Vault",
   "authenticateVaultAdminDialog.description": "Type in the vault admin password to manage it.",

--- a/frontend/src/i18n/en-US.json
+++ b/frontend/src/i18n/en-US.json
@@ -37,9 +37,11 @@
   "admin.licenseInfo.expiresAt.description.valid": "Your license is valid.",
   "admin.licenseInfo.expiresAt.description.expired": "Your license has expired.",
   "admin.licenseInfo.manageSubscription": "Manage Subscription",
+  "admin.licenseInfo.type.title": "Type",
+  "admin.licenseInfo.upgradeLicense": "Get License",
   "admin.licenseInfo.communityLicense.description": "Thank you for using Cryptomator Hub! You have been granted the Community License. If you need more seats, upgrade your license.",
-  "admin.licenseInfo.communityLicense.type.title": "Type",
-  "admin.licenseInfo.communityLicense.upgradeLicense": "Get License",
+  "admin.licenseInfo.managedNoLicense.description": "Thank you for using Cryptomator Hub! You currently have no active license.",
+  
 
   "authenticateVaultAdminDialog.title": "Manage Vault",
   "authenticateVaultAdminDialog.description": "Type in the vault admin password to manage it.",


### PR DESCRIPTION
When deploying Hub, we can now set `HUB_MANAGED_INSTANCE=true` (default is `false`) to indicate if this is a self-hosted or a managed instance which in turn has an influence on the community license: managed instances does not have one.

Unfortunately I didn't get it running to have a test with a custom test profile inside a test with the default profile, that is the reason for the `BillingResourceManagedInstanceTest` class. Sad but wanted to test this case as well.