### PR TITLE
Set header to instruct the browser how to cache

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -89,6 +89,32 @@ quarkus.http.header."Cross-Origin-Opener-Policy".value=same-origin
 quarkus.http.header."Cross-Origin-Resource-Policy".value=same-origin
 quarkus.http.header."Content-Type".value=text/html
 
+# Cache
+# /app for 5min in case hub gets updated
+# /index.html and / for 1min in case hub gets updated
+# /api never because the backend content can change at any time
+# /assets "forever" (1 year) because those files are versioned
+# /favicon.ico and /logo.svg for one day
+quarkus.http.filter.app.header."Cache-Control"=private, max-age=300
+quarkus.http.filter.app.methods=GET,HEAD
+quarkus.http.filter.app.matches=/app/.*
+
+quarkus.http.filter.index.header."Cache-Control"=private, max-age=60
+quarkus.http.filter.index.methods=GET,HEAD
+quarkus.http.filter.index.matches=/index.html|/
+
+quarkus.http.filter.api.header."Cache-Control"=no-cache, no-store, must-revalidate
+quarkus.http.filter.api.methods=GET,HEAD
+quarkus.http.filter.api.matches=/api/.*
+
+quarkus.http.filter.assets.header."Cache-Control"=max-age=31536000, immutable
+quarkus.http.filter.assets.methods=GET,HEAD
+quarkus.http.filter.assets.matches=/assets/.*
+
+quarkus.http.filter.static.header."Cache-Control"=public, max-age=86400
+quarkus.http.filter.static.methods=GET,HEAD
+quarkus.http.filter.static.matches=/(favicon.ico|logo.svg)
+
 # Container Image Adjustments
 quarkus.container-image.registry=ghcr.io
 quarkus.container-image.group=cryptomator

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -90,18 +90,13 @@ quarkus.http.header."Cross-Origin-Resource-Policy".value=same-origin
 quarkus.http.header."Content-Type".value=text/html
 
 # Cache
-# /app for 5min in case hub gets updated
-# /index.html and / for 1min in case hub gets updated
+# /app, /index.html and / for 1min in case hub gets updated
 # /api never because the backend content can change at any time
 # /assets "forever" (1 year) because those files are versioned
 # /favicon.ico and /logo.svg for one day
-quarkus.http.filter.app.header."Cache-Control"=private, max-age=300
+quarkus.http.filter.app.header."Cache-Control"=private, max-age=60
 quarkus.http.filter.app.methods=GET,HEAD
-quarkus.http.filter.app.matches=/app/.*
-
-quarkus.http.filter.index.header."Cache-Control"=private, max-age=60
-quarkus.http.filter.index.methods=GET,HEAD
-quarkus.http.filter.index.matches=/index.html|/
+quarkus.http.filter.app.matches=/app/.*|/index.html|/
 
 quarkus.http.filter.api.header."Cache-Control"=no-cache, no-store, must-revalidate
 quarkus.http.filter.api.methods=GET,HEAD

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -130,7 +130,10 @@ router.beforeEach((to, from, next) => {
       if (auth.isAuthenticated()) {
         next();
       } else {
-        const redirect: RouteLocationRaw = { query: { ...to.query, 'sync_me': null } };
+        // secondsSinceEpoch is required for legacy reasons, as caching headers were only introduced in #255
+        // as result, the redirect URI changes and caching does not break updates anymore
+        const secondsSinceEpoch = Math.round(new Date().getTime() / 1000);
+        const redirect: RouteLocationRaw = { query: { ...to.query, 'sync_me': secondsSinceEpoch } };
         const redirectUri = `${location.origin}${router.resolve(redirect, to).href}`;
         auth.login(redirectUri);
       }


### PR DESCRIPTION
Currently, no caching headers are explicitly set, leaving it up to the browser to decide what to cache. Especially on updates, this can lead to an old version of hub being displayed, and may even lead to errors. This commit fixes that, but only for the future.

Additionally, we add a unique value to the `sync_me` param each time we redirect back from the authorization server. This will force the browser to load a fresh copy from the server regardless of any cached version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Implemented cache settings to improve loading times for key resources including the application's main page, API endpoints, and asset files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->