### PR TITLE
refactored `PUT /api/vaults/{v}/access-tokens/{u}` → `POST /api/vaults/{v}/access-tokens`

### DIFF
--- a/frontend/src/common/backend.ts
+++ b/frontend/src/common/backend.ts
@@ -59,6 +59,11 @@ export type DeviceDto = {
 
 export type VaultRole = 'MEMBER' | 'OWNER';
 
+export type AccessGrant = {
+  userId: string,
+  token: string
+};
+
 enum AuthorityType {
   User = 'USER',
   Group = 'GROUP'
@@ -265,8 +270,12 @@ class VaultService {
       .catch((error) => rethrowAndConvertIfExpected(error, 403));
   }
 
-  public async grantAccess(vaultId: string, userId: string, jwe: string) {
-    await axiosAuth.put(`/vaults/${vaultId}/access-tokens/${userId}`, jwe, { headers: { 'Content-Type': 'text/plain' } })
+  public async grantAccess(vaultId: string, ...grants: AccessGrant[]) {
+    var body = grants.reduce<Record<string, string>>((accumulator, curr) => {
+      accumulator[curr.userId] = curr.token;
+      return accumulator;
+    }, {});
+    await axiosAuth.post(`/vaults/${vaultId}/access-tokens`, body)
       .catch((error) => rethrowAndConvertIfExpected(error, 404, 409));
   }
 

--- a/frontend/src/components/CreateVault.vue
+++ b/frontend/src/components/CreateVault.vue
@@ -295,7 +295,7 @@ async function createVault() {
     vaultConfig.value = await VaultConfig.create(vaultId, vaultKeys.value);
     const ownerJwe = await vaultKeys.value.encryptForUser(base64.parse(owner.publicKey));
     await backend.vaults.createOrUpdateVault(vaultId, vaultName.value, false, vaultDescription.value);
-    await backend.vaults.grantAccess(vaultId, owner.id, ownerJwe);
+    await backend.vaults.grantAccess(vaultId, { userId: owner.id, token: ownerJwe });
     state.value = State.Finished;
   } catch (error) {
     console.error('Creating vault failed.', error);

--- a/frontend/src/components/RecoverVaultDialog.vue
+++ b/frontend/src/components/RecoverVaultDialog.vue
@@ -108,7 +108,7 @@ async function recoverVault() {
     if (props.me.publicKey && vaultKeys) {
       const publicKey = base64.parse(props.me.publicKey);
       const jwe = await vaultKeys.encryptForUser(publicKey);
-      await backend.vaults.grantAccess(props.vault.id, props.me.id, jwe);
+      await backend.vaults.grantAccess(props.vault.id, { userId: props.me.id, token: jwe });
       emit('recovered');
       open.value = false;
     }

--- a/frontend/src/components/VaultDetails.vue
+++ b/frontend/src/components/VaultDetails.vue
@@ -310,7 +310,7 @@ async function provedOwnership(keys: VaultKeys, ownerKeyPair: CryptoKeyPair) {
 
   const vaultKeyJwe = keys.encryptForUser(base64.parse(me.value.publicKey));
   try {
-    await backend.vaults.grantAccess(props.vaultId, me.value.id, await vaultKeyJwe);
+    await backend.vaults.grantAccess(props.vaultId, { userId: me.value.id, token: await vaultKeyJwe });
   } catch (error) {
     if (error instanceof ConflictError) {
       console.debug('User already member of this vault.');


### PR DESCRIPTION
The new API accepts multiple access grants in a single requests, making bulk requests easier, as can be seen here:

https://github.com/cryptomator/hub/blob/1c2133d9868a2de3922aaa73b7b1cf3d90063cca/frontend/src/components/GrantPermissionDialog.vue#L127-L135