### PR TITLE
Last changes for Cryptomator Hub CLI

### DIFF
--- a/backend/src/main/java/org/cryptomator/hub/api/AuthorityResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/AuthorityResource.java
@@ -30,7 +30,7 @@ public class AuthorityResource {
 
 	@GET
 	@Path("/")
-	@RolesAllowed("admin")
+	@RolesAllowed("user")
 	@Produces(MediaType.APPLICATION_JSON)
 	@NoCache
 	@Operation(summary = "lists all authorities matching the given ids", description = "lists for each id in the list its corresponding authority. Ignores all id's where an authority cannot be found")

--- a/backend/src/main/java/org/cryptomator/hub/api/GroupsResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/GroupsResource.java
@@ -3,9 +3,12 @@ package org.cryptomator.hub.api;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+import org.cryptomator.hub.entities.EffectiveGroupMembership;
 import org.cryptomator.hub.entities.Group;
+import org.cryptomator.hub.validation.ValidId;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 
 import java.util.List;
@@ -21,6 +24,15 @@ public class GroupsResource {
 	@Operation(summary = "list all groups")
 	public List<GroupDto> getAll() {
 		return Group.findAll().<Group>stream().map(GroupDto::fromEntity).toList();
+	}
+
+	@GET
+	@Path("/{groupId}/effective-members")
+	@RolesAllowed("user")
+	@Produces(MediaType.APPLICATION_JSON)
+	@Operation(summary = "list all effective group members")
+	public List<UserDto> getEffectiveMembers(@PathParam("groupId") @ValidId String groupId) {
+		return EffectiveGroupMembership.getEffectiveGroupUsers(groupId).map(UserDto::justPublicInfo).toList();
 	}
 
 }

--- a/backend/src/main/java/org/cryptomator/hub/api/GroupsResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/GroupsResource.java
@@ -1,0 +1,26 @@
+package org.cryptomator.hub.api;
+
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.cryptomator.hub.entities.Group;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+
+import java.util.List;
+
+@Path("/groups")
+@Produces(MediaType.TEXT_PLAIN)
+public class GroupsResource {
+
+	@GET
+	@Path("/")
+	@RolesAllowed("user")
+	@Produces(MediaType.APPLICATION_JSON)
+	@Operation(summary = "list all groups")
+	public List<GroupDto> getAll() {
+		return Group.findAll().<Group>stream().map(GroupDto::fromEntity).toList();
+	}
+
+}

--- a/backend/src/main/java/org/cryptomator/hub/api/GroupsResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/GroupsResource.java
@@ -14,7 +14,6 @@ import org.eclipse.microprofile.openapi.annotations.Operation;
 import java.util.List;
 
 @Path("/groups")
-@Produces(MediaType.TEXT_PLAIN)
 public class GroupsResource {
 
 	@GET

--- a/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
@@ -223,7 +223,7 @@ public class VaultResource {
 	@VaultRole(VaultAccess.Role.OWNER) // may throw 403
 	@Transactional
 	@Produces(MediaType.APPLICATION_JSON)
-	@Operation(summary = "remove an authority from this vault", description = "revokes the given authority's access rights from this vault. If the given authority is no member, the request is a no-op.")
+	@Operation(summary = "remove a user or group from this vault", description = "revokes the given authority's access rights from this vault. If the given authority is no member, the request is a no-op.")
 	@APIResponse(responseCode = "204", description = "authority removed")
 	@APIResponse(responseCode = "403", description = "not a vault owner")
 	public Response removeAuthority(@PathParam("vaultId") UUID vaultId, @PathParam("authorityId") @ValidId String authorityId) {

--- a/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
@@ -217,32 +217,15 @@ public class VaultResource {
 	}
 
 	@DELETE
-	@Path("/{vaultId}/users/{userId}")
+	@Path("/{vaultId}/authority/{authorityId}")
 	@RolesAllowed("user")
 	@VaultRole(VaultAccess.Role.OWNER) // may throw 403
 	@Transactional
 	@Produces(MediaType.APPLICATION_JSON)
-	@Operation(summary = "remove a member from this vault", description = "revokes the given user's access rights from this vault. If the given user is no member, the request is a no-op.")
-	@APIResponse(responseCode = "204", description = "member removed")
+	@Operation(summary = "remove an authority from this vault", description = "revokes the given authority's access rights from this vault. If the given authority is no member, the request is a no-op.")
+	@APIResponse(responseCode = "204", description = "authority removed")
 	@APIResponse(responseCode = "403", description = "not a vault owner")
-	public Response removeUser(@PathParam("vaultId") UUID vaultId, @PathParam("userId") @ValidId String userId) {
-		return removeAuthority(vaultId, userId);
-	}
-
-	@DELETE
-	@Path("/{vaultId}/groups/{groupId}")
-	@RolesAllowed("user")
-	@VaultRole(VaultAccess.Role.OWNER) // may throw 403
-	@Transactional
-	@Produces(MediaType.APPLICATION_JSON)
-	@Operation(summary = "remove a group from this vault", description = "revokes the given group's access rights from this vault. If the given group is no member, the request is a no-op.")
-	@APIResponse(responseCode = "204", description = "member removed")
-	@APIResponse(responseCode = "403", description = "not a vault owner")
-	public Response removeGroup(@PathParam("vaultId") UUID vaultId, @PathParam("groupId") @ValidId String groupId) {
-		return removeAuthority(vaultId, groupId);
-	}
-
-	private Response removeAuthority(UUID vaultId, String authorityId) {
+	public Response removeAuthority(@PathParam("vaultId") UUID vaultId, @PathParam("authorityId") @ValidId String authorityId) {
 		if (VaultAccess.deleteById(new VaultAccess.Id(vaultId, authorityId))) {
 			AuditEventVaultMemberRemove.log(jwt.getSubject(), vaultId, authorityId);
 			return Response.status(Response.Status.NO_CONTENT).build();

--- a/backend/src/main/java/org/cryptomator/hub/entities/EffectiveGroupMembership.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/EffectiveGroupMembership.java
@@ -12,6 +12,7 @@ import org.hibernate.annotations.Immutable;
 
 import java.io.Serializable;
 import java.util.Objects;
+import java.util.stream.Stream;
 
 @Entity
 @Immutable
@@ -20,6 +21,12 @@ import java.util.Objects;
 				SELECT count( DISTINCT u)
 				FROM User u
 				INNER JOIN EffectiveGroupMembership egm	ON u.id = egm.id.memberId
+				WHERE egm.id.groupId = :groupId
+		""")
+@NamedQuery(name = "EffectiveGroupMembership.getEGUs", query = """
+				SELECT DISTINCT u
+				FROM User u
+				INNER JOIN EffectiveGroupMembership egm ON u.id = egm.id.memberId
 				WHERE egm.id.groupId = :groupId
 		""")
 public class EffectiveGroupMembership extends PanacheEntityBase {
@@ -31,6 +38,10 @@ public class EffectiveGroupMembership extends PanacheEntityBase {
 
 	public static long countEffectiveGroupUsers(String groupdId) {
 		return EffectiveGroupMembership.count("#EffectiveGroupMembership.countEGUs", Parameters.with("groupId", groupdId));
+	}
+
+	public static Stream<User> getEffectiveGroupUsers(String groupdId) {
+		return EffectiveGroupMembership.find("#EffectiveGroupMembership.getEGUs", Parameters.with("groupId", groupdId)).stream();
 	}
 
 	@Embeddable

--- a/backend/src/test/java/org/cryptomator/hub/api/AuthorityResourceTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/AuthorityResourceTest.java
@@ -118,17 +118,5 @@ public class AuthorityResourceTest {
 					.then().statusCode(200)
 					.body("id", containsInAnyOrder("user1", "group2"));
 		}
-
-		@Test
-		@DisplayName("GET /authorities?ids=user1&ids=group2 as user returns 403")
-		@TestSecurity(user = "User Name 1", roles = {"user"})
-		@OidcSecurity(claims = {
-				@Claim(key = "sub", value = "user1")
-		})
-		public void testGetSomeAsUser() {
-			given().param("ids", "user1", "group2")
-					.when().get("/authorities")
-					.then().statusCode(403);
-		}
 	}
 }

--- a/backend/src/test/java/org/cryptomator/hub/api/GroupsResourceTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/GroupsResourceTest.java
@@ -1,10 +1,13 @@
 package org.cryptomator.hub.api;
 
+import io.agroal.api.AgroalDataSource;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.security.TestSecurity;
 import io.quarkus.test.security.oidc.Claim;
 import io.quarkus.test.security.oidc.OidcSecurity;
 import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import jakarta.inject.Inject;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -12,6 +15,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+import java.sql.SQLException;
+
+import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
@@ -40,6 +46,14 @@ public class GroupsResourceTest {
 			when().get("/groups")
 					.then().statusCode(200)
 					.body("id", hasItems("group1", "group2"));
+		}
+
+		@Test
+		@DisplayName("GET /groups/group1/effective-members contains direct and subgroup members")
+		public void testGetEffectiveUsers() {
+			when().get("/groups/{groupId}/effective-members", "group1")
+					.then().statusCode(200)
+					.body("id", hasItems("user1"));
 		}
 
 	}

--- a/backend/src/test/java/org/cryptomator/hub/api/GroupsResourceTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/GroupsResourceTest.java
@@ -1,0 +1,63 @@
+package org.cryptomator.hub.api;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.security.TestSecurity;
+import io.quarkus.test.security.oidc.Claim;
+import io.quarkus.test.security.oidc.OidcSecurity;
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.empty;
+
+@QuarkusTest
+@DisplayName("Resource /groups")
+public class GroupsResourceTest {
+
+	@BeforeAll
+	public static void beforeAll() {
+		RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+	}
+
+	@Nested
+	@DisplayName("As user1")
+	@TestSecurity(user = "User Name 1", roles = {"user"})
+	@OidcSecurity(claims = {
+			@Claim(key = "sub", value = "user1")
+	})
+	public class AsAuthorzedUser1 {
+
+		@Test
+		@DisplayName("GET /groups returns 200")
+		public void testGetAll() {
+			when().get("/groups")
+					.then().statusCode(200)
+					.body("id", hasItems("group1", "group2"));
+		}
+
+	}
+
+	@Nested
+	@DisplayName("As unauthenticated user")
+	public class AsAnonymous {
+
+		@DisplayName("401 Unauthorized")
+		@ParameterizedTest(name = "{0} {1}")
+		@CsvSource(value = {
+				"GET, /users"
+		})
+		public void testGet(String method, String path) {
+			when().request(method, path)
+					.then().statusCode(401);
+		}
+
+	}
+
+}

--- a/backend/src/test/java/org/cryptomator/hub/api/VaultResourceTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/VaultResourceTest.java
@@ -497,7 +497,7 @@ public class VaultResourceTest {
 		@Order(13)
 		@DisplayName("DELETE /vaults/7E57C0DE-0000-4000-8000-000100002222/members/user2 returns 204")
 		public void testRevokeAccess() { // previously added in testGrantAccess()
-			given().when().delete("/vaults/{vaultId}/users/{userId}", "7E57C0DE-0000-4000-8000-000100002222", "user2")
+			given().when().delete("/vaults/{vaultId}/authority/{userId}", "7E57C0DE-0000-4000-8000-000100002222", "user2")
 					.then().statusCode(204);
 		}
 
@@ -597,7 +597,7 @@ public class VaultResourceTest {
 		@Order(7)
 		@DisplayName("DELETE /vaults/7E57C0DE-0000-4000-8000-000100001111/groups/group2 returns 204")
 		public void removeGroup2() {
-			given().when().delete("/vaults/{vaultId}/groups/{groupId}", "7E57C0DE-0000-4000-8000-000100001111", "group2")
+			given().when().delete("/vaults/{vaultId}/authority/{groupId}", "7E57C0DE-0000-4000-8000-000100001111", "group2")
 					.then().statusCode(204);
 		}
 
@@ -995,7 +995,7 @@ public class VaultResourceTest {
 				"GET, /vaults/7E57C0DE-0000-4000-8000-000100001111",
 				"GET, /vaults/7E57C0DE-0000-4000-8000-000100001111/members",
 				"PUT, /vaults/7E57C0DE-0000-4000-8000-000100001111/users/user1",
-				"DELETE, /vaults/7E57C0DE-0000-4000-8000-000100001111/users/user1",
+				"DELETE, /vaults/7E57C0DE-0000-4000-8000-000100001111/authority/user1",
 				"GET, /vaults/7E57C0DE-0000-4000-8000-000100001111/users-requiring-access-grant",
 				"GET, /vaults/7E57C0DE-0000-4000-8000-000100001111/access-token"
 		})

--- a/frontend/src/common/backend.ts
+++ b/frontend/src/common/backend.ts
@@ -270,8 +270,8 @@ class VaultService {
       .catch((error) => rethrowAndConvertIfExpected(error, 404, 409));
   }
 
-  public async removeUser(vaultId: string, userId: string) {
-    await axiosAuth.delete(`/vaults/${vaultId}/users/${userId}`)
+  public async removeAuthority(vaultId: string, authorityId: string) {
+    await axiosAuth.delete(`/vaults/${vaultId}/authority/${authorityId}`)
       .catch((error) => rethrowAndConvertIfExpected(error, 404));
   }
 }

--- a/frontend/src/components/VaultDetails.vue
+++ b/frontend/src/components/VaultDetails.vue
@@ -412,7 +412,7 @@ async function updateMemberRole(member: MemberDto, role: VaultRole) {
 async function removeMember(memberId: string) {
   delete onUpdateVaultMembershipError.value[memberId];
   try {
-    await backend.vaults.removeUser(props.vaultId, memberId);
+    await backend.vaults.removeAuthority(props.vaultId, memberId);
     members.value.delete(memberId);
     usersRequiringAccessGrant.value = await backend.vaults.getUsersRequiringAccessGrant(props.vaultId);
   } catch (error) {


### PR DESCRIPTION
This PR provides some changes for Cryptomator Hub CLI:
1. `GET /vaults/some?ids=vaultId3000` can now be executed as `USER`, was before `OWNER`
2. There is a new `GroupsResource` to get all groups and of a group all effective users (including users of the subgroups) 
3. `DELETE /{vaultId}/users/{userId}` and `DELETE /{vaultId}/groups/{groupId}` is removed and replaced by `DELETE /{vaultId}/authority/{authorityId}`