### PR TITLE
Add new API for Legacy Device Migration

### DIFF
--- a/backend/src/main/java/org/cryptomator/hub/api/DeviceResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/DeviceResource.java
@@ -41,7 +41,9 @@ import java.net.URI;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Path("/devices")
 public class DeviceResource {
@@ -125,12 +127,11 @@ public class DeviceResource {
 	@Produces(MediaType.APPLICATION_JSON)
 	@NoCache
 	@Transactional
-	@Operation(summary = "list legacy access tokens", description = "get a list of all legacy access tokens for this device. The device must be owned by the currently logged-in user")
+	@Operation(summary = "list legacy access tokens", description = "get all legacy access tokens for this device ({vault1: token1, vault1: token2, ...}). The device must be owned by the currently logged-in user")
 	@APIResponse(responseCode = "200")
-	public List<LegacyAccessTokenDto> getLegacyAccessTokens(@PathParam("deviceId") @ValidId String deviceId) {
+	public Map<UUID, String> getLegacyAccessTokens(@PathParam("deviceId") @ValidId String deviceId) {
 		return LegacyAccessToken.getByDeviceAndOwner(deviceId, jwt.getSubject())
-				.map(result -> new LegacyAccessTokenDto(result.id.vaultId, result.jwe))
-				.toList();
+				.collect(Collectors.toMap(token -> token.id.vaultId , token -> token.jwe));
 	}
 
 	@DELETE

--- a/backend/src/main/java/org/cryptomator/hub/api/UsersResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/UsersResource.java
@@ -6,6 +6,7 @@ import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
@@ -74,7 +75,7 @@ public class UsersResource {
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Operation(summary = "adds/updates user-specific vault keys", description = "Stores one or more vaultid-vaultkey-tuples for the currently logged-in user, as defined in the request body ({vault1: token1, vault2: token2, ...}).")
 	@APIResponse(responseCode = "200", description = "all keys stored")
-	public Response updateMyAccessTokens(@NotEmpty Map<UUID, String> tokens) {
+	public Response updateMyAccessTokens(@NotNull Map<UUID, String> tokens) {
 		var user = User.<User>findById(jwt.getSubject());
 		for (var entry : tokens.entrySet()) {
 			var vault = Vault.<Vault>findById(entry.getKey());

--- a/backend/src/main/java/org/cryptomator/hub/api/UsersResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/UsersResource.java
@@ -30,6 +30,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -73,7 +74,7 @@ public class UsersResource {
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Operation(summary = "adds/updates user-specific vault keys", description = "Stores one or more vaultid-vaultkey-tuples for the currently logged-in user, as defined in the request body ({vault1: token1, vault2: token2, ...}).")
 	@APIResponse(responseCode = "200", description = "all keys stored")
-	public Response updateMyAccessTokens(@NotEmpty Map<String, String> tokens) {
+	public Response updateMyAccessTokens(@NotEmpty Map<UUID, String> tokens) {
 		var user = User.<User>findById(jwt.getSubject());
 		for (var entry : tokens.entrySet()) {
 			var vault = Vault.<Vault>findById(entry.getKey());

--- a/backend/src/main/java/org/cryptomator/hub/api/UsersResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/UsersResource.java
@@ -78,7 +78,7 @@ public class UsersResource {
 		var user = User.<User>findById(jwt.getSubject());
 		for (var entry : tokens.entrySet()) {
 			var vault = Vault.<Vault>findById(entry.getKey());
-			if (vault == null || vault.archived) {
+			if (vault == null) {
 				continue; // skip
 			}
 			var token = AccessToken.<AccessToken>findById(new AccessToken.AccessId(user.id, vault.id));

--- a/backend/src/test/java/org/cryptomator/hub/api/DeviceResourceTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/DeviceResourceTest.java
@@ -89,8 +89,17 @@ public class DeviceResourceTest {
 
 		@Test
 		@Order(1)
-		@DisplayName("GET /devices/legacyDevice3/legacy-access-tokens returns 200")
+		@DisplayName("GET /devices/legacyDevice2/legacy-access-tokens returns empty list (owned by different user)")
 		public void testGetLegacyAccessTokens2() {
+			given().when().get("/devices/{deviceId}/legacy-access-tokens", "legacyDevice2")
+					.then().statusCode(200)
+					.body(is("{}"));
+		}
+
+		@Test
+		@Order(1)
+		@DisplayName("GET /devices/legacyDevice3/legacy-access-tokens returns 200")
+		public void testGetLegacyAccessTokens3() {
 			given().when().get("/devices/{deviceId}/legacy-access-tokens", "legacyDevice3")
 					.then().statusCode(200)
 					.body("7e57c0de-0000-4000-8000-000100002222", is("legacy.jwe.jwe.vault2.device3"));

--- a/backend/src/test/java/org/cryptomator/hub/api/DeviceResourceTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/DeviceResourceTest.java
@@ -80,6 +80,24 @@ public class DeviceResourceTest {
 
 		@Test
 		@Order(1)
+		@DisplayName("GET /devices/legacyDevice1/legacy-access-tokens returns 200")
+		public void testGetLegacyAccessTokens1() {
+			given().when().get("/devices/{deviceId}/legacy-access-tokens", "legacyDevice1")
+					.then().statusCode(200)
+					.body("7e57c0de-0000-4000-8000-000100001111", is("legacy.jwe.jwe.vault1.device1"));
+		}
+
+		@Test
+		@Order(1)
+		@DisplayName("GET /devices/legacyDevice3/legacy-access-tokens returns 200")
+		public void testGetLegacyAccessTokens2() {
+			given().when().get("/devices/{deviceId}/legacy-access-tokens", "legacyDevice3")
+					.then().statusCode(200)
+					.body("7e57c0de-0000-4000-8000-000100002222", is("legacy.jwe.jwe.vault2.device3"));
+		}
+
+		@Test
+		@Order(1)
 		@DisplayName("GET /devices/device2 returns 404 (owned by other user)")
 		public void testGet2() {
 			given().when().get("/devices/{deviceId}", "device2")

--- a/backend/src/test/java/org/cryptomator/hub/api/DeviceResourceTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/DeviceResourceTest.java
@@ -107,6 +107,15 @@ public class DeviceResourceTest {
 
 		@Test
 		@Order(1)
+		@DisplayName("GET /devices/noSuchDevice/legacy-access-tokens returns empty list (no such device)")
+		public void testGetLegacyAccessTokens4() {
+			given().when().get("/devices/{deviceId}/legacy-access-tokens", "noSuchDevice")
+					.then().statusCode(200)
+					.body(is("{}"));
+		}
+
+		@Test
+		@Order(1)
 		@DisplayName("GET /devices/device2 returns 404 (owned by other user)")
 		public void testGet2() {
 			given().when().get("/devices/{deviceId}", "device2")

--- a/backend/src/test/java/org/cryptomator/hub/api/UsersResourceTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/UsersResourceTest.java
@@ -71,7 +71,7 @@ public class UsersResourceTest {
 
 		@Test
 		@DisplayName("POST /users/me/access-tokens returns 200")
-		public void testPostAccessTokens() {
+		public void testPostAccessTokens1() {
 			var body = """
 					{
 						"7E57C0DE-0000-4000-8000-000100001111": "jwe.jwe.jwe.vault1.user1",
@@ -81,6 +81,22 @@ public class UsersResourceTest {
 			given().contentType(ContentType.JSON).body(body)
 					.when().post("/users/me/access-tokens")
 					.then().statusCode(200);
+		}
+
+		@Test
+		@DisplayName("POST /users/me/access-tokens returns 200 for empty list")
+		public void testPostAccessTokens2() {
+			given().contentType(ContentType.JSON).body("{}")
+					.when().post("/users/me/access-tokens")
+					.then().statusCode(200);
+		}
+
+		@Test
+		@DisplayName("POST /users/me/access-tokens returns 400 for malformed body")
+		public void testPostAccessTokens3() {
+			given().contentType(ContentType.JSON).body("")
+					.when().post("/users/me/access-tokens")
+					.then().statusCode(400);
 		}
 
 	}

--- a/backend/src/test/java/org/cryptomator/hub/api/UsersResourceTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/UsersResourceTest.java
@@ -5,8 +5,7 @@ import io.quarkus.test.security.TestSecurity;
 import io.quarkus.test.security.oidc.Claim;
 import io.quarkus.test.security.oidc.OidcSecurity;
 import io.restassured.RestAssured;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.text.IsEqualIgnoringCase;
+import io.restassured.http.ContentType;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -14,11 +13,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.text.IsEqualIgnoringCase.equalToIgnoringCase;
 
 @QuarkusTest
 @DisplayName("Resource /users")
@@ -68,6 +67,20 @@ public class UsersResourceTest {
 			when().get("/users")
 					.then().statusCode(200)
 					.body("id", hasItems("user1", "user2"));
+		}
+
+		@Test
+		@DisplayName("POST /users/me/access-tokens returns 200")
+		public void testPostAccessTokens() {
+			var body = """
+					{
+						"7E57C0DE-0000-4000-8000-000100001111": "jwe.jwe.jwe.vault1.user1",
+						"7E57C0DE-0000-4000-8000-BADBADBADBAD": "noSuchVault"
+					},
+					""";
+			given().contentType(ContentType.JSON).body(body)
+					.when().post("/users/me/access-tokens")
+					.then().statusCode(200);
 		}
 
 	}


### PR DESCRIPTION
This adds two new API endpoints:

* deprecated `GET /api/devices/{deviceId}/legacy-access-tokens` (to be removed after all users migrated from 1.2.x)
* permanent `POST /api/users/me/access-tokens`

The response body of the former and the request body of the latter are both JSON objects with these key-value-pairs:

```json
{
  "vault1": "token1",
  "vault2": "token2",
  ...
}
```

The difference is that the deprecated legacy access tokens are encrypted using the device key, while the current access tokens posted to the users resource shall be encrypted using the user key.

Both endpoints are accessible to all users, as they only expose information owned by the currently logged in user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added the ability to list legacy access tokens for devices.
	- Introduced a new feature to update user-specific vault keys.

- **Bug Fixes**
	- Improved the retrieval of legacy access tokens by ensuring they are filtered by device and owner.

- **Tests**
	- Implemented new tests to verify the functionality of legacy access token retrieval.
	- Added tests to ensure proper handling of access token POST requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->