### PR TITLE
replace H2 with Postgres in `%test` profile

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -71,10 +71,6 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-jdbc-h2</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jdbc-postgresql</artifactId>
     </dependency>
     <dependency>
@@ -130,14 +126,6 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-undertow</artifactId>
-    </dependency>
-
-    <!-- needed until https://github.com/quarkusio/quarkus/issues/14240 is solved -->
-    <dependency>
-      <groupId>com.radcortez.flyway</groupId>
-      <artifactId>flyway-junit5-extension</artifactId>
-      <version>1.4.0</version>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -59,14 +59,6 @@ quarkus.datasource.jdbc.transaction-requirement=off
 quarkus.datasource.jdbc.max-size=16
 quarkus.hibernate-orm.dialect=org.hibernate.dialect.PostgreSQL10Dialect
 quarkus.hibernate-orm.database.globally-quoted-identifiers=true
-%dev.quarkus.datasource.devservices.enabled=true
-%dev.quarkus.datasource.db-kind=postgresql
-%dev.quarkus.datasource.jdbc.driver=org.postgresql.Driver
-%dev.quarkus.hibernate-orm.dialect=org.hibernate.dialect.PostgreSQL10Dialect
-%test.quarkus.datasource.db-kind=h2
-%test.quarkus.datasource.jdbc.driver=org.h2.Driver
-%test.quarkus.datasource.jdbc.url=jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=false
-%test.quarkus.hibernate-orm.dialect=org.hibernate.dialect.H2Dialect
 quarkus.flyway.migrate-at-start=true
 quarkus.flyway.locations=classpath:org/cryptomator/hub/flyway
 

--- a/backend/src/test/java/org/cryptomator/hub/api/AuthorityResourceTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/AuthorityResourceTest.java
@@ -1,7 +1,5 @@
 package org.cryptomator.hub.api;
 
-import com.radcortez.flyway.test.annotation.DataSource;
-import com.radcortez.flyway.test.annotation.FlywayTest;
 import io.agroal.api.AgroalDataSource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
@@ -21,7 +19,6 @@ import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.Matchers.empty;
 
 @QuarkusTest
-@FlywayTest(value = @DataSource(url = "jdbc:h2:mem:test"), additionalLocations = {"classpath:org/cryptomator/hub/flyway"})
 @DisplayName("Resource /authorities")
 public class AuthorityResourceTest {
 
@@ -82,35 +79,11 @@ public class AuthorityResourceTest {
 		}
 
 		@Test
-		@DisplayName("GET /search?query=Name 3000 returns 200 with \"user3000\", \"group3000\"")
-		public void testGetSameUserGroupName() throws SQLException {
-			try (var s = dataSource.getConnection().createStatement()) {
-				s.execute("""
-						INSERT INTO "authority" ("id", "type", "name")
-						VALUES
-							('user3000', 'USER', 'Name 3000');
-							
-						INSERT INTO "user_details" ("id")
-						VALUES
-							('user3000');
-							
-						""");
-
-				s.execute("""
-						INSERT INTO "authority" ("id", "type", "name")
-						VALUES
-							('group3000', 'GROUP', 'Name 3000');
-							
-						INSERT INTO "group_details" ("id")
-						VALUES
-							('group3000');
-							
-						""");
-			}
-
-			when().get("/authorities/search?query=Name 3000")
+		@DisplayName("GET /search?query=1 returns 200 with \"user1\", \"group1\"")
+		public void testGetSameUserGroupName() {
+			when().get("/authorities/search?query=1")
 					.then().statusCode(200)
-					.body("id", hasItems("user3000", "group3000"));
+					.body("id", hasItems("user1", "group1"));
 		}
 	}
 }

--- a/backend/src/test/java/org/cryptomator/hub/api/BillingResourceManagedInstanceTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/BillingResourceManagedInstanceTest.java
@@ -1,7 +1,5 @@
 package org.cryptomator.hub.api;
 
-import com.radcortez.flyway.test.annotation.DataSource;
-import com.radcortez.flyway.test.annotation.FlywayTest;
 import io.agroal.api.AgroalDataSource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
@@ -23,7 +21,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 
 @QuarkusTest
