### PR TITLE
Enhance license

### DIFF
--- a/backend/src/test/java/org/cryptomator/hub/license/LicenseHolderTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/license/LicenseHolderTest.java
@@ -2,8 +2,12 @@ package org.cryptomator.hub.license;
 
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
+import io.quarkus.arc.Arc;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
 import org.cryptomator.hub.entities.Settings;
 import org.hibernate.Session;
 import org.hibernate.query.Query;
@@ -16,10 +20,12 @@ import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
+import java.util.Map;
 
 @QuarkusTest
 public class LicenseHolderTest {
 
+	@Inject
 	LicenseHolder holder;
 
 	@Nested
@@ -29,6 +35,7 @@ public class LicenseHolderTest {
 		@InjectMock
 		Session session;
 
+		@InjectMock
 		LicenseValidator validator;
 
 		MockedStatic<Settings> settingsClass;
@@ -40,14 +47,13 @@ public class LicenseHolderTest {
 			Mockito.when(session.createQuery(Mockito.anyString())).thenReturn(mockQuery);
 			Mockito.when(mockQuery.getSingleResult()).thenReturn(0l);
 
-			validator = Mockito.mock(LicenseValidator.class);
 			settingsClass = Mockito.mockStatic(Settings.class);
-			holder = new LicenseHolder(validator);
 		}
 
 		@AfterEach
 		public void teardown() {
 			settingsClass.close();
+			Arc.container().instance(LicenseHolder.class).destroy();
 		}
 
 		@Test
@@ -62,14 +68,16 @@ public class LicenseHolderTest {
 
 			holder.init();
 
-			Mockito.verify(validator, Mockito.times(1)).validate("token", "42");
+			Mockito.verify(validator, Mockito.times(2)).validate("token", "42");
 			Assertions.assertEquals(decodedJWT, holder.get());
 		}
 
 		@Test
 		@DisplayName("If database token is invalid, do net set it in license holder and nullify db entry")
 		public void testDBTokenOnFailedValidationNotSet() {
-			Mockito.when(validator.validate(Mockito.anyString(), Mockito.anyString())).thenThrow(JWTVerificationException.class);
+			Mockito.when(validator.validate(Mockito.anyString(), Mockito.anyString())).thenAnswer(invocationOnMock -> {
+				throw new JWTVerificationException("");
+			});
 			Settings settingsMock = new Settings();
 			settingsMock.licenseKey = "token";
 			settingsMock.hubId = "42";
@@ -78,7 +86,7 @@ public class LicenseHolderTest {
 			holder.init();
 
 			Mockito.verify(validator, Mockito.times(1)).validate("token", "42");
-			Mockito.verify(session, Mockito.times(1)).persist(Mockito.any());
+			Mockito.verify(session, Mockito.times(1)).persist(Mockito.eq(settingsMock));
 			Assertions.assertNull(holder.get());
 		}
 
@@ -87,6 +95,7 @@ public class LicenseHolderTest {
 		public void testNullDBTokenNotSet() {
 			Settings settingsEntity = Mockito.mock(Settings.class);
 			settingsClass.when(Settings::get).thenReturn(settingsEntity);
+
 			holder.init();
 
 			Mockito.verify(validator, Mockito.never()).validate(Mockito.anyString(), Mockito.anyString());
@@ -103,6 +112,7 @@ public class LicenseHolderTest {
 		@InjectMock
 		Session session;
 
+		@InjectMock
 		LicenseValidator validator;
 
 		MockedStatic<Settings> settingsClass;
@@ -114,14 +124,13 @@ public class LicenseHolderTest {
 			Mockito.when(session.createQuery(Mockito.anyString())).thenReturn(mockQuery);
 			Mockito.when(mockQuery.getSingleResult()).thenReturn(0l);
 
-			validator = Mockito.mock(LicenseValidator.class);
 			settingsClass = Mockito.mockStatic(Settings.class);
-			holder = new LicenseHolder(validator);
 		}
 
 		@AfterEach
 		public void teardown() {
 			settingsClass.close();
+			Arc.container().instance(LicenseHolder.class).destroy();
 		}
 
 		@Test
@@ -136,7 +145,7 @@ public class LicenseHolderTest {
 			holder.set("token");
 
 			Mockito.verify(validator, Mockito.times(1)).validate("token", "42");
-			Mockito.verify(session, Mockito.times(1)).persist(Mockito.any());
+			Mockito.verify(session, Mockito.times(1)).persist(Mockito.eq(settingsMock));
 			Assertions.assertEquals("token", settingsMock.licenseKey);
 			Assertions.assertEquals(decodedJWT, holder.get());
 		}
@@ -144,7 +153,9 @@ public class LicenseHolderTest {
 		@Test
 		@DisplayName("Setting an invalid token fails with exception")
 		public void testSetInvalidToken() {
-			Mockito.when(validator.validate("token", "42")).thenThrow(JWTVerificationException.class);
+			Mockito.when(validator.validate("token", "42")).thenAnswer(invocationOnMock -> {
+				throw new JWTVerificationException("");
+			});
 			Settings settingsMock = new Settings();
 			settingsMock.hubId = "42";
 			settingsClass.when(Settings::get).thenReturn(settingsMock);
@@ -157,6 +168,122 @@ public class LicenseHolderTest {
 		}
 	}
 
+	@Nested
+	@TestProfile(LicenseHolderInitPropsTest.ValidInitPropsInstanceTestProfile.class)
+	@DisplayName("Testing LicenseHolder methods using InitProps")
+	class LicenseHolderInitPropsTest {
+
+		@InjectMock
+		Session session;
+
+		@InjectMock
+		LicenseValidator validator;
+
+		MockedStatic<Settings> settingsClass;
+
+		public static class ValidInitPropsInstanceTestProfile implements QuarkusTestProfile {
+			@Override
+			public Map<String, String> getConfigOverrides() {
+				return Map.of("hub.initial-id", "42", "hub.initial-license", "token");
+			}
+		}
+
+		@BeforeEach
+		public void setup() {
+			Query mockQuery = Mockito.mock(Query.class);
+			Mockito.doNothing().when(session).persist(Mockito.any());
+			Mockito.when(session.createQuery(Mockito.anyString())).thenReturn(mockQuery);
+			Mockito.when(mockQuery.getSingleResult()).thenReturn(0l);
+
+			settingsClass = Mockito.mockStatic(Settings.class);
+		}
+
+		@AfterEach
+		public void teardown() {
+			settingsClass.close();
+			Arc.container().instance(LicenseHolder.class).destroy();
+		}
+
+		@Test
+		@DisplayName("If init token is valid, set it in license holder")
+		public void testValidInitTokenSet() {
+			var decodedJWT = Mockito.mock(DecodedJWT.class);
+			Mockito.when(validator.validate("token", "42")).thenReturn(decodedJWT);
+			Settings settingsMock = new Settings();
+			settingsMock.hubId = "42";
+			settingsClass.when(Settings::get).thenReturn(settingsMock);
+
+			holder.init();
+
+			Mockito.verify(validator, Mockito.times(2)).validate("token", "42");
+			Assertions.assertEquals(decodedJWT, holder.get());
+		}
+
+		@Test
+		@DisplayName("If init token is invalid, do net set it in license holder and nullify db entry")
+		public void testInitTokenOnFailedValidationNotSet() {
+			Mockito.when(validator.validate("token", "42")).thenAnswer(invocationOnMock -> {
+				throw new JWTVerificationException("");
+			});
+			Settings settingsMock = new Settings();
+			settingsMock.hubId = "42";
+			settingsClass.when(Settings::get).thenReturn(settingsMock);
+
+			holder.init();
+
+			Mockito.verify(validator, Mockito.times(2)).validate("token", "42");
+			Mockito.verify(session, Mockito.times(2)).persist(Mockito.eq(settingsMock));
+			Assertions.assertNull(holder.get());
+		}
+
+		@Test
+		@DisplayName("Setting a valid token validates and and overwrites the init token")
+		public void testSetValidToken() {
+			var decodedJWT = Mockito.mock(DecodedJWT.class);
+			Mockito.when(validator.validate("token3000", "42")).thenReturn(decodedJWT);
+
+			Settings initSettingsMock = new Settings();
+			initSettingsMock.licenseKey = "token";
+			initSettingsMock.hubId = "42";
+			settingsClass.when(Settings::get).thenReturn(initSettingsMock);
+
+			Settings persistingSettingsMock = new Settings();
+			persistingSettingsMock.hubId = "42";
+			persistingSettingsMock.licenseKey = "token3000";
+
+			Settings persistedSettingsMock = new Settings();
+			persistedSettingsMock.hubId = "42";
+			settingsClass.when(Settings::get).thenReturn(persistedSettingsMock);
+
+			holder.set("token3000");
+
+			Mockito.verify(validator, Mockito.times(1)).validate("token3000", "42");
+			Mockito.verify(session, Mockito.times(1)).persist(Mockito.eq(persistingSettingsMock));
+			Assertions.assertEquals("token3000", persistedSettingsMock.licenseKey);
+			Assertions.assertEquals(decodedJWT, holder.get());
+		}
+
+		@Test
+		@DisplayName("Setting an invalid token fails with exception and falls back to previous token")
+		public void testSetInvalidToken() {
+			var decodedJWT = Mockito.mock(DecodedJWT.class);
+			Mockito.when(validator.validate("token", "42")).thenReturn(decodedJWT);
+			Mockito.when(validator.validate("token3000", "42")).thenAnswer(invocationOnMock -> {
+				throw new JWTVerificationException("");
+			});
+			Settings settingsMock = new Settings();
+			settingsMock.licenseKey = "token";
+			settingsMock.hubId = "42";
+			settingsClass.when(Settings::get).thenReturn(settingsMock);
+
+			Assertions.assertThrows(JWTVerificationException.class, () -> holder.set("token3000"));
+
+			Mockito.verify(validator, Mockito.times(1)).validate("token3000", "42");
+			Mockito.verify(session, Mockito.never()).persist(Mockito.any());
+			Assertions.assertEquals(decodedJWT, holder.get());
+		}
+
+	}
 
 }
 

--- a/backend/src/test/java/org/cryptomator/hub/license/LicenseHolderTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/license/LicenseHolderTest.java
@@ -237,7 +237,7 @@ public class LicenseHolderTest {
 		}
 
 		@Test
-		@DisplayName("Setting a valid token validates and and overwrites the init token")
+		@DisplayName("Setting a valid token validates and overwrites the init token")
 		public void testSetValidToken() {
 			var decodedJWT = Mockito.mock(DecodedJWT.class);
 			Mockito.when(validator.validate("token3000", "42")).thenReturn(decodedJWT);


### PR DESCRIPTION
Notes about some not obvious changes:

* `Arc.container().instance(LicenseHolder.class).destroy();`  is required because `LicenseHolder` is `@ApplicationScoped` and we need to destroy it to freshly start in each test
* In some scenarios we did increase `Mockito.verify(validator, Mockito.times(...)).validate(...);` times by 1 because depending on the call chain, the `@PostConstruct` annotated `init`-method of the `LicenseHolder` is implicitly called
* The new nested test uses `QuarkusTestProfile`  to initially set the properties in question