### PR TITLE
Allow Access to `/app/admin/settings` Before Finishing Onboarding

### DIFF
--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -82,7 +82,8 @@ const routes: RouteRecordRaw[] = [
           {
             path: 'settings',
             component: AdminSettings,
-            props: (route) => ({ token: route.query.token })
+            props: (route) => ({ token: route.query.token }),
+            meta: { skipSetup: true }
           },
           {
             path: 'auditlog',


### PR DESCRIPTION
When a user is successfully authenticated and holds the `admin` role, she may want to be able to access `/app/admin/settings` without being redirected to `/app/setup`.

No user-specific key material is required for general administrative purposes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved navigation in the app by allowing direct access to the Admin Settings page without additional setup steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->