-@FlywayTest(value = @DataSource(url = "jdbc:h2:mem:test"), additionalLocations = {"classpath:org/cryptomator/hub/flyway"})
 @DisplayName("Resource /billing managed instance")
 @TestSecurity(user = "Admin", roles = {"admin"})
 @OidcSecurity(claims = {

--- a/backend/src/test/java/org/cryptomator/hub/api/BillingResourceTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/BillingResourceTest.java
@@ -1,7 +1,5 @@
 package org.cryptomator.hub.api;
 
-import com.radcortez.flyway.test.annotation.DataSource;
-import com.radcortez.flyway.test.annotation.FlywayTest;
 import io.agroal.api.AgroalDataSource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
@@ -26,7 +24,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 
 @QuarkusTest
-@FlywayTest(value = @DataSource(url = "jdbc:h2:mem:test"), additionalLocations = {"classpath:org/cryptomator/hub/flyway"})
 @DisplayName("Resource /billing")
 public class BillingResourceTest {
 
@@ -40,7 +37,6 @@ public class BillingResourceTest {
 
 	@Nested
 	@DisplayName("As admin")
-	@FlywayTest(value = @DataSource(url = "jdbc:h2:mem:test"), additionalLocations = {"classpath:org/cryptomator/hub/flyway"}, clean = false)
 	@TestSecurity(user = "Admin", roles = {"admin"})
 	@OidcSecurity(claims = {
 			@Claim(key = "sub", value = "admin")

--- a/backend/src/test/java/org/cryptomator/hub/api/UsersResourceTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/UsersResourceTest.java
@@ -1,7 +1,5 @@
 package org.cryptomator.hub.api;
 
-import com.radcortez.flyway.test.annotation.DataSource;
-import com.radcortez.flyway.test.annotation.FlywayTest;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
 import io.quarkus.test.security.oidc.Claim;
@@ -20,7 +18,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.empty;
 
 @QuarkusTest
-@FlywayTest(value = @DataSource(url = "jdbc:h2:mem:test"), additionalLocations = {"classpath:org/cryptomator/hub/flyway"})
 @DisplayName("Resource /users")
 public class UsersResourceTest {
 

--- a/backend/src/test/java/org/cryptomator/hub/entities/EntityIntegrationTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/entities/EntityIntegrationTest.java
@@ -1,90 +1,98 @@
 package org.cryptomator.hub.entities;
 
-import com.radcortez.flyway.test.annotation.DataSource;
-import com.radcortez.flyway.test.annotation.FlywayTest;
 import io.agroal.api.AgroalDataSource;
+import io.quarkus.hibernate.orm.panache.Panache;
+import io.quarkus.hibernate.orm.panache.runtime.JpaOperations;
 import io.quarkus.panache.common.Parameters;
+import io.quarkus.panache.common.Sort;
+import io.quarkus.test.TestTransaction;
 import io.quarkus.test.junit.QuarkusTest;
+import org.hibernate.annotations.QueryHints;
 import org.hibernate.exception.ConstraintViolationException;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
+import javax.persistence.EntityManager;
 import javax.persistence.PersistenceException;
+import javax.transaction.TransactionScoped;
 import javax.transaction.Transactional;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.List;
 
 @QuarkusTest
-@FlywayTest(value = @DataSource(url = "jdbc:h2:mem:test"), additionalLocations = {"classpath:org/cryptomator/hub/flyway"})
 @DisplayName("Persistent Entities")
 public class EntityIntegrationTest {
 
 	@Inject
 	AgroalDataSource dataSource;
 
-	@Transactional(Transactional.TxType.REQUIRES_NEW)
-	public static void tx(Runnable validation) {
-		validation.run();
-	}
+	@Inject
+	EntityManager entityManager;
 
 	@Test
+	@TestTransaction
 	@DisplayName("Removing a Device cascades to Access")
-	public void removingDeviceCascadesToAccess() {
-		tx(() -> {
-			Device device = Device.findById("device1");
-			/* FIXME Affects the deletion of the device such that the following transaction fails but should be executed.
-			boolean match = Access.<Access>findAll().stream().anyMatch(a -> "device1".equals(a.device.id));
-			Assertions.assertTrue(match);
-			*/
-			device.delete();
-		});
+	public void removingDeviceCascadesToAccess() throws SQLException {
+		try (var s = dataSource.getConnection().createStatement()) {
+			// test data will be removed via @TestTransaction
+			s.execute("""
+					INSERT INTO "device" ("id", "owner_id", "name", "publickey", "creation_time")
+						VALUES ('device999', 'user1', 'Computer 999', 'publickey999', '2020-02-20 20:20:20');
+					INSERT INTO "access_token" ("device_id", "vault_id", "jwe") VALUES ('device999', 'vault1', 'jwe4');
+					""");
+		}
 
-		tx(() -> {
-			var match = AccessToken.<AccessToken>findAll().stream().anyMatch(a -> "device1".equals(a.device.id));
-			Assertions.assertFalse(match);
-		});
+		var deleted = Device.deleteById("device999");
+		var matchAfter = AccessToken.<AccessToken>findAll().stream().anyMatch(a -> "device999".equals(a.device.id));
+		Assertions.assertTrue(deleted);
+		Assertions.assertFalse(matchAfter);
 	}
 
 	@Test
+	@TestTransaction
 	@DisplayName("User's device names need to be unique")
 	public void testAddNonUniqueDeviceName() {
-		tx(() -> {
-			Device existingDevice = Device.findById("device1");
-			Device conflictingDevice = new Device();
-			conflictingDevice.id = "deviceX";
-			conflictingDevice.name = existingDevice.name;
-			conflictingDevice.owner = existingDevice.owner;
-			conflictingDevice.publickey = "XYZ";
-			conflictingDevice.creationTime = Timestamp.valueOf("2020-02-20 20:20:20");
+		Device existingDevice = Device.findById("device1");
+		Device conflictingDevice = new Device();
+		conflictingDevice.id = "deviceX";
+		conflictingDevice.name = existingDevice.name;
+		conflictingDevice.owner = existingDevice.owner;
+		conflictingDevice.publickey = "XYZ";
+		conflictingDevice.creationTime = Timestamp.valueOf("2020-02-20 20:20:20");
 
-			PersistenceException thrown = Assertions.assertThrows(PersistenceException.class, conflictingDevice::persistAndFlush);
-			Assertions.assertInstanceOf(ConstraintViolationException.class, thrown.getCause());
-		});
+		PersistenceException thrown = Assertions.assertThrows(PersistenceException.class, conflictingDevice::persistAndFlush);
+		Assertions.assertInstanceOf(ConstraintViolationException.class, thrown.getCause());
 	}
 
 	@Test
+	@TestTransaction
 	@DisplayName("Retrieve the correct token when a device has access to multiple vaults")
 	public void testGetCorrectTokenForDeviceWithAcessToMultipleVaults() throws SQLException {
 		try (var s = dataSource.getConnection().createStatement()) {
+			// test data will be removed via @TestTransaction
 			s.execute("""
-					INSERT INTO "access_token" ("device_id", "vault_id", "jwe") VALUES ('device3', 'vault1', 'jwe4');
+					INSERT INTO "device" ("id", "owner_id", "name", "publickey", "creation_time")
+						VALUES ('device999', 'user1', 'Computer 999', 'publickey999', '2020-02-20 20:20:20');
+					INSERT INTO "access_token" ("device_id", "vault_id", "jwe") VALUES ('device999', 'vault1', 'jwe4');
+					INSERT INTO "access_token" ("device_id", "vault_id", "jwe") VALUES ('device999', 'vault2', 'jwe5');
 					""");
-
-			List<AccessToken> tokens = AccessToken
-					.<AccessToken>find("#AccessToken.get", Parameters.with("deviceId", "device3")
-							.and("vaultId", "vault1")
-							.and("userId", "user1"))
-					.stream().toList();
-
-			var token = tokens.get(0);
-
-			Assertions.assertEquals(1, tokens.size());
-			Assertions.assertEquals("vault1", token.vault.id);
-			Assertions.assertEquals("device3", token.device.id);
-			Assertions.assertEquals("jwe4", token.jwe);
 		}
+
+		List<AccessToken> tokens = AccessToken
+				.<AccessToken>find("#AccessToken.get", Parameters.with("deviceId", "device999")
+						.and("vaultId", "vault1")
+						.and("userId", "user1"))
+				.stream().toList();
+
+		var token = tokens.get(0);
+
+		Assertions.assertEquals(1, tokens.size());
+		Assertions.assertEquals("vault1", token.vault.id);
+		Assertions.assertEquals("device999", token.device.id);
+		Assertions.assertEquals("jwe4", token.jwe);
 	}
 }

--- a/backend/src/test/java/org/cryptomator/hub/filters/VaultAdminOnlyFilterProviderTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/filters/VaultAdminOnlyFilterProviderTest.java
@@ -4,8 +4,6 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.DecodedJWT;
-import com.radcortez.flyway.test.annotation.DataSource;
-import com.radcortez.flyway.test.annotation.FlywayTest;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,7 +21,6 @@ import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 
 @QuarkusTest
-@FlywayTest(value = @DataSource(url = "jdbc:h2:mem:test"), additionalLocations = {"classpath:org/cryptomator/hub/flyway"})
 class VaultAdminOnlyFilterProviderTest {
 
 	private static final String NO_VAULT_ID_TOKEN = "eyJhbGciOiJFUzM4NCIsInR5cCI6IkpXVCJ9.e30.vT0jNCotwtzr37JNM_C6uZFCw3GvVjcikn-CVrDociILPiXBXA8i7dWFwBnUQkDBcFbouh-eUB_wEWgqe9WTG2rT66_c1G2LZUQcCsKdWJdTyK4ZxLXLYOYhNOHtqShI";

--- a/backend/src/test/java/org/cryptomator/hub/filters/VaultAdminOnlyFilterProviderTestIT.java
+++ b/backend/src/test/java/org/cryptomator/hub/filters/VaultAdminOnlyFilterProviderTestIT.java
@@ -2,8 +2,6 @@ package org.cryptomator.hub.filters;
 
 import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
-import com.radcortez.flyway.test.annotation.DataSource;
-import com.radcortez.flyway.test.annotation.FlywayTest;
 import io.agroal.api.AgroalDataSource;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Assertions;
@@ -18,11 +16,9 @@ import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.UriInfo;
 import java.sql.SQLException;
 import java.time.Clock;
-import java.time.Instant;
 import java.time.ZoneId;
 
 @QuarkusTest
-@FlywayTest(value = @DataSource(url = "jdbc:h2:mem:test"), additionalLocations = {"classpath:org/cryptomator/hub/flyway"})
 class VaultAdminOnlyFilterProviderTestIT {
 
 	private VaultAdminOnlyFilterProvider vaultAdminOnlyFilterProvider;

--- a/backend/src/test/resources/org/cryptomator/hub/flyway/V9999__Test_Data.sql
+++ b/backend/src/test/resources/org/cryptomator/hub/flyway/V9999__Test_Data.sql
@@ -1,5 +1,7 @@
 -- noinspection SqlNoDataSourceInspectionForFile
 
+-- This test data can be used in unit tests. A test should leave this data as it found it, either by transaction rollback or other means. See https://github.com/cryptomator/hub/pull/182 for some options
+
 UPDATE "settings"
 SET "hub_id" = '42',
 	"license_key"  = 'eyJhbGciOiJFUzUxMiJ9.eyJqdGkiOiI0MiIsImlhdCI6MTY0ODA0OTM2MCwiaXNzIjoiU2t5bWF0aWMiLCJhdWQiOiJDcnlwdG9tYXRvciBIdWIiLCJzdWIiOiJodWJAY3J5cHRvbWF0b3Iub3JnIiwic2VhdHMiOjUsImV4cCI6MjUzNDAyMjE0NDAwLCJyZWZyZXNoVXJsIjoiaHR0cDovL2xvY2FsaG9zdDo4Nzg3L2h1Yi9zdWJzY3JpcHRpb24_aHViX2lkPTQyIn0.AKyoZ0WQ8xhs8vPymWPHCsc6ch6pZpfxBcrF5QjVLSQVnYz2s5QF3nnkwn4AGR7V14TuhkJMZLUZxMdQAYLyL95sAV2Fu0E4-e1v3IVKlNKtze89eqYvEs6Ak9jWjtecOgPWNWjz2itI4MfJBDmbFtTnehOtqRqUdsDoC9NFik2C7tHm'

--- a/backend/src/test/resources/org/cryptomator/hub/flyway/V9999__Test_Data.sql
+++ b/backend/src/test/resources/org/cryptomator/hub/flyway/V9999__Test_Data.sql
@@ -9,7 +9,8 @@ INSERT INTO "authority" ("id", "type", "name")
 VALUES
 	('user1', 'USER', 'User Name 1'),
 	('user2', 'USER', 'User Name 2'),
-	('group1', 'GROUP', 'Group Name 1');
+	('group1', 'GROUP', 'Group Name 1'),
+    ('group2', 'GROUP', 'Group Name 2');
 
 INSERT INTO "user_details" ("id")
 VALUES
@@ -18,11 +19,13 @@ VALUES
 
 INSERT INTO "group_details" ("id")
 VALUES
-	('group1');
+	('group1'),
+	('group2');
 
 INSERT INTO "group_membership" ("group_id", "member_id")
 VALUES
-	('group1', 'user1');
+	('group1', 'user1'),
+	('group2', 'user2');
 
 INSERT INTO "vault" ("id", "name", "description", "creation_time", "salt", "iterations", "masterkey", "auth_pubkey", "auth_prvkey")
 VALUES


### PR DESCRIPTION
In order to use non-ANSI-SQL features, we need to make sure all profiles rely on the same dialect. So we need to drop h2 in unit tests, replacing it with Postgres (provided via testcontainers).

Sadly, this breaks `@FlywayTest`, so I needed to change a lot of unit tests to make sure, they don't modify anything prepared via `V9999__Test_Data.sql`. If a test wants to delete/change something, it should prepare its own data. As a general rule, a unit tests should "leave it (the database) as it found it". This is achieved in one of the following ways:

1. In some cases, `@TestTransaction` could be use to rollback such changes. This requires all to happen in the same transaction, obviously. So this is not feasible when using _REST assured_, as the serverside code is running outside the test transaction.
2. In other cases a `@AfterAll` function could do some cleanup.
3. For `@Order`ed tests creation and deletion could be run in pairs
4. If every other approach fails, the test itself needs to do the cleanup work. Ugly but simple.

Especially in `VaultResourceTest` I regrouped some of the nested tests and tried to make all tests run on the same set of common test data.