### PR TITLE
Add "Edit Vault Metadata" action to VaultDetails

### DIFF
--- a/frontend/src/components/EditVaultMetadataDialog.vue
+++ b/frontend/src/components/EditVaultMetadataDialog.vue
@@ -1,0 +1,126 @@
+<template>
+  <TransitionRoot as="template" :show="open" @after-leave="$emit('close')">
+    <Dialog as="div" class="fixed z-10 inset-0 overflow-y-auto" @close="open = false">
+      <TransitionChild as="template" enter="ease-out duration-300" enter-from="opacity-0" enter-to="opacity-100" leave="ease-in duration-200" leave-from="opacity-100" leave-to="opacity-0">
+        <DialogOverlay class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" />
+      </TransitionChild>
+
+      <div class="fixed inset-0 z-10 overflow-y-auto">
+        <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+          <TransitionChild as="template" enter="ease-out duration-300" enter-from="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95" enter-to="opacity-100 translate-y-0 sm:scale-100" leave="ease-in duration-200" leave-from="opacity-100 translate-y-0 sm:scale-100" leave-to="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95">
+            <DialogPanel class="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
+              <form ref="form" novalidate @submit.prevent="updateVaultMetadata()">
+                <div class="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+                  <div class="sm:flex sm:items-start">
+                    <div class="mx-auto shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-gray-100 sm:mx-0 sm:h-10 sm:w-10">
+                      <PencilIcon class="h-6 w-6 text-gray-600" aria-hidden="true" />
+                    </div>
+                    <div class="mt-3 grow text-center sm:mt-0 sm:ml-4 sm:text-left">
+                      <DialogTitle as="h3" class="text-lg leading-6 font-medium text-gray-900">
+                        {{ t('editVaultMetadataDialog.title') }}
+                      </DialogTitle>
+                      <div class="mt-2">
+                        <p class="text-sm text-gray-500">
+                          {{ t('editVaultMetadataDialog.description') }}
+                        </p>
+                      </div>
+                      <div class="mt-5 sm:mt-6">      
+                        <label for="vaultName" class="block text-sm font-medium text-gray-700">{{ t('editVaultMetadataDialog.vaultName') }}</label>
+                        <input id="vaultName" v-model="vaultName" type="text" name="vaultName" class="mt-1 focus:ring-primary focus:border-primary block w-full shadow-sm sm:text-sm border-gray-300 rounded-md disabled:bg-gray-200" :class="{ 'invalid:border-red-300 invalid:text-red-900 focus:invalid:ring-red-500 focus:invalid:border-red-500': onUpdateVaultMetadataError instanceof FormValidationFailedError }" required />
+                      </div>
+                      <div class="mt-5 sm:mt-6">      
+                        <label for="vaultDescription" class="block text-sm font-medium text-gray-700">
+                          {{ t('editVaultMetadataDialog.vaultDescription') }}
+                          <span class="text-xs text-gray-500">({{ t('common.optional') }})</span>
+                        </label>
+                        <input id="vaultDescription" v-model="vaultDescription" type="text" name="vaultDescription" class="mt-1 focus:ring-primary focus:border-primary block w-full shadow-sm sm:text-sm border-gray-300 rounded-md disabled:bg-gray-200" :class="{ 'invalid:border-red-300 invalid:text-red-900 focus:invalid:ring-red-500 focus:invalid:border-red-500': onUpdateVaultMetadataError instanceof FormValidationFailedError }" />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse items-baseline">
+                  <button type="submit" class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-primary  text-base font-medium text-white hover:bg-primary-d1 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary sm:ml-3 sm:w-auto sm:text-sm">
+                    {{ t('common.update') }}
+                  </button>
+                  <button type="button" class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm" @click="open = false">
+                    {{ t('common.cancel') }}
+                  </button>
+                  <div v-if="onUpdateVaultMetadataError != null">
+                    <p v-if="onUpdateVaultMetadataError instanceof FormValidationFailedError" class="text-sm text-red-900">
+                      {{ t('editVaultMetadataDialog.error.formValidationFailed') }}
+                    </p>
+                    <p v-else-if="onUpdateVaultMetadataError instanceof ConflictError" class="text-sm text-red-900">
+                      {{ t('editVaultMetadataDialog.error.vaultAlreadyExists') }}
+                    </p>
+                    <p v-else class="text-sm text-red-900">
+                      {{ t('common.unexpectedError', [onUpdateVaultMetadataError.message]) }}
+                    </p>
+                  </div>
+                </div>
+              </form>
+            </DialogPanel>
+          </TransitionChild>
+        </div>
+      </div>
+    </Dialog>
+  </TransitionRoot>
+</template>
+
+<script setup lang="ts">
+import { Dialog, DialogOverlay, DialogPanel, DialogTitle, TransitionChild, TransitionRoot } from '@headlessui/vue';
+import { PencilIcon } from '@heroicons/vue/24/outline';
+import { ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import backend, { ConflictError, VaultDto } from '../common/backend';
+
+class FormValidationFailedError extends Error {
+  constructor() {
+    super('The form is invalid.');
+  }
+}
+
+const { t } = useI18n({ useScope: 'global' });
+
+const open = ref(false);
+const form = ref<HTMLFormElement>();
+
+const onUpdateVaultMetadataError = ref<Error|null>();
+
+const vaultName = ref('');
+const vaultDescription = ref('');
+
+const props = defineProps<{
+  vault: VaultDto
+}>();
+
+const emit = defineEmits<{
+  (e: 'close'): void
+  (e: 'updated', updatedVault: VaultDto): void
+}>();
+
+defineExpose({
+  show
+});
+
+function show() {
+  open.value = true;
+  vaultName.value = props.vault.name;
+  vaultDescription.value = props.vault.description;
+}
+
+async function updateVaultMetadata() {
+  onUpdateVaultMetadataError.value = null;
+  try {
+    if (!form.value?.checkValidity()) {
+      throw new FormValidationFailedError();
+    }
+    const vault = props.vault;
+    const updatedVault = await backend.vaults.createOrUpdateVault(vault.id, vaultName.value, vaultDescription.value, vault.archived, vault.masterkey, vault.iterations, vault.salt, vault.authPublicKey, vault.authPrivateKey);
+    emit('updated', updatedVault);
+    open.value = false;
+  } catch (error) {
+    console.error('Updating vault metadata failed.', error);
+    onUpdateVaultMetadataError.value = error instanceof Error ? error : new Error('Unknown Error');
+  }
+}
+</script>

--- a/frontend/src/components/VaultDetails.vue
+++ b/frontend/src/components/VaultDetails.vue
@@ -85,6 +85,9 @@
               <ArrowPathIcon class="h-5 w-5" aria-hidden="true" />
             </button>
           </div>
+          <button type="button" class="bg-white py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary" @click="showEditVaultMetadataDialog()">
+            {{ t('vaultDetails.actions.editVaultMetadata') }}
+          </button>
           <button type="button" class="bg-white py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary" @click="showDownloadVaultTemplateDialog()">
             {{ t('vaultDetails.actions.downloadVaultTemplate') }}
           </button>
@@ -116,9 +119,10 @@
 
   <AuthenticateVaultAdminDialog v-if="authenticatingVaultAdmin && vault != null" ref="authenticateVaultAdminDialog" :vault="vault" @action="vaultAdminAuthenticated" @close="authenticatingVaultAdmin = false" />
   <GrantPermissionDialog v-if="grantingPermission && vault != null && vaultKeys != null" ref="grantPermissionDialog" :vault="vault" :devices="devicesRequiringAccessGrant" :vault-keys="vaultKeys" @close="grantingPermission = false" @permission-granted="permissionGranted()" />
+  <EditVaultMetadataDialog v-if="editingVaultMetadata && vault != null && vaultKeys != null" ref="editVaultMetadataDialog" :vault="vault" @close="editingVaultMetadata = false" @updated="v => refreshVault(v)" />
   <DownloadVaultTemplateDialog v-if="downloadingVaultTemplate && vault != null && vaultKeys != null" ref="downloadVaultTemplateDialog" :vault="vault" :vault-keys="vaultKeys" @close="downloadingVaultTemplate = false" />
   <RecoveryKeyDialog v-if="showingRecoveryKey && vault != null && vaultKeys != null" ref="recoveryKeyDialog" :vault="vault" :vault-keys="vaultKeys" @close="showingRecoveryKey = false" />
-  <ArchiveVaultDialog v-if="archivingVault && vault != null" ref="archiveVaultDialog" :vault="vault" @close="archivingVault = false" @archived="v => refreshVault(v)"/>
+  <ArchiveVaultDialog v-if="archivingVault && vault != null" ref="archiveVaultDialog" :vault="vault" @close="archivingVault = false" @archived="v => refreshVault(v)" />
   <ReactivateVaultDialog v-if="reactivatingVault && vault != null" ref="reactivateVaultDialog" :vault="vault" @close="reactivatingVault = false" @reactivated="v => refreshVault(v)" />
 </template>
 
@@ -132,6 +136,7 @@ import { VaultKeys } from '../common/crypto';
 import ArchiveVaultDialog from './ArchiveVaultDialog.vue';
 import AuthenticateVaultAdminDialog from './AuthenticateVaultAdminDialog.vue';
 import DownloadVaultTemplateDialog from './DownloadVaultTemplateDialog.vue';
+import EditVaultMetadataDialog from './EditVaultMetadataDialog.vue';
 import FetchError from './FetchError.vue';
 import GrantPermissionDialog from './GrantPermissionDialog.vue';
 import ReactivateVaultDialog from './ReactivateVaultDialog.vue';
@@ -158,6 +163,8 @@ const isVaultAdmin = ref(false);
 const addingUser = ref(false);
 const grantingPermission = ref(false);
 const grantPermissionDialog = ref<typeof GrantPermissionDialog>();
+const editingVaultMetadata = ref(false);
+const editVaultMetadataDialog = ref<typeof EditVaultMetadataDialog>();
 const downloadingVaultTemplate = ref(false);
 const downloadVaultTemplateDialog = ref<typeof DownloadVaultTemplateDialog>();
 const showingRecoveryKey = ref(false);
@@ -262,6 +269,11 @@ async function showManageVaultDialog() {
 function showGrantPermissionDialog() {
   grantingPermission.value = true;
   nextTick(() => grantPermissionDialog.value?.show());
+}
+
+function showEditVaultMetadataDialog() {
+  editingVaultMetadata.value = true;
+  nextTick(() => editVaultMetadataDialog.value?.show());
 }
 
 function showDownloadVaultTemplateDialog() {

--- a/frontend/src/components/VaultList.vue
+++ b/frontend/src/components/VaultList.vue
@@ -111,7 +111,7 @@
   </div>
 
   <SlideOver v-if="selectedVault != null" ref="vaultDetailsSlideOver" :title="selectedVault.name" @close="selectedVault = null">
-    <VaultDetails :vault-id="selectedVault.id" @vault-updated="_ => fetchData()"></VaultDetails>
+    <VaultDetails :vault-id="selectedVault.id" @vault-updated="v => onSelectedVaultUpdate(v)"></VaultDetails>
   </SlideOver>
 </template>
 
@@ -175,5 +175,18 @@ async function onAllVaultsClick() {
 
 async function onAccessibleVaultsClick() {
   vaults.value = (await backend.vaults.listAccessible()).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+async function onSelectedVaultUpdate(vault: VaultDto) {
+  await fetchData();
+  if (vaults.value == null || vault.id !== selectedVault.value?.id) {
+    return;
+  }
+  const index = vaults.value?.findIndex(v => v.id === vault.id);
+  if (index !== undefined && index !== -1) {
+    selectedVault.value = vaults.value[index];
+  } else {
+    selectedVault.value = vault;
+  }
 }
 </script>

--- a/frontend/src/i18n/de-DE.json
+++ b/frontend/src/i18n/de-DE.json
@@ -22,6 +22,7 @@
   "common.retry": "Wiederholen",
   "common.share": "Teilen",
   "common.unexpectedError": "Unerwarteter Fehler: {0}",
+  "common.update": "Aktualisieren",
 
   "admin.title": "Admin",
   "admin.serverInfo.title": "Server.Info",
@@ -113,6 +114,13 @@
   "downloadVaultTemplateDialog.title": "Tresorvorlage herunterladen",
   "downloadVaultTemplateDialog.description": "Lade die gezippte Tresorvorlage herunter und entpacke ihn an einem beliebigen Ort, der für deine Teammitglieder freigegeben ist. Dies ist einmal für die Ersteinrichtung erforderlich.",
 
+  "editVaultMetadataDialog.title": "Tresor-Metadaten bearbeiten",
+  "editVaultMetadataDialog.description": "Aktualisiere den Namen und die Beschreibung des Tresors.",
+  "editVaultMetadataDialog.vaultName": "Tresorname",
+  "editVaultMetadataDialog.vaultDescription": "Beschreibung",
+  "editVaultMetadataDialog.error.formValidationFailed": "Tresorname darf nicht leer sein.",
+  "editVaultMetadataDialog.error.conflict": "Ein Tresor mit dem angegebenen Namen existiert bereits.",
+
   "grantPermissionDialog.title": "Berechtigung erteilen",
   "grantPermissionDialog.description": "Berechtige weitere Geräten auf den Tresor zuzugreifen.",
   "grantPermissionDialog.submit": "Berechtigung für {0} Gerät(e) gewähren",
@@ -145,6 +153,7 @@
   "vaultDetails.sharedWith.title": "Geteilt mit",
   "vaultDetails.actions.updatePermissions": "Berechtigungen aktualisieren",
   "vaultDetails.actions.updatePermissions.reload": "Neu laden",
+  "vaultDetails.actions.editVaultMetadata": "Tresor-Metadaten bearbeiten",
   "vaultDetails.actions.downloadVaultTemplate": "Tresor-Vorlage herunterladen",
   "vaultDetails.actions.showRecoveryKey": "Wiederherstellungsschlüssel anzeigen",
   "vaultDetails.actions.archiveVault": "Tresor archivieren",

--- a/frontend/src/i18n/en-US.json
+++ b/frontend/src/i18n/en-US.json
@@ -23,6 +23,7 @@
   "common.retry": "Retry",
   "common.share": "Share",
   "common.unexpectedError": "Unexpected Error: {0}",
+  "common.update": "Update",
 
   "admin.title": "Admin",
   "admin.serverInfo.title": "Server Info",
@@ -114,6 +115,13 @@
   "downloadVaultTemplateDialog.title": "Download Vault Template",
   "downloadVaultTemplateDialog.description": "Download and unpack the zipped vault template to any location shared with your team members. This is required only once during the initial setup.",
 
+  "editVaultMetadataDialog.title": "Edit Vault Metadata",
+  "editVaultMetadataDialog.description": "Update the name and description of the vault.",
+  "editVaultMetadataDialog.vaultName": "Vault Name",
+  "editVaultMetadataDialog.vaultDescription": "Description",
+  "editVaultMetadataDialog.error.formValidationFailed": "Vault name must not be empty.",
+  "editVaultMetadataDialog.error.vaultAlreadyExists": "A vault with the given name already exists.",
+
   "grantPermissionDialog.title": "Grant Permission",
   "grantPermissionDialog.description": "Grant additional devices permission to access the vault.",
   "grantPermissionDialog.submit": "Grant Permission to {0} Device(s)",
@@ -148,6 +156,7 @@
   "vaultDetails.actions.title": "Actions",
   "vaultDetails.actions.updatePermissions": "Update Permissions",
   "vaultDetails.actions.updatePermissions.reload": "Reload",
+  "vaultDetails.actions.editVaultMetadata": "Edit Vault Metadata",
   "vaultDetails.actions.downloadVaultTemplate": "Download Vault Template",
   "vaultDetails.actions.showRecoveryKey": "Show Recovery Key",
   "vaultDetails.actions.archiveVault": "Archive Vault",


### PR DESCRIPTION
Fixes #195. Fixes #101. Supersedes #180.

This was actually quite easy to implement, since #202 added support for updating the vault entity.

![edit-vault-metadata](https://github.com/cryptomator/hub/assets/2924160/96000dfd-1727-40b3-9080-94305541022e)