### PR TITLE
Add Update Description to VaultDetails

### DIFF
--- a/frontend/src/common/backend.ts
+++ b/frontend/src/common/backend.ts
@@ -198,6 +198,11 @@ class VaultService {
     }).catch(err => rethrowAndConvertIfExpected(err, 403));
   }
 
+  public async updateDescription(vaultId: string, newDescription: String) {
+    return axiosAuth.put(`/vaults/${vaultId}/description`, newDescription)
+      .catch((error) => rethrowAndConvertIfExpected(error, 404));
+  }
+
   public async addUser(vaultId: string, userId: string, vaultKeys: VaultKeys): Promise<AxiosResponse<void>> {
     let vaultAdminAuthorizationJWT = await this.buildVaultAdminAuthorizationJWT(vaultId, vaultKeys);
     return axiosAuth.put(`/vaults/${vaultId}/users/${userId}`, null, { headers: { 'Cryptomator-Vault-Admin-Authorization': vaultAdminAuthorizationJWT } })

--- a/frontend/src/components/VaultDetails.vue
+++ b/frontend/src/components/VaultDetails.vue
@@ -9,16 +9,31 @@
 
   <div v-else class="pb-16 space-y-6">
     <div>
-      <h3 class="font-medium text-gray-900">{{ t('vaultDetails.description.header') }}</h3>
-      <div class="mt-2 flex items-center justify-between">
-        <p v-if="vault != null && vault.description.length > 0" class="text-sm text-gray-500">{{ vault.description }}</p>
-        <p v-else class="text-sm text-gray-500 italic">{{ t('vaultDetails.description.empty') }}</p>
-        <!-- TODO: add rest API to change vault metadata in backend
-        <button v-if="isVaultAdmin" type="button" class="-mr-2 h-8 w-8 bg-white rounded-full flex items-center justify-center text-gray-400 hover:bg-gray-100 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-primary">
-          <PencilIcon class="h-5 w-5" aria-hidden="true" />
-          <span class="sr-only">Add description</span>
+      <header class="flex items-center gap-1">
+        <h3 class="font-medium text-gray-900">{{ t('vaultDetails.description.header') }}</h3>
+        <button v-if="isVaultAdmin && !updatingDescription" type="button" class="-mr-2 h-6 w-6 bg-white rounded-full flex items-center justify-center text-gray-400 hover:bg-gray-100 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-primary" @click="beginUpdateDescription()">
+          <PencilIcon class="h-4 w-4" aria-hidden="true" />
+          <span class="sr-only">Update description</span>
         </button>
-        -->
+      </header>
+      <div class="mt-2">
+        <form v-if="vault != null && updatingDescription" novalidate @submit.prevent="updateDescription()" @keydown.esc.prevent="cancelUpdateDescription()">
+          <input v-model="newDescription" v-focus type="text" maxlength="255" class="block w-full rounded-md border-gray-300 shadow-sm focus:border-primary focus:ring-primary sm:text-sm" :placeholder="t('vaultDetails.description.placeholder')" />
+          <div class="mt-2 flex flex-row-reverse gap-2">
+            <button type="submit" class="inline-flex items-center rounded-md border border-transparent bg-primary px-3 py-2 text-sm font-medium leading-4 text-white shadow-sm hover:bg-primary-d1 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2">
+              {{ t('common.save') }}
+            </button>
+            <button type="button" class="inline-flex items-center rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium leading-4 text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2" @click="cancelUpdateDescription()">
+              {{ t('common.cancel') }}
+            </button>
+          </div>
+        </form>
+        <p v-else-if="vault != null && vault.description.length > 0" class="text-sm text-gray-500">
+          {{ vault.description }}
+        </p>
+        <p v-else class="text-sm text-gray-500 italic">
+          {{ t('vaultDetails.description.empty') }}
+        </p>
       </div>
     </div>
 
@@ -91,6 +106,7 @@
 </template>
 
 <script setup lang="ts">
+import { PencilIcon } from '@heroicons/vue/20/solid';
 import { PlusSmallIcon } from '@heroicons/vue/24/solid';
 import { computed, nextTick, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
@@ -108,6 +124,12 @@ const props = defineProps<{
   vaultId: string
 }>();
 
+const vFocus = {
+  mounted: (el: HTMLElement) => {
+    el.focus();
+  }
+};
+
 const isFetching = ref<boolean>();
 const onFetchError = ref<Error | null>();
 const allowRetryFetch = computed(() => onFetchError.value != null && !(onFetchError.value instanceof NotFoundError));  //fetch requests either list something, or query from th vault. In the latter, a 404 indicates the vault does not exists anymore.
@@ -116,6 +138,8 @@ const onRevokeUserAccessError = ref< {[id: string]: Error} >({});
 const onAddUserError = ref<Error | null>();
 
 const isVaultAdmin = ref(false);
+const updatingDescription = ref(false);
+const newDescription = ref('');
 const addingUser = ref(false);
 const grantingPermission = ref(false);
 const grantPermissionDialog = ref<typeof GrantPermissionDialog>();
@@ -156,6 +180,29 @@ async function vaultAdminAuthenticated(keys: VaultKeys) {
     console.error('Getting member or requiring devices access grant failed.', error);
     onFetchError.value = error instanceof Error ? error : new Error('Unknown Error');
   }
+}
+
+function beginUpdateDescription() {
+  updatingDescription.value = true;
+  newDescription.value = vault.value?.description ?? '';
+}
+
+function cancelUpdateDescription() {
+  updatingDescription.value = false;
+}
+
+function updateDescription() {
+  if (vault.value == null) {
+    return;
+  }
+
+  backend.vaults.updateDescription(vault.value.id, newDescription.value).then(() => {
+    vault.value!.description = newDescription.value;
+    updatingDescription.value = false;
+  }).catch(error => {
+    console.error('Updating description failed.', error);
+    onFetchError.value = error instanceof Error ? error : new Error('Unknown Error');
+  });
 }
 
 function isAuthorityDto(toCheck: any): toCheck is AuthorityDto {

--- a/frontend/src/i18n/de-DE.json
+++ b/frontend/src/i18n/de-DE.json
@@ -11,6 +11,7 @@
   "common.reload": "Bitte lade die Seite neu.",
   "common.remove": "Entfernen",
   "common.retry": "Wiederholen",
+  "common.save": "Speichern",
   "common.share": "Teilen",
   "common.unexpectedError": "Unerwarteter Fehler: {0}",
 
@@ -100,6 +101,7 @@
   "vaultDetails.manageVault": "Tresor verwalten",
   "vaultDetails.description.header": "Beschreibung",
   "vaultDetails.description.empty": "Keine Beschreibung vorhanden.",
+  "vaultDetails.description.placeholder": "Kurze Beschreibung dieses Tresors",
   "vaultDetails.information.header": "Information",
   "vaultDetails.information.created": "Erstellt",
   "vaultDetails.sharedWith.title": "Geteilt mit",

--- a/frontend/src/i18n/en-US.json
+++ b/frontend/src/i18n/en-US.json
@@ -12,6 +12,7 @@
   "common.reload": "Please reload the page.",
   "common.remove": "Remove",
   "common.retry": "Retry",
+  "common.save": "Save",
   "common.share": "Share",
   "common.unexpectedError": "Unexpected Error: {0}",
 
@@ -101,6 +102,7 @@
   "vaultDetails.manageVault": "Manage Vault",
   "vaultDetails.description.header": "Description",
   "vaultDetails.description.empty": "No description provided.",
+  "vaultDetails.description.placeholder": "Short description of this vault",
   "vaultDetails.information.header": "Information",
   "vaultDetails.information.created": "Created",
   "vaultDetails.sharedWith.title": "Shared with",


### PR DESCRIPTION
Fixes #101.

Currently, the draft only contains the frontend code. I'm hesitating with the backend code because I'm not sure how to achieve this "properly".

Suggestions:
- Change existing PUT on `/{vaultId}` to `createOrUpdate()`.
- Add new PUT on `/{vaultId}/description`.

Original PR is #161 but I had to re-open it.