### PR TITLE
Feature: License status endpoint

### DIFF
--- a/backend/src/main/java/org/cryptomator/hub/api/BillingResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/BillingResource.java
@@ -24,6 +24,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import java.time.Instant;
 import java.util.Optional;
 
+//TODO: redirect ot /license path
 @Path("/billing")
 public class BillingResource {
 

--- a/backend/src/main/java/org/cryptomator/hub/api/BillingResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/BillingResource.java
@@ -69,7 +69,7 @@ public class BillingResource {
 							 @JsonProperty("issuedAt") Instant issuedAt, @JsonProperty("expiresAt") Instant expiresAt, @JsonProperty("managedInstance") Boolean managedInstance) {
 
 		public static BillingDto create(String hubId, LicenseHolder licenseHolder) {
-			var licensedSeats = licenseHolder.getNoLicenseSeats();
+			var licensedSeats = licenseHolder.getSeats();
 			var usedSeats = EffectiveVaultAccess.countSeatOccupyingUsers();
 			var managedInstance = licenseHolder.isManagedInstance();
 			return new BillingDto(hubId, false, null, (int) licensedSeats, (int) usedSeats, null, null, managedInstance);

--- a/backend/src/main/java/org/cryptomator/hub/api/LicenseResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/LicenseResource.java
@@ -26,7 +26,7 @@ public class LicenseResource {
 	@Path("/status")
 	@Produces(MediaType.APPLICATION_JSON)
 	@RolesAllowed("user")
-	@Operation(summary = "Get license status information", description = "Information includes the license expiration date, the licensed seats and the already used seats")
+	@Operation(summary = "Get license status information", description = "Information includes the licensed seats, the already used seats and if defined, the license expiration date.")
 	@APIResponse(responseCode = "200")
 	public LicenseStatusDto get() {
 		return LicenseStatusDto.create(licenseHolder);

--- a/backend/src/main/java/org/cryptomator/hub/api/LicenseResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/LicenseResource.java
@@ -23,25 +23,25 @@ public class LicenseResource {
 	LicenseHolder licenseHolder;
 
 	@GET
-	@Path("/status")
+	@Path("/user-info")
 	@Produces(MediaType.APPLICATION_JSON)
 	@RolesAllowed("user")
-	@Operation(summary = "Get license status information", description = "Information includes the licensed seats, the already used seats and if defined, the license expiration date.")
+	@Operation(summary = "Get license information for regular users", description = "Information includes the licensed seats, the already used seats and if defined, the license expiration date.")
 	@APIResponse(responseCode = "200")
-	public LicenseStatusDto get() {
-		return LicenseStatusDto.create(licenseHolder);
+	public LicenseUserInfoDto get() {
+		return LicenseUserInfoDto.create(licenseHolder);
 	}
 
 
-	public record LicenseStatusDto(@JsonProperty("licensedSeats") Integer licensedSeats,
-								   @JsonProperty("usedSeats") Integer usedSeats,
-								   @JsonProperty("expiresAt") Instant expiresAt) {
+	public record LicenseUserInfoDto(@JsonProperty("licensedSeats") Integer licensedSeats,
+									 @JsonProperty("usedSeats") Integer usedSeats,
+									 @JsonProperty("expiresAt") Instant expiresAt) {
 
-		public static LicenseStatusDto create(LicenseHolder licenseHolder) {
+		public static LicenseUserInfoDto create(LicenseHolder licenseHolder) {
 			var licensedSeats = (int) licenseHolder.getSeats();
 			var usedSeats = (int) EffectiveVaultAccess.countSeatOccupyingUsers();
 			var expiresAt = Optional.ofNullable(licenseHolder.get()).map(DecodedJWT::getExpiresAtAsInstant).orElse(null);
-			return new LicenseStatusDto(licensedSeats, usedSeats, expiresAt);
+			return new LicenseUserInfoDto(licensedSeats, usedSeats, expiresAt);
 		}
 
 	}

--- a/backend/src/main/java/org/cryptomator/hub/api/LicenseResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/LicenseResource.java
@@ -1,0 +1,49 @@
+package org.cryptomator.hub.api;
+
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import org.cryptomator.hub.entities.EffectiveVaultAccess;
+import org.cryptomator.hub.license.LicenseHolder;
+import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+
+import java.time.Instant;
+import java.util.Optional;
+
+@Path("/license")
+public class LicenseResource {
+
+	@Inject
+	LicenseHolder licenseHolder;
+
+	@GET
+	@Path("/status")
+	@Produces(MediaType.APPLICATION_JSON)
+	@RolesAllowed("user")
+	@Operation(summary = "Get license status information", description = "Information includes the license expiration date, the licensed seats and the already used seats")
+	@APIResponse(responseCode = "200")
+	public LicenseStatusDto get() {
+		return LicenseStatusDto.create(licenseHolder);
+	}
+
+
+	public record LicenseStatusDto(@JsonProperty("licensedSeats") Integer licensedSeats,
+								   @JsonProperty("usedSeats") Integer usedSeats,
+								   @JsonProperty("expiresAt") Instant expiresAt) {
+
+		public static LicenseStatusDto create(LicenseHolder licenseHolder) {
+			var licensedSeats = (int) licenseHolder.getSeats();
+			var usedSeats = (int) EffectiveVaultAccess.countSeatOccupyingUsers();
+			var expiresAt = Optional.ofNullable(licenseHolder.get()).map(DecodedJWT::getExpiresAtAsInstant).orElse(null);
+			return new LicenseStatusDto(licensedSeats, usedSeats, expiresAt);
+		}
+
+	}
+
+}

--- a/backend/src/main/java/org/cryptomator/hub/license/LicenseHolder.java
+++ b/backend/src/main/java/org/cryptomator/hub/license/LicenseHolder.java
@@ -83,7 +83,7 @@ public class LicenseHolder {
 			settings.hubId = initialId;
 			settings.persistAndFlush();
 		} catch (JWTVerificationException e) {
-			LOG.warn("Provided initial license is invalid.");
+			LOG.warn("Provided initial license is invalid.", e);
 		}
 	}
 

--- a/backend/src/main/java/org/cryptomator/hub/license/LicenseHolder.java
+++ b/backend/src/main/java/org/cryptomator/hub/license/LicenseHolder.java
@@ -176,10 +176,11 @@ public class LicenseHolder {
 		return Optional.ofNullable(license) //
 				.map(l -> l.getClaim("seats")) //
 				.map(Claim::asLong) //
-				.orElseGet(this::getNoLicenseSeats);
+				.orElseGet(this::seatsOnNotExisingLicense);
 	}
 
-	public long getNoLicenseSeats() {
+	//visible for testing
+	public long seatsOnNotExisingLicense() {
 		if (!managedInstance) {
 			return SelfHostedNoLicenseConstants.SEATS;
 		} else {

--- a/backend/src/test/java/org/cryptomator/hub/api/BillingResourceTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/BillingResourceTest.java
@@ -55,8 +55,7 @@ public class BillingResourceTest {
 		@DisplayName("GET /billing returns 200 with empty license self-hosted")
 		public void testGetEmptySelfHosted() {
 			Mockito.when(licenseHolder.get()).thenReturn(null);
-			Mockito.when(licenseHolder.getNoLicenseSeats()).thenReturn(5L);
-			Mockito.when(licenseHolder.getSeats()).thenReturn(3L);
+			Mockito.when(licenseHolder.getSeats()).thenReturn(5L);
 			when().get("/billing")
 					.then().statusCode(200)
 					.body("hubId", is("42"))

--- a/frontend/src/common/backend.ts
+++ b/frontend/src/common/backend.ts
@@ -195,7 +195,7 @@ export type VersionDto = {
   keycloakVersion: string;
 }
 
-export class LicenseStatusDto {
+export class LicenseUserInfoDto {
   constructor(
     public licensedSeats: number,
     public usedSeats: number,
@@ -373,9 +373,9 @@ class BillingService {
 }
 
 class LicenseService {
-  public async getStatus(): Promise<LicenseStatusDto> {
-    return axiosAuth.get('/license/status').then(response => {
-      return new LicenseStatusDto(response.data.licensedSeats, response.data.usedSeats, response.data.expiresAt ? new Date(response.data.expiresAt) : null);
+  public async getUserInfo(): Promise<LicenseUserInfoDto> {
+    return axiosAuth.get('/license/user-info').then(response => {
+      return new LicenseUserInfoDto(response.data.licensedSeats, response.data.usedSeats, response.data.expiresAt ? new Date(response.data.expiresAt) : null);
     });
   }
 }

--- a/frontend/src/common/backend.ts
+++ b/frontend/src/common/backend.ts
@@ -199,12 +199,12 @@ export class LicenseStatusDto {
   constructor(
     public licensedSeats: number,
     public usedSeats: number,
-    public expiresAt: Date) {
+    public expiresAt: Date | null) {
   }
 
   public isExpired(): boolean {
     const now = new Date();
-    return now > this.expiresAt;
+    return now > (this.expiresAt ?? now); //if expired is null, the license cannot expire
   }
 
   public isExceeded(): boolean {
@@ -375,7 +375,7 @@ class BillingService {
 class LicenseService {
   public async getStatus(): Promise<LicenseStatusDto> {
     return axiosAuth.get('/license/status').then(response => {
-      return new LicenseStatusDto(response.data.licensedSeats, response.data.usedSeats, new Date(response.data.expiresAt));
+      return new LicenseStatusDto(response.data.licensedSeats, response.data.usedSeats, response.data.expiresAt ? new Date(response.data.expiresAt) : null);
     });
   }
 }

--- a/frontend/src/components/LicenseAlert.vue
+++ b/frontend/src/components/LicenseAlert.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="admin && admin.hasLicense && now > admin.expiresAt" class="rounded-md bg-red-50 p-4 mb-3">
+  <div v-if="license?.expiresAt && now > license.expiresAt" class="rounded-md bg-red-50 p-4 mb-3">
     <div class="flex">
       <div class="flex-shrink-0">
         <XCircleIcon class="h-5 w-5 text-red-400" aria-hidden="true" />
@@ -15,7 +15,7 @@
     </div>
   </div>
 
-  <div v-else-if="admin && (admin.licensedSeats - admin.usedSeats < 0)" class="rounded-md bg-yellow-50 p-4 mb-3">
+  <div v-else-if="license && (license.licensedSeats - license.usedSeats < 0)" class="rounded-md bg-yellow-50 p-4 mb-3">
     <div class="flex">
       <div class="flex-shrink-0">
         <ExclamationTriangleIcon class="h-5 w-5 text-yellow-400" aria-hidden="true" />
@@ -30,27 +30,26 @@
       </div>
     </div>
   </div>
-
 </template>
 
 <script setup lang="ts">
 import { ExclamationTriangleIcon, XCircleIcon } from '@heroicons/vue/20/solid';
 import { onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
-import backend, { BillingDto } from '../common/backend';
+import backend, { LicenseUserInfoDto } from '../common/backend';
 
 const { t } = useI18n({ useScope: 'global' });
 
 const now = ref<Date>(new Date());
-const admin = ref<BillingDto>();
+const license = ref<LicenseUserInfoDto>();
 
 onMounted(fetchData);
 
 async function fetchData() {
   try {
-    admin.value = await backend.billing.get();
+    license.value = await backend.license.getUserInfo();
   } catch (error) {
-    console.error('Retrieving billing information failed', error);
+    console.error('Retrieving license information failed', error);
   }
 }
 </script>

--- a/frontend/src/components/VaultList.vue
+++ b/frontend/src/components/VaultList.vue
@@ -121,7 +121,7 @@ import { CheckIcon, ChevronRightIcon, ChevronUpDownIcon } from '@heroicons/vue/2
 import { computed, nextTick, onMounted, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import auth from '../common/auth';
-import backend, { VaultDto, LicenseStatusDto } from '../common/backend';
+import backend, { VaultDto, LicenseUserInfoDto } from '../common/backend';
 import FetchError from './FetchError.vue';
 import SlideOver from './SlideOver.vue';
 import VaultDetails from './VaultDetails.vue';
@@ -140,7 +140,7 @@ const ownsSelectedVault = computed(() => {
 });
 
 const isAdmin = ref<boolean>();
-const licenseStatus = ref<LicenseStatusDto>();
+const licenseStatus = ref<LicenseUserInfoDto>();
 const isLicenseSuspicious = computed(() => {
   if (licenseStatus.value) {
     return licenseStatus.value.isExceeded() || licenseStatus.value.isExpired();
@@ -188,7 +188,7 @@ async function fetchData() {
       default:
         throw new Error('Unknown filter');
     }
-    licenseStatus.value = await backend.license.getStatus();
+    licenseStatus.value = await backend.license.getUserInfo();
   } catch (error) {
     console.error('Retrieving vault list failed.', error);
     onFetchError.value = error instanceof Error ? error : new Error('Unknown Error');

--- a/frontend/src/components/VaultList.vue
+++ b/frontend/src/components/VaultList.vue
@@ -8,7 +8,7 @@
     </div>
   </div>
 
-  <LicenseAlert v-if="isAdmin" />
+  <LicenseAlert v-if="isLicenseSuspicious" />
 
   <h2 class="text-2xl font-bold leading-7 text-gray-900 sm:text-3xl sm:truncate">
     {{ t('vaultList.title') }}
@@ -40,7 +40,7 @@
 
     <Menu as="div" class="relative inline-block text-left">
       <div>
-        <MenuButton class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary hover:bg-primary-d1 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary">
+        <MenuButton :disabled="isLicenseSuspicious" class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary hover:bg-primary-d1 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary" :class="{ 'cursor-not-allowed opacity-50': isLicenseSuspicious }">
           {{ t('vaultList.addVault') }}
           <ChevronDownIcon class="-mr-1 ml-2 h-5 w-5" aria-hidden="true" />
         </MenuButton>
@@ -121,7 +121,7 @@ import { CheckIcon, ChevronRightIcon, ChevronUpDownIcon } from '@heroicons/vue/2
 import { computed, nextTick, onMounted, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import auth from '../common/auth';
-import backend, { VaultDto } from '../common/backend';
+import backend, { VaultDto, LicenseStatusDto } from '../common/backend';
 import FetchError from './FetchError.vue';
 import SlideOver from './SlideOver.vue';
 import VaultDetails from './VaultDetails.vue';
@@ -140,6 +140,14 @@ const ownsSelectedVault = computed(() => {
 });
 
 const isAdmin = ref<boolean>();
+const licenseStatus = ref<LicenseStatusDto>();
+const isLicenseSuspicious = computed(() => {
+  if (licenseStatus.value) {
+    return licenseStatus.value.isExceeded() || licenseStatus.value.isExpired();
+  } else {
+    return false;
+  }
+});
 
 const filterOptions = ref< {[key: string]: string} >({
   accessibleVaults: t('vaultList.filter.entry.accessibleVaults'),
@@ -164,7 +172,7 @@ async function fetchData() {
     isAdmin.value = (await auth).isAdmin();
 
     if (isAdmin.value) {
-      filterOptions.value['allVaults'] = t('vaultList.filter.entry.allVaults')
+      filterOptions.value['allVaults'] = t('vaultList.filter.entry.allVaults');
     }
     ownedVaults.value = (await backend.vaults.listAccessible('OWNER')).sort((a, b) => a.name.localeCompare(b.name));
     switch (selectedFilter.value) {
@@ -180,6 +188,7 @@ async function fetchData() {
       default:
         throw new Error('Unknown filter');
     }
+    licenseStatus.value = await backend.license.getStatus();
   } catch (error) {
     console.error('Retrieving vault list failed.', error);
     onFetchError.value = error instanceof Error ? error : new Error('Unknown Error');


### PR DESCRIPTION
Fixes #262.

This PR adds the new REST endpoint `/license`.

This endpoint is intended to give information about the license set in the hub instance. Currently, this endpoint does not have any direct actions, but only a subresource `/license/user-info`. This is intentional, because the longterm goal is to move the `/billing` endpoint to `/license`.

The subresource `/license/user-info` is intended for any user to get necessary information about the license like expiration date and licensed seats.

Remark: The license endpoint could also be used in the `VaultDetails` vue component, but due to a required refactoring there it is not used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Introduced a new `LicenseResource` class to provide endpoints for retrieving license status information.
    - Added `LicenseStatusDto` and `LicenseService` in the frontend to support license status checks and display.
    - Enhanced the Vault List view to show `LicenseAlert` based on license status.

- **Bug Fixes**
    - Corrected the license seats count logic in the billing system.

- **Refactor**
    - Improved logging in `LicenseHolder`.
    - Renamed and updated methods for clarity and testing compatibility.

- **Style**
    - Updated `MenuButton` attributes in `VaultList.vue` for better user interaction based on license status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->