### PR TITLE
Avoid Native Queries

### DIFF
--- a/backend/src/main/java/org/cryptomator/hub/entities/LegacyAccessToken.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/LegacyAccessToken.java
@@ -5,7 +5,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
-import jakarta.persistence.NamedNativeQuery;
+import jakarta.persistence.NamedQuery;
 import jakarta.persistence.NoResultException;
 import jakarta.persistence.Table;
 
@@ -15,12 +15,12 @@ import java.util.UUID;
 
 @Entity
 @Table(name = "access_token_legacy")
-@NamedNativeQuery(name = "LegacyAccessToken.get", resultClass = LegacyAccessToken.class, query = """
-		SELECT t.device_id, t.vault_id, t.jwe
-		FROM access_token_legacy t
-		INNER JOIN device_legacy d ON d.id = t.device_id
-		INNER JOIN effective_vault_access a ON a.vault_id = t.vault_id AND a.authority_id = d.owner_id
-		WHERE t.vault_id = :vaultId AND d.id = :deviceId AND d.owner_id = :userId
+@NamedQuery(name = "LegacyAccessToken.get", query = """
+		SELECT token
+		FROM LegacyAccessToken token
+		INNER JOIN LegacyDevice device ON device.id = token.id.deviceId
+		INNER JOIN EffectiveVaultAccess perm ON token.id.vaultId = perm.id.vaultId AND device.ownerId = perm.id.authorityId
+		WHERE token.id.vaultId = :vaultId AND token.id.deviceId = :deviceId AND device.ownerId = :userId
 		""")
 @Deprecated
 public class LegacyAccessToken extends PanacheEntityBase {

--- a/backend/src/main/java/org/cryptomator/hub/entities/LegacyDevice.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/LegacyDevice.java
@@ -15,4 +15,7 @@ public class LegacyDevice extends PanacheEntityBase {
 	@Column(name = "id", nullable = false)
 	public String id;
 
+	@Column(name = "owner_id", nullable = false)
+	public String ownerId;
+
 }

--- a/backend/src/main/java/org/cryptomator/hub/entities/LegacyDevice.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/LegacyDevice.java
@@ -18,4 +18,6 @@ public class LegacyDevice extends PanacheEntityBase {
 	@Column(name = "owner_id", nullable = false)
 	public String ownerId;
 
+	// Further attributes omitted, as they are no longer used. The above ones are exceptions, as they are referenced via JPQL for joining.
+
 }


### PR DESCRIPTION
Fixes #222 by reverting native queries back to `@NamedQuery`.

### AccessToken

The unlock `@NamedQuery` avoids any join on User:

```sql
SELECT token
FROM AccessToken token
INNER JOIN EffectiveVaultAccess perm ON token.id.vaultId = perm.id.vaultId AND token.id.userId = perm.id.authorityId
WHERE token.id.vaultId = :vaultId AND token.id.userId = :userId
```

Hibernate translates this to the following:

```sql
    select
        a1_0."user_id",
        a1_0."vault_id",
        a1_0."vault_masterkey" 
    from
        "access_token" a1_0 
    join
        "effective_vault_access" e1_0 
            on a1_0."vault_id"=e1_0."vault_id" 
            and a1_0."user_id"=e1_0."authority_id" 
    where
        a1_0."vault_id"=? 
        and a1_0."user_id"=? fetch first ? rows only
```

### LegacyAccessToken

This is the `@NamedQuery`:

```sql
SELECT token
FROM LegacyAccessToken token
INNER JOIN LegacyDevice device ON device.id = token.id.deviceId
INNER JOIN EffectiveVaultAccess perm ON token.id.vaultId = perm.id.vaultId AND device.ownerId = perm.id.authorityId
WHERE token.id.vaultId = :vaultId AND token.id.deviceId = :deviceId AND device.ownerId = :userId
```

Hibernate translates this to the following:

```sql
    select
        l1_0."device_id",
        l1_0."vault_id",
        l1_0."jwe" 
    from
        "access_token_legacy" l1_0 
    join
        "device_legacy" l2_0 
            on l2_0."id"=l1_0."device_id" 
    join
        "effective_vault_access" e1_0 
            on l1_0."vault_id"=e1_0."vault_id" 
            and l2_0."owner_id"=e1_0."authority_id" 
    where
        l1_0."vault_id"=? 
        and l1_0."device_id"=? 
        and l2_0."owner_id"=?
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated access token retrieval to use a named query for improved maintainability.
	- Transitioned from native SQL to JPQL in `LegacyAccessToken` to enhance database compatibility.
- **New Features**
	- Introduced an `ownerId` field to `LegacyDevice` for better ownership tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->