### PR TITLE
Redesigned unlock success

### DIFF
--- a/frontend/src/components/UnlockError.vue
+++ b/frontend/src/components/UnlockError.vue
@@ -1,22 +1,24 @@
 <template>
-  <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-    <div class="pt-8 pb-4 shrink-0 flex items-center">
-      <img src="/logo.svg" class="h-8" alt="Logo"/>
-      <span class="font-headline font-bold text-primary ml-2 pb-px">CRYPTOMATOR HUB</span>
+  <nav class="bg-tertiary2">
+    <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 h-16 flex-1 flex items-center justify-center sm:items-stretch sm:justify-start">
+      <div class="shrink-0 flex items-center">
+        <img src="/logo.svg" class="h-8" alt="Logo"/>
+        <span class="font-headline font-bold text-primary ml-2 pb-px">CRYPTOMATOR HUB</span>
+      </div>
     </div>
+  </nav>
 
-    <div class="relative shadow-xl sm:rounded-2xl sm:overflow-hidden">
-      <div class="absolute inset-0">
-        <div class="absolute inset-0 bg-gradient-to-r from-primary-l1 to-primary mix-blend-multiply" />
+  <div class="max-w-7xl mx-auto px-4 py-12 sm:px-6 lg:px-8 flex justify-center">
+    <div class="bg-white px-4 py-5 shadow sm:rounded-lg sm:p-6 text-center sm:w-full sm:max-w-lg">
+      <div class="flex justify-center mb-3 sm:mb-5">
+        <img src="/logo.svg" class="h-12" alt="Logo" aria-hidden="true" />
       </div>
-      <div class="relative px-4 py-16 sm:px-6 sm:py-24 lg:py-32 lg:px-8">
-        <h1 class="text-center text-4xl font-extrabold tracking-tight sm:text-5xl lg:text-6xl text-white">
-          Unlock failed
-        </h1>
-        <p class="mt-6 max-w-lg mx-auto text-center text-xl text-primary-l2 sm:max-w-3xl">
-          Your unlock failed unexpectedly. Please try again.
-        </p>
-      </div>
+      <h1 class="text-2xl leading-6 font-medium text-gray-900">
+        Unlock failed
+      </h1>
+      <p class="mt-6 text-sm text-gray-500">
+        Your unlock failed unexpectedly. Please try again.
+      </p>
     </div>
   </div>
 </template>

--- a/frontend/src/components/UnlockSuccess.vue
+++ b/frontend/src/components/UnlockSuccess.vue
@@ -25,7 +25,7 @@
           Setup Required
         </h1>
         <p class="my-3">
-          To continue, please follow a few simple steps get your account set up.
+          Complete setting up your account and retrieve your account key.
         </p>
         <router-link to="/app/setup" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-primary focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary">Complete Setup</router-link>
       </div>
@@ -47,7 +47,7 @@
           No access to this Vault
         </h1>
         <p class="mt-2">
-          Please contact the vault owner to add your account to the vault members.
+          Please contact the vault owner to add you as a vault member.
         </p>
       </div>
 

--- a/frontend/src/components/UnlockSuccess.vue
+++ b/frontend/src/components/UnlockSuccess.vue
@@ -1,5 +1,5 @@
 <template>
-  <NavigationBar v-if="me?.publicKey && browserKeys" :me="me"/>
+  <NavigationBar v-if="accountState == AccountState.Ready && browserKeys" :me="me!"/>
   <SimpleNavigationBar v-else-if="me" :me="me"/>
 
   <div class="max-w-7xl mx-auto px-4 py-12 sm:px-6 lg:px-8 flex justify-center">
@@ -57,7 +57,7 @@
           Vault unlocked successfully
         </h1>
         <p class="mt-2">
-          You may now close this browser tab.
+          You may now close this browser tab and return to Cryptomator.
         </p>
       </div>
     </div>
