### PR TITLE
Replace `V2__Initialize_Settings.java` with `V3__Initialize_Settings.sql`

### DIFF
--- a/backend/src/main/java/org/cryptomator/hub/flyway/V2__Initialize_Settings.java
+++ b/backend/src/main/java/org/cryptomator/hub/flyway/V2__Initialize_Settings.java
@@ -3,6 +3,10 @@ package org.cryptomator.hub.flyway;
 import org.flywaydb.core.api.migration.BaseJavaMigration;
 import org.flywaydb.core.api.migration.Context;
 
+/**
+ * @deprecated This used to generated the hub id. It got replaced by <code>V3__Initialize_Settings.sql</code>, though. Despite being dead code,
+ * this class must remain present in order for Flyway to work correctly on existing installations. May be removed when we start with a new <a href="https://flywaydb.org/documentation/concepts/baselinemigrations">baseline migration</a>
+ */
 @Deprecated
 public class V2__Initialize_Settings extends BaseJavaMigration {
 

--- a/backend/src/main/java/org/cryptomator/hub/flyway/V2__Initialize_Settings.java
+++ b/backend/src/main/java/org/cryptomator/hub/flyway/V2__Initialize_Settings.java
@@ -3,20 +3,12 @@ package org.cryptomator.hub.flyway;
 import org.flywaydb.core.api.migration.BaseJavaMigration;
 import org.flywaydb.core.api.migration.Context;
 
-import java.sql.PreparedStatement;
-import java.sql.Types;
-import java.util.UUID;
-
+@Deprecated
 public class V2__Initialize_Settings extends BaseJavaMigration {
 
 	@Override
-	public void migrate(Context context) throws Exception {
-		try (PreparedStatement statement = context.getConnection().prepareStatement("INSERT INTO \"settings\" (\"id\", \"hub_id\", \"license_key\") VALUES (?, ?, ?)")) {
-			statement.setInt(1, 0);
-			statement.setString(2, UUID.randomUUID().toString());
-			statement.setNull(3, Types.VARCHAR);
-			statement.executeUpdate();
-		}
+	public void migrate(Context context) {
+		// no-op: Replaced by V3__Initialize_Settings.sql
 	}
 
 }

--- a/backend/src/main/resources/org/cryptomator/hub/flyway/V3__Initialize_Settings.sql
+++ b/backend/src/main/resources/org/cryptomator/hub/flyway/V3__Initialize_Settings.sql
@@ -1,0 +1,2 @@
+-- Only relevant for _new_ installations. This replaces old Java-based V2 migration. See issue #183 why we could not replace V2
+INSERT INTO "settings" ("id", "hub_id") VALUES (0, gen_random_uuid()) ON CONFLICT DO NOTHING


### PR DESCRIPTION
The Java based Flyway migration caused problems during unit tests from time to time. Not reliably and we don't know the cause. Maybe this problem only occurred with H2 (now obsolete), but we don't know.

In 0392467 I tried replacing the Java-based migration with an SQL one, but this causes problem with existing installations (see #183).

Once applied, Flyway migrations *must not change*. Flyway checks the checksum of migration scripts. There is no checksum for Java-based migrations though. So as long as the V2 migration keeps being a Java-based migration, it may change.

This allows to keep V2 as a Java-based migration, but making it a no-op migration. And add a V3 SQL-based migration:

| installed_rank | version | description | type | script | checksum | installed_by | installed_on | execution_time | success |
|---|---|---|---|---|---|---|---|---|---|
| 1 | 1 | Create Tables | SQL | org/cryptomator/hub/flyway/V1__Create_Tables.sql | -285654398 | hub | 2023-03-06 14:04:23.680275 | 503 | true |
| 2 | 2 | Initialize Settings | JDBC | org.cryptomator.hub.flyway.V2__Initialize_Settings |  | hub | 2023-03-06 14:04:24.310263 | 29 | true |
| 3 | 3 | Initialize Settings | SQL | org/cryptomator/hub/flyway/V3__Initialize_Settings.sql | -1214478227 | hub | 2023-03-06 14:19:46.061209 | 19 | true |