### PR TITLE
Rename regenerate Account Key dialog message

### DIFF
--- a/frontend/src/i18n/de-DE.json
+++ b/frontend/src/i18n/de-DE.json
@@ -174,8 +174,8 @@
   "recoveryKeyDialog.description": "Dies ist dein Wiederherstellungsschlüssel für „{0}“. Verwahre ihn gut, er ist im Falle eines Systemausfalls deine einzige Möglichkeit, auf einen Tresor zuzugreifen.",
   "recoveryKeyDialog.recoveryKey": "Wiederherstellungsschlüssel für deinen Tresor",
 
-  "regenerateSetupCodeDialog.confirmRegenerateSetupCode.title": "Neuen Key generieren",
-  "regenerateSetupCodeDialog.confirmRegenerateSetupCode.description": "Möchtest du einen neuen Account Key generiereren? Dadurch wird der alte Key ungültig.",
+  "regenerateSetupCodeDialog.confirmRegenerateSetupCode.title": "Neuen Account Key generieren",
+  "regenerateSetupCodeDialog.confirmRegenerateSetupCode.description": "Wenn du den Verdacht hast, dass dein alter Account Key kompromittiert wurde, kannst du ihn neu generieren. Anschließend können neue Geräte nur mit dem neuen Account Key hinzugefügt werden. Deine bestehenden Geräte bleiben davon unberührt.",
   "regenerateSetupCodeDialog.saveSetupCode.title": "Account Key speichern",
   "regenerateSetupCodeDialog.saveSetupCode.description": "Vergiss nicht, diesen neuen Key zu speichern. Du benötigst ihn, um dich bei neuen Geräten anzumelden. Den alten Key kannst du gefahrlos löschen.",
   "regenerateSetupCodeDialog.saveSetupCode.setupCode": "Account Key",

--- a/frontend/src/i18n/en-US.json
+++ b/frontend/src/i18n/en-US.json
@@ -175,7 +175,7 @@
   "recoveryKeyDialog.recoveryKey": "Recovery Key of Your Vault",
 
   "regenerateSetupCodeDialog.confirmRegenerateSetupCode.title": "Regenerate Account Key",
-  "regenerateSetupCodeDialog.confirmRegenerateSetupCode.description": "Do you want to generate a new Account Key? If you do so, the old one will be invalidated.",
+  "regenerateSetupCodeDialog.confirmRegenerateSetupCode.description": "If you suspect that your old Account Key has been compromised, you can regenerate it. You will then only be able to add new devices with the new Account Key. Your existing devices will remain intact.",
   "regenerateSetupCodeDialog.saveSetupCode.title": "Save Account Key",
   "regenerateSetupCodeDialog.saveSetupCode.description": "Be sure to save this new key. You'll need it to sign in to new devices. You can safely delete the old one.",
   "regenerateSetupCodeDialog.saveSetupCode.setupCode": "Account Key",


### PR DESCRIPTION
This PR attempts to clarify what happens to existing devices when a new account key is generated:

![2023-10-31_15-06](https://github.com/cryptomator/hub/assets/1786772/31689e77-d49d-4ad5-90ba-c85f77bf460d)