@@ -68,10 +68,10 @@
 import { ComputedRef, computed, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import backend, { UserDto, VaultDto } from '../common/backend';
+import { BrowserKeys } from '../common/crypto';
 import FetchError from './FetchError.vue';
 import NavigationBar from './NavigationBar.vue';
 import SimpleNavigationBar from './SimpleNavigationBar.vue';
-import { BrowserKeys } from '../common/crypto';
 
 const { t } = useI18n({ useScope: 'global' });
 
@@ -120,7 +120,7 @@ enum VaultAccess {
 }
 
 const me = ref<UserDto>();
-const browserKeys = ref<BrowserKeys | undefined>();
+const browserKeys = ref<boolean>(false);
 const accessibleVaults = ref<VaultDto[]>();
 const onFetchError = ref<Error | null>();
 
@@ -130,7 +130,7 @@ async function fetchData() {
   onFetchError.value = null;
   try {
     me.value = await backend.users.me(true);
-    browserKeys.value = await BrowserKeys.load(me.value.id);
+    browserKeys.value = await BrowserKeys.load(me.value.id) != null;
     accessibleVaults.value = await backend.vaults.listAccessible();
   } catch (error) {
     console.error('Retrieving user information failed.', error);

--- a/frontend/src/components/UnlockSuccess.vue
+++ b/frontend/src/components/UnlockSuccess.vue
@@ -1,7 +1,7 @@
 <template>
   <NavigationBar v-if="me != null" :me="me"/>
 
-  <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+  <div class="max-w-7xl mx-auto px-4 py-12 sm:px-6 lg:px-8 flex justify-center">
     <div v-if="me == null">
       <div v-if="onFetchError == null">
         {{ t('common.loading') }}
@@ -11,42 +11,42 @@
       </div>
     </div>
 
-    <div v-else>
+    <div v-else class="bg-white px-4 py-5 shadow sm:rounded-lg sm:p-6 text-center sm:w-full sm:max-w-lg">
+      <div class="flex justify-center mb-3 sm:mb-5">
+        <img src="/logo.svg" class="h-12" alt="Logo" aria-hidden="true" />
+      </div>
 
-      <div class="mt-8 pb-4 relative shadow-xl sm:rounded-2xl sm:overflow-hidden">
-        <div class="absolute inset-0">
-          <div class="absolute inset-0 bg-gradient-to-r from-primary-l1 to-primary mix-blend-multiply" />
-        </div>
-        <!-- TODO: localize-->
-        <div class="relative px-4 py-16 sm:px-6 sm:py-24 lg:py-32 lg:px-8">
-          <h1 class="text-center text-4xl font-extrabold tracking-tight sm:text-5xl lg:text-6xl text-white">
-            Welcome back, {{ me.name }}!
-          </h1>
-          <div v-if="deviceState == DeviceState.NoSuchDevice" class="max-w-lg mx-auto text-center text-xl text-primary-l2 sm:max-w-3xl">
-            <p class="mt-6">
-              This device is unknown to Cryptomator Hub.
-            </p>
-            <p class="mt-3">
-              Please return to Cryptomator and register your device.
-            </p>
-          </div>
-          <div v-else-if="vaultAccess == VaultAccess.Denied" class="max-w-lg mx-auto text-center text-xl text-primary-l2 sm:max-w-3xl">
-            <p class="mt-6">
-              You don't have access to this vault.
-            </p>
-            <p class="mt-3">
-              Please contact the vault owner to add your account to the vault members.
-            </p>
-          </div>
-          <div v-else class="max-w-lg mx-auto text-center text-xl text-primary-l2 sm:max-w-3xl">
-            <p class="mt-6">
-              Your unlock was successful.
-            </p>
-            <p class="mt-3">
-              You can now close this page and continue using Cryptomator.
-            </p>
-          </div>
-        </div>
+      <!-- TODO: localize -->
+
+      <!-- DEVICE SETUP -->
+      <div v-if="deviceState == DeviceState.NoSuchDevice" class="text-sm text-gray-500">
+        <h1 class="text-2xl leading-6 font-medium text-gray-900">
+          New Device
+        </h1>
+        <p class="my-3">
+          Please enter your account key in Cryptomator to authorize it.
+        </p>
+        <router-link v-if="browserKeys" to="/app/profile" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-primary focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary">View Account Key in my Profile</router-link>
+      </div>
+
+      <!-- NO VAULT ACCESS -->
+      <div v-else-if="vaultAccess == VaultAccess.Denied" class="text-sm text-gray-500">
+        <h1 class="text-2xl leading-6 font-medium text-gray-900">
+          No access to this Vault
+        </h1>
+        <p class="mt-2">
+          Please contact the vault owner to add your account to the vault members.
+        </p>
+      </div>
+
+      <!-- SUCCESS -->
+      <div v-else class="text-sm text-gray-500">
+        <h1 class="text-2xl leading-6 font-medium text-gray-900">
+          Vault unlocked successfully
+        </h1>
+        <p class="mt-2">
+          You may now close this browser tab.
+        </p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Replaced the green "welcome back, alice" screens with more useful messages and matching the design of the remaining page.

Also added a new state when unlocking a vault after migrating to 1.3.0, when the account requires setting up user keys.

> [!note]
> Not yet localized, as we require to guess the browser language, first.

## when oauth failed
<img width="481" alt="Bildschirmfoto 2023-11-24 um 13 38 46" src="https://github.com/cryptomator/hub/assets/1204330/e3c06a8e-3b8e-4b05-907b-ed8fd08b4d06">

## when user didn't complete setup yet
<img width="493" alt="Bildschirmfoto 2023-11-24 um 13 38 56" src="https://github.com/cryptomator/hub/assets/1204330/e081b1eb-9942-458a-a407-494fd4927989">

## when the app needs registration
either on a known browser:
<img width="482" alt="Bildschirmfoto 2023-11-24 um 13 37 53" src="https://github.com/cryptomator/hub/assets/1204330/23de5004-5ba6-4220-b72c-c85d5c675e24">

or when the browser is unknown:
<img width="481" alt="Bildschirmfoto 2023-11-24 um 13 37 56" src="https://github.com/cryptomator/hub/assets/1204330/b0dc975d-542e-43e0-9b4a-67a4eeb3614c">

## 403
<img width="506" alt="Bildschirmfoto 2023-11-24 um 13 41 08" src="https://github.com/cryptomator/hub/assets/1204330/b6fa064e-5600-4f4e-8581-9b8a42040797">

## success
<img width="490" alt="Bildschirmfoto 2023-11-24 um 13 40 09" src="https://github.com/cryptomator/hub/assets/1204330/44026952-e7be-4b37-86f5-9c8c8f6d4e9a">
