### PR TITLE
Feature: Rework when to return 402 for VaultResource

### DIFF
--- a/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
@@ -268,8 +268,8 @@ public class VaultResource {
 			throw new GoneException("Vault is archived.");
 		}
 
-		var usedSeats = EffectiveVaultAccess.countSeatOccupyingUsersWithAccessToken();
-		if (usedSeats > license.getAvailableSeats()) {
+		var accessTokenSeats = EffectiveVaultAccess.countSeatOccupyingUsersWithAccessToken();
+		if (accessTokenSeats > license.getAvailableSeats()) {
 			throw new PaymentRequiredException("Number of effective vault users exceeds available license seats");
 		}
 
@@ -305,8 +305,8 @@ public class VaultResource {
 			throw new GoneException("Vault is archived.");
 		}
 
-		var usedSeats = EffectiveVaultAccess.countSeatOccupyingUsersWithAccessToken();
-		if (usedSeats > license.getAvailableSeats()) {
+		var accessTokenSeats = EffectiveVaultAccess.countSeatOccupyingUsersWithAccessToken();
+		if (accessTokenSeats > license.getAvailableSeats()) {
 			throw new PaymentRequiredException("Number of effective vault users exceeds available license seats");
 		}
 

--- a/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
@@ -157,7 +157,7 @@ public class VaultResource {
 	@APIResponse(responseCode = "404", description = "user not found")
 	@ActiveLicense
 	public Response addUser(@PathParam("vaultId") UUID vaultId, @PathParam("userId") @ValidId String userId, @QueryParam("role") @DefaultValue("MEMBER") VaultAccess.Role role) {
-		var vault = Vault.<Vault>findById(vaultId); // // should always be found, since @VaultRole filter would have triggered
+		var vault = Vault.<Vault>findById(vaultId); // should always be found, since @VaultRole filter would have triggered
 		var user = User.<User>findByIdOptional(userId).orElseThrow(NotFoundException::new);
 		var usedSeats = EffectiveVaultAccess.countSeatOccupyingUsers();
 		//check if license seats are free

--- a/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
@@ -378,7 +378,7 @@ public class VaultResource {
 	@Transactional
 	@Operation(summary = "gets a vault")
 	@APIResponse(responseCode = "200")
-	@APIResponse(responseCode = "403", description = "requesting user is not member of the vault")
+	@APIResponse(responseCode = "403", description = "requesting user is neither a member of the vault nor has the admin role")
 	public VaultDto get(@PathParam("vaultId") UUID vaultId) {
 		Vault vault = Vault.<Vault>findByIdOptional(vaultId).orElseThrow(NotFoundException::new);
 		if (vault.effectiveMembers.stream().noneMatch(u -> u.id.equals(jwt.getSubject())) && !identity.getRoles().contains("admin")) {

--- a/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
@@ -161,11 +161,11 @@ public class VaultResource {
 		var user = User.<User>findByIdOptional(userId).orElseThrow(NotFoundException::new);
 		var usedSeats = EffectiveVaultAccess.countSeatOccupyingUsers();
 		//check if license seats are free
-		if (usedSeats  < license.getAvailableSeats()) {
+		if (usedSeats  < license.getSeats()) {
 			return addAuthority(vault, user, role);
 		}
 		// else check, if all seats are taken, but the person to add is already sitting
-		if (usedSeats == license.getAvailableSeats() && EffectiveVaultAccess.isUserOccupyingSeat(userId)) {
+		if (usedSeats == license.getSeats() && EffectiveVaultAccess.isUserOccupyingSeat(userId)) {
 			return addAuthority(vault, user, role);
 		}
 		//otherwise block
@@ -192,7 +192,7 @@ public class VaultResource {
 		var group = Group.<Group>findByIdOptional(groupId).orElseThrow(NotFoundException::new);
 
 		//usersInGroup - usersInGroupAndPartOfAtLeastOneVault + usersOfAtLeastOneVault
-		if (EffectiveGroupMembership.countEffectiveGroupUsers(groupId) - EffectiveVaultAccess.countSeatOccupyingUsersOfGroup(groupId) + EffectiveVaultAccess.countSeatOccupyingUsers() > license.getAvailableSeats()) {
+		if (EffectiveGroupMembership.countEffectiveGroupUsers(groupId) - EffectiveVaultAccess.countSeatOccupyingUsersOfGroup(groupId) + EffectiveVaultAccess.countSeatOccupyingUsers() > license.getSeats()) {
 			throw new PaymentRequiredException("Number of effective vault users greater than or equal to the available license seats");
 		}
 
@@ -269,7 +269,7 @@ public class VaultResource {
 		}
 
 		var accessTokenSeats = EffectiveVaultAccess.countSeatOccupyingUsersWithAccessToken();
-		if (accessTokenSeats > license.getAvailableSeats()) {
+		if (accessTokenSeats > license.getSeats()) {
 			throw new PaymentRequiredException("Number of effective vault users exceeds available license seats");
 		}
 
@@ -306,7 +306,7 @@ public class VaultResource {
 		}
 
 		var accessTokenSeats = EffectiveVaultAccess.countSeatOccupyingUsersWithAccessToken();
-		if (accessTokenSeats > license.getAvailableSeats()) {
+		if (accessTokenSeats > license.getSeats()) {
 			throw new PaymentRequiredException("Number of effective vault users exceeds available license seats");
 		}
 
@@ -351,7 +351,7 @@ public class VaultResource {
 		long occupiedSeats = EffectiveVaultAccess.countSeatOccupyingUsers();
 		long usersWithoutSeat = tokens.size() - EffectiveVaultAccess.countSeatsOccupiedByUsers(tokens.keySet().stream().toList());
 
-		if (occupiedSeats + usersWithoutSeat > license.getAvailableSeats()) {
+		if (occupiedSeats + usersWithoutSeat > license.getSeats()) {
 			throw new PaymentRequiredException("Number of effective vault users greater than or equal to the available license seats");
 		}
 
@@ -409,7 +409,7 @@ public class VaultResource {
 		} else {
 			//if license is exceeded block vault creation, independent if the user is already sitting
 			var usedSeats = EffectiveVaultAccess.countSeatOccupyingUsers();
-			if (usedSeats > license.getAvailableSeats()) {
+			if (usedSeats > license.getSeats()) {
 				throw new PaymentRequiredException("Number of effective vault users exceeds available license seats");
 			}
 			// create new vault:

--- a/backend/src/main/java/org/cryptomator/hub/license/LicenseHolder.java
+++ b/backend/src/main/java/org/cryptomator/hub/license/LicenseHolder.java
@@ -168,11 +168,11 @@ public class LicenseHolder {
 	}
 
 	/**
-	 * Gets the number of available seats of the license
+	 * Gets the number of seats in the license
 	 *
-	 * @return Number of available seats, if license is not null. Otherwise {@value SelfHostedNoLicenseConstants#SEATS}.
+	 * @return Number of seats of the license, if license is not null. Otherwise {@value SelfHostedNoLicenseConstants#SEATS}.
 	 */
-	public long getAvailableSeats() {
+	public long getSeats() {
 		return Optional.ofNullable(license) //
 				.map(l -> l.getClaim("seats")) //
 				.map(Claim::asLong) //

--- a/backend/src/test/java/org/cryptomator/hub/api/BillingResourceTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/BillingResourceTest.java
@@ -56,7 +56,7 @@ public class BillingResourceTest {
 		public void testGetEmptySelfHosted() {
 			Mockito.when(licenseHolder.get()).thenReturn(null);
 			Mockito.when(licenseHolder.getNoLicenseSeats()).thenReturn(5L);
-			Mockito.when(licenseHolder.getAvailableSeats()).thenReturn(3L);
+			Mockito.when(licenseHolder.getSeats()).thenReturn(3L);
 			when().get("/billing")
 					.then().statusCode(200)
 					.body("hubId", is("42"))

--- a/backend/src/test/java/org/cryptomator/hub/api/VaultResourceTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/VaultResourceTest.java
@@ -739,15 +739,38 @@ public class VaultResourceTest {
 					.then().statusCode(402);
 		}
 
+
 		@Test
-		@TestSecurity(user = "User 94", roles = {"user"})
-		@OidcSecurity(claims = {
-				@Claim(key = "sub", value = "user94")
-		})
 		@Order(4)
-		@DisplayName("PUT /vaults/7E57C0DE-0000-4000-8000-0001FFFF3333 (as user94) exceeding the license returns 402")
-		public void testCreateVaultExceedingSeats() {
+		@DisplayName("PUT /vaults/7E57C0DE-0000-4000-8000-000100001111 (as user1) returns 200 with only updated name, description and archive flag, despite exceeding license")
+		public void testUpdateVaultDespiteLicenseExceeded() {
 			assert EffectiveVaultAccess.countSeatOccupyingUsers() == 5;
+			var vaultId = "7E57C0DE-0000-4000-8000-000100001111";
+
+			var vaultDto = new VaultResource.VaultDto(UUID.fromString(vaultId), "Vault 1", "This is a testvault.", false, Instant.parse("2222-11-11T11:11:11Z"), "someVaule", -1, "doNotUpdate", "doNotUpdate", "doNotUpdate");
+			given().contentType(ContentType.JSON)
+					.body(vaultDto)
+					.when().put("/vaults/{vaultId}", vaultId)
+					.then().statusCode(200)
+					.body("id", equalToIgnoringCase(vaultId))
+					.body("name", equalTo("Vault 1"))
+					.body("description", equalTo("This is a testvault."))
+					.body("archived", equalTo(false));
+		}
+
+		@Test
+		@Order(5)
+		@DisplayName("PUT /vaults/7E57C0DE-0000-4000-8000-0001FFFF3333 (as user1) exceeding the license returns 402")
+		public void testCreateVaultExceedingSeats() throws SQLException {
+			try (var c = dataSource.getConnection(); var s = c.createStatement()) {
+				s.execute("""
+						INSERT INTO "vault_access" ("vault_id", "authority_id")
+						VALUES
+							('7E57C0DE-0000-4000-8000-000100001111', 'group91');
+						""");
+			}
+
+			assert EffectiveVaultAccess.countSeatOccupyingUsers() > 5;
 
 			var uuid = UUID.fromString("7E57C0DE-0000-4000-8000-0001FFFF3333");
 			var vaultDto = new VaultResource.VaultDto(uuid, "My Vault", "Test vault 4", false, Instant.parse("2112-12-21T21:12:21Z"), "masterkey3", 42, "NaCl", "authPubKey3", "authPrvKey3");
@@ -757,50 +780,9 @@ public class VaultResourceTest {
 		}
 
 		@Test
-		@Order(5)
-		@DisplayName("PUT /vaults/7E57C0DE-0000-4000-8000-0001FFFF3333 (as user1) returns 201 not exceeding seats because user already has access to an existing vault")
-		public void testCreateVaultNotExceedingSeats() {
-			assert EffectiveVaultAccess.countSeatOccupyingUsers() == 5;
-
-			var uuid = UUID.fromString("7E57C0DE-0000-4000-8000-0001FFFF3333");
-			var vaultDto = new VaultResource.VaultDto(uuid, "My Vault", "Test vault 3", false, Instant.parse("2112-12-21T21:12:21Z"), "masterkey3", 42, "NaCl", "authPubKey3", "authPrvKey3");
-			given().contentType(ContentType.JSON).body(vaultDto)
-					.when().put("/vaults/{vaultId}", "7E57C0DE-0000-4000-8000-0001FFFF3333")
-					.then().statusCode(201)
-					.body("id", equalToIgnoringCase("7E57C0DE-0000-4000-8000-0001FFFF3333"))
-					.body("name", equalTo("My Vault"))
-					.body("description", equalTo("Test vault 3"))
-					.body("archived", equalTo(false));
-		}
-
-		@Test
-		@Order(6)
-		@DisplayName("PUT /vaults/7E57C0DE-0000-4000-8000-0001FFFF3333 (as user1) returns 200 with only updated name, description and archive flag, despite exceeding license")
-		public void testUpdateVaultDespiteLicenseExceeded() {
-			assert EffectiveVaultAccess.countSeatOccupyingUsers() == 5;
-
-			var uuid = UUID.fromString("7E57C0DE-0000-4000-8000-0001FFFF3333");
-			var vaultDto = new VaultResource.VaultDto(uuid, "VaultUpdated", "Vault updated.", true, Instant.parse("2222-11-11T11:11:11Z"), "someVaule", -1, "doNotUpdate", "doNotUpdate", "doNotUpdate");
-			given().contentType(ContentType.JSON)
-					.body(vaultDto)
-					.when().put("/vaults/{vaultId}", "7E57C0DE-0000-4000-8000-0001FFFF3333")
-					.then().statusCode(200)
-					.body("id", equalToIgnoringCase("7E57C0DE-0000-4000-8000-0001FFFF3333"))
-					.body("name", equalTo("VaultUpdated"))
-					.body("description", equalTo("Vault updated."))
-					.body("archived", equalTo(true));
-		}
-
-		@Test
 		@Order(7)
 		@DisplayName("unlock/legacyUnlock is granted, if (effective vault user) > license seats but (effective vault user with access token) <= license seat")
 		public void testUnlockAllowedExceedingLicenseSoftLimit() throws SQLException {
-			try (var c = dataSource.getConnection(); var s = c.createStatement()) {
-				s.execute("""
-						INSERT INTO "vault_access" ("vault_id", "authority_id")
-							VALUES ('7E57C0DE-0000-4000-8000-000100001111', 'group91');
-						""");
-			}
 			assert EffectiveVaultAccess.countSeatOccupyingUsersWithAccessToken() <= 5;
 
 			when().get("/vaults/{vaultId}/access-token", "7E57C0DE-0000-4000-8000-000100001111")


### PR DESCRIPTION
Fixes #262.

The Cryptomator Hub license has two conditions:
1. Is the expiration date in the past?
1. Is the number of seats exceeded?

Depending on which of the above is true, certain features are disabled and certain REST endpoints return 402. In general it holds, that if one of the above is true, management features are disabled. Additionally, we introduced in #258 a soft- and a hard threshold, depeding on if a user has already vault access or not.

This PR adjusts the `/vaults/...` path to this new philosophy. Conditions to return 402, orderd by endpoint:
* addUser: if the user to add exceeds the seat count (including if the seats are already exceeded)
* createOrUpdate: if vault is created and the seat count is already exceeded