### PR TITLE
Fix 204 without description.

### DIFF
--- a/backend/src/main/java/org/cryptomator/hub/api/BillingResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/BillingResource.java
@@ -52,7 +52,7 @@ public class BillingResource {
 	@RolesAllowed("admin")
 	@Consumes(MediaType.TEXT_PLAIN)
 	@Operation(summary = "set the token")
-	@APIResponse(responseCode = "204")
+	@APIResponse(responseCode = "204", description = "token set")
 	@APIResponse(responseCode = "400", description = "token is invalid (e.g., expired or invalid signature)")
 	@APIResponse(responseCode = "403", description = "only admins are allowed to set the token")
 	public Response setToken(@NotNull @ValidJWS String token) {


### PR DESCRIPTION
Context:
```
org.openapitools.codegen.SpecValidationException: There were issues with the specification. The option can be disabled via validateSpec (Maven/Gradle) or --skip-validate-spec (CLI).
 | Error count: 1, Warning count: 0
Errors: 
	-attribute paths.'/api/billing/token'(put).responses.204.description is missing
```