### PR TITLE
Fix unarchive vaults

### DIFF
--- a/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
@@ -310,11 +310,11 @@ public class VaultResource {
 	@APIResponse(responseCode = "402", description = "number of effective vault users exceeds available license seats")
 	@APIResponse(responseCode = "403", description = "not a vault member")
 	@APIResponse(responseCode = "404", description = "unknown vault")
-	@APIResponse(responseCode = "410", description = "Vault is archived")
+	@APIResponse(responseCode = "410", description = "Vault is archived. Only returned if ignoreArchivedVault is false or not set, otherwise the archived flag is ignored")
 	@ActiveLicense // may throw 402
-	public String unlock(@PathParam("vaultId") UUID vaultId) {
+	public String unlock(@PathParam("vaultId") UUID vaultId, @QueryParam("ignoreArchivedFlag") Optional<Boolean> ignoreArchivedFlag) {
 		var vault = Vault.<Vault>findById(vaultId); // should always be found, since @VaultRole filter would have triggered
-		if (vault.archived) {
+		if (vault.archived && !ignoreArchivedFlag.orElse(false)) {
 			throw new GoneException("Vault is archived.");
 		}
 

--- a/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
@@ -86,7 +86,7 @@ public class VaultResource {
 	@RolesAllowed("user")
 	@Produces(MediaType.APPLICATION_JSON)
 	@Transactional
-	@Operation(summary = "list all accessible vaults", description = "list all (non-archived) vaults that have been shared with the currently logged in user or a group in wich this user is")
+	@Operation(summary = "list all accessible vaults", description = "list all vaults that have been shared with the currently logged in user or a group in wich this user is")
 	public List<VaultDto> getAccessible(@Nullable @QueryParam("role") VaultAccess.Role role) {
 		var currentUserId = jwt.getSubject();
 		// TODO refactor to JEP 441 in JDK 21

--- a/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
@@ -312,9 +312,9 @@ public class VaultResource {
 	@APIResponse(responseCode = "404", description = "unknown vault")
 	@APIResponse(responseCode = "410", description = "Vault is archived. Only returned if ignoreArchivedVault is false or not set, otherwise the archived flag is ignored")
 	@ActiveLicense // may throw 402
-	public String unlock(@PathParam("vaultId") UUID vaultId, @QueryParam("ignoreArchivedFlag") Optional<Boolean> ignoreArchivedFlag) {
+	public String unlock(@PathParam("vaultId") UUID vaultId, @QueryParam("evenIfArchived") @DefaultValue("false") boolean ignoreArchived) {
 		var vault = Vault.<Vault>findById(vaultId); // should always be found, since @VaultRole filter would have triggered
-		if (vault.archived && !ignoreArchivedFlag.orElse(false)) {
+		if (vault.archived && !ignoreArchived) {
 			throw new GoneException("Vault is archived.");
 		}
 

--- a/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
@@ -310,7 +310,7 @@ public class VaultResource {
 	@APIResponse(responseCode = "402", description = "number of effective vault users exceeds available license seats")
 	@APIResponse(responseCode = "403", description = "not a vault member")
 	@APIResponse(responseCode = "404", description = "unknown vault")
-	@APIResponse(responseCode = "410", description = "Vault is archived. Only returned if ignoreArchivedVault is false or not set, otherwise the archived flag is ignored")
+	@APIResponse(responseCode = "410", description = "Vault is archived. Only returned if evenIfArchived query param is false or not set, otherwise the archived flag is ignored")
 	@ActiveLicense // may throw 402
 	public String unlock(@PathParam("vaultId") UUID vaultId, @QueryParam("evenIfArchived") @DefaultValue("false") boolean ignoreArchived) {
 		var vault = Vault.<Vault>findById(vaultId); // should always be found, since @VaultRole filter would have triggered

--- a/backend/src/main/java/org/cryptomator/hub/entities/Vault.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/Vault.java
@@ -37,14 +37,13 @@ import java.util.stream.Stream;
 				SELECT DISTINCT v
 				FROM Vault v
 				INNER JOIN EffectiveVaultAccess a ON a.id.vaultId = v.id AND a.id.authorityId = :userId
-				WHERE NOT v.archived
 				""")
 @NamedQuery(name = "Vault.accessibleByUserAndRole",
 		query = """
 				SELECT DISTINCT v
 				FROM Vault v
 				INNER JOIN EffectiveVaultAccess a ON a.id.vaultId = v.id AND a.id.authorityId = :userId
-				WHERE a.id.role = :role AND NOT v.archived
+				WHERE a.id.role = :role
 				""")
 @NamedQuery(name = "Vault.allInList",
 		query = """

--- a/backend/src/test/java/org/cryptomator/hub/api/VaultResourceTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/VaultResourceTest.java
@@ -139,10 +139,32 @@ public class VaultResourceTest {
 		}
 
 		@Test
+		@DisplayName("GET /vaults/7E57C0DE-0000-4000-8000-000100001111/access-token returns 200 using user access with ignoreArchivedFlag set")
+		public void testUnlock3() {
+			when().get("/vaults/{vaultId}/access-token?ignoreArchivedFlag=true", "7E57C0DE-0000-4000-8000-000100001111")
+					.then().statusCode(200)
+					.body(is("jwe.jwe.jwe.vault1.user1"));
+		}
+
+		@Test
 		@DisplayName("GET /vaults/7E57C0DE-0000-4000-8000-00010000AAAA/access-token returns 410 for archived vaults")
-		public void testUnlockArchived() {
+		public void testUnlockArchived1() {
 			when().get("/vaults/{vaultId}/access-token", "7E57C0DE-0000-4000-8000-00010000AAAA")
 					.then().statusCode(410);
+		}
+
+		@Test
+		@DisplayName("GET /vaults/7E57C0DE-0000-4000-8000-00010000AAAA/access-token returns 410 for archived vaults with ignoreArchivedFlag set to false")
+		public void testUnlockArchived2() {
+			when().get("/vaults/{vaultId}/access-token?ignoreArchivedFlag=false", "7E57C0DE-0000-4000-8000-00010000AAAA")
+					.then().statusCode(410);
+		}
+
+		@Test
+		@DisplayName("GET /vaults/7E57C0DE-0000-4000-8000-00010000AAAA/access-token returns 403 for archived vaults with ignoreArchivedFlag set to true")
+		public void testUnlockArchived3() throws SQLException {
+			when().get("/vaults/{vaultId}/access-token?ignoreArchivedFlag=true", "7E57C0DE-0000-4000-8000-00010000AAAA")
+					.then().statusCode(403);
 		}
 
 		@Nested

--- a/backend/src/test/java/org/cryptomator/hub/api/VaultResourceTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/VaultResourceTest.java
@@ -139,9 +139,9 @@ public class VaultResourceTest {
 		}
 
 		@Test
-		@DisplayName("GET /vaults/7E57C0DE-0000-4000-8000-000100001111/access-token returns 200 using user access with ignoreArchivedFlag set")
+		@DisplayName("GET /vaults/7E57C0DE-0000-4000-8000-000100001111/access-token returns 200 using user access with evenIfArchived set")
 		public void testUnlock3() {
-			when().get("/vaults/{vaultId}/access-token?ignoreArchivedFlag=true", "7E57C0DE-0000-4000-8000-000100001111")
+			when().get("/vaults/{vaultId}/access-token?evenIfArchived=true", "7E57C0DE-0000-4000-8000-000100001111")
 					.then().statusCode(200)
 					.body(is("jwe.jwe.jwe.vault1.user1"));
 		}
@@ -154,16 +154,16 @@ public class VaultResourceTest {
 		}
 
 		@Test
-		@DisplayName("GET /vaults/7E57C0DE-0000-4000-8000-00010000AAAA/access-token returns 410 for archived vaults with ignoreArchivedFlag set to false")
+		@DisplayName("GET /vaults/7E57C0DE-0000-4000-8000-00010000AAAA/access-token returns 410 for archived vaults with evenIfArchived set to false")
 		public void testUnlockArchived2() {
-			when().get("/vaults/{vaultId}/access-token?ignoreArchivedFlag=false", "7E57C0DE-0000-4000-8000-00010000AAAA")
+			when().get("/vaults/{vaultId}/access-token?evenIfArchived=false", "7E57C0DE-0000-4000-8000-00010000AAAA")
 					.then().statusCode(410);
 		}
 
 		@Test
-		@DisplayName("GET /vaults/7E57C0DE-0000-4000-8000-00010000AAAA/access-token returns 403 for archived vaults with ignoreArchivedFlag set to true")
+		@DisplayName("GET /vaults/7E57C0DE-0000-4000-8000-00010000AAAA/access-token returns 403 for archived vaults with evenIfArchived set to true")
 		public void testUnlockArchived3() throws SQLException {
-			when().get("/vaults/{vaultId}/access-token?ignoreArchivedFlag=true", "7E57C0DE-0000-4000-8000-00010000AAAA")
+			when().get("/vaults/{vaultId}/access-token?evenIfArchived=true", "7E57C0DE-0000-4000-8000-00010000AAAA")
 					.then().statusCode(403);
 		}
 

--- a/frontend/src/common/backend.ts
+++ b/frontend/src/common/backend.ts
@@ -257,7 +257,7 @@ class VaultService {
   }
 
   public async accessToken(vaultId: string): Promise<string> {
-    return axiosAuth.get(`/vaults/${vaultId}/access-token?ignoreArchivedFlag=true`, { headers: { 'Content-Type': 'text/plain' } })
+    return axiosAuth.get(`/vaults/${vaultId}/access-token?evenIfArchived=true`, { headers: { 'Content-Type': 'text/plain' } })
       .then(response => response.data)
       .catch((error) => rethrowAndConvertIfExpected(error, 403));
   }

--- a/frontend/src/common/backend.ts
+++ b/frontend/src/common/backend.ts
@@ -256,8 +256,8 @@ class VaultService {
       .catch((error) => rethrowAndConvertIfExpected(error, 400, 404, 409));
   }
 
-  public async accessToken(vaultId: string): Promise<string> {
-    return axiosAuth.get(`/vaults/${vaultId}/access-token?evenIfArchived=true`, { headers: { 'Content-Type': 'text/plain' } })
+  public async accessToken(vaultId: string, evenIfArchived = false): Promise<string> {
+    return axiosAuth.get(`/vaults/${vaultId}/access-token?evenIfArchived=${evenIfArchived}`, { headers: { 'Content-Type': 'text/plain' } })
       .then(response => response.data)
       .catch((error) => rethrowAndConvertIfExpected(error, 403));
   }

--- a/frontend/src/common/backend.ts
+++ b/frontend/src/common/backend.ts
@@ -257,7 +257,7 @@ class VaultService {
   }
 
   public async accessToken(vaultId: string): Promise<string> {
-    return axiosAuth.get(`/vaults/${vaultId}/access-token`, { headers: { 'Content-Type': 'text/plain' } })
+    return axiosAuth.get(`/vaults/${vaultId}/access-token?ignoreArchivedFlag=true`, { headers: { 'Content-Type': 'text/plain' } })
       .then(response => response.data)
       .catch((error) => rethrowAndConvertIfExpected(error, 403));
   }

--- a/frontend/src/components/VaultDetails.vue
+++ b/frontend/src/components/VaultDetails.vue
@@ -237,7 +237,7 @@ async function fetchData() {
 }
 
 async function fetchOwnerData() {
-  const vaultKeyJwe = await backend.vaults.accessToken(props.vaultId);
+  const vaultKeyJwe = await backend.vaults.accessToken(props.vaultId, true);
   vaultKeys.value = await loadVaultKeys(vaultKeyJwe);
   (await backend.vaults.getMembers(props.vaultId)).forEach(member => members.value.set(member.id, member));
   usersRequiringAccessGrant.value = await backend.vaults.getUsersRequiringAccessGrant(props.vaultId);

--- a/frontend/src/components/VaultList.vue
+++ b/frontend/src/components/VaultList.vue
@@ -138,7 +138,10 @@ const ownsSelectedVault = computed(() => {
 
 const isAdmin = ref<boolean>();
 
-const filterOptions = ref< {[key: string]: string} >({accessibleVaults: t('vaultList.filter.entry.accessibleVaults'), ownedVaults: t('vaultList.filter.entry.ownedVaults')});
+const filterOptions = ref< {[key: string]: string} >({
+  accessibleVaults: t('vaultList.filter.entry.accessibleVaults'),
+  ownedVaults: t('vaultList.filter.entry.ownedVaults')
+});
 const selectedFilter = ref<'accessibleVaults' | 'ownedVaults' | 'allVaults'>('accessibleVaults');
 watch(selectedFilter, fetchData);
 const query = ref('');

--- a/frontend/src/components/VaultList.vue
+++ b/frontend/src/components/VaultList.vue
@@ -162,7 +162,7 @@ async function fetchData() {
     ownedVaults.value = (await backend.vaults.listAccessible('OWNER')).sort((a, b) => a.name.localeCompare(b.name));
     switch (selectedFilter.value) {
       case 'accessibleVaults':
-        vaults.value = (await backend.vaults.listAccessible()).sort((a, b) => a.name.localeCompare(b.name));
+        vaults.value = (await backend.vaults.listAccessible()).filter(v => !v.archived).sort((a, b) => a.name.localeCompare(b.name));
         break;
       case 'ownedVaults':
         vaults.value = ownedVaults.value;

--- a/frontend/src/components/VaultList.vue
+++ b/frontend/src/components/VaultList.vue
@@ -15,7 +15,7 @@
   <div class="pb-5 mt-3 border-b border-gray-200 flex flex-wrap sm:flex-nowrap gap-3 items-center whitespace-nowrap">
     <input id="vaultSearch" v-model="query" :placeholder="t('vaultList.search.placeholder')" type="text" class="focus:ring-primary focus:border-primary block w-full shadow-sm text-sm border-gray-300 rounded-md disabled:bg-gray-200"/>
 
-    <Listbox v-if="isAdmin" v-model="selectedFilter" as="div">
+    <Listbox v-model="selectedFilter" as="div">
       <div class="relative w-44">
         <ListboxButton class="relative w-full rounded-md border border-gray-300 bg-white py-2 pl-3 pr-10 text-left shadow-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary text-sm">
           <span class="block truncate">{{ filterOptions[selectedFilter] }}</span>
@@ -138,11 +138,7 @@ const ownsSelectedVault = computed(() => {
 
 const isAdmin = ref<boolean>();
 
-const filterOptions = {
-  accessibleVaults: t('vaultList.filter.entry.accessibleVaults'),
-  ownedVaults: t('vaultList.filter.entry.ownedVaults'),
-  allVaults: t('vaultList.filter.entry.allVaults'),
-};
+const filterOptions = ref< {[key: string]: string} >({accessibleVaults: t('vaultList.filter.entry.accessibleVaults'), ownedVaults: t('vaultList.filter.entry.ownedVaults')});
 const selectedFilter = ref<'accessibleVaults' | 'ownedVaults' | 'allVaults'>('accessibleVaults');
 watch(selectedFilter, fetchData);
 const query = ref('');
@@ -159,6 +155,11 @@ onMounted(fetchData);
 async function fetchData() {
   onFetchError.value = null;
   try {
+    isAdmin.value = (await auth).isAdmin();
+
+    if (isAdmin.value) {
+      filterOptions.value['allVaults'] = t('vaultList.filter.entry.allVaults')
+    }
     ownedVaults.value = (await backend.vaults.listAccessible('OWNER')).sort((a, b) => a.name.localeCompare(b.name));
     switch (selectedFilter.value) {
       case 'accessibleVaults':
@@ -173,7 +174,7 @@ async function fetchData() {
       default:
         throw new Error('Unknown filter');
     }
-    isAdmin.value = (await auth).isAdmin();
+
   } catch (error) {
     console.error('Retrieving vault list failed.', error);
     onFetchError.value = error instanceof Error ? error : new Error('Unknown Error');


### PR DESCRIPTION
To unarchive vaults again, it was required to 
* add an optional `ignoreArchivedFlag` query parameter to the `"/{vaultId}/access-token"` resource. If set to `true`, the archived state of the vault will be ignored when retrieving an access token. We need this because the frontend uses it to check if the user is actually the owner of the vault
* the database query `Vault.accessibleByUserAndRole` and `Vault.accessibleByUser` now also returns the archived vaults and the frontend excludes the archived vaults depending on what it wants to show to the user
* the non-admin user can now also filter the vault list between "Accessible" and "Owned by me" so that the user can unarchive their vaults