### PR TITLE
Fix archived vault migration during Hub upgrade

### DIFF
--- a/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
@@ -340,12 +340,8 @@ public class VaultResource {
 	@APIResponse(responseCode = "402", description = "number of users granted access exceeds available license seats")
 	@APIResponse(responseCode = "403", description = "not a vault owner")
 	@APIResponse(responseCode = "404", description = "at least one user has not been found")
-	@APIResponse(responseCode = "410", description = "vault is archived")
 	public Response grantAccess(@PathParam("vaultId") UUID vaultId, @NotEmpty Map<String, String> tokens) {
 		var vault = Vault.<Vault>findById(vaultId); // should always be found, since @VaultRole filter would have triggered
-		if (vault.archived) {
-			throw new GoneException("Vault is archived.");
-		}
 
 		// check number of available seats
 		long occupiedSeats = EffectiveVaultAccess.countSeatOccupyingUsers();

--- a/backend/src/test/java/org/cryptomator/hub/api/VaultResourceTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/VaultResourceTest.java
@@ -162,10 +162,10 @@ public class VaultResourceTest {
 		}
 
 		@Test
-		@DisplayName("GET /vaults/7E57C0DE-0000-4000-8000-00010000AAAA/access-token returns 403 for archived vaults with evenIfArchived set to true")
+		@DisplayName("GET /vaults/7E57C0DE-0000-4000-8000-00010000AAAA/access-token returns 200 for archived vaults with evenIfArchived set to true")
 		public void testUnlockArchived3() throws SQLException {
 			when().get("/vaults/{vaultId}/access-token?evenIfArchived=true", "7E57C0DE-0000-4000-8000-00010000AAAA")
-					.then().statusCode(403);
+					.then().statusCode(200);
 		}
 
 		@Nested
@@ -378,11 +378,11 @@ public class VaultResourceTest {
 		}
 
 		@Test
-		@DisplayName("POST /vaults/7E57C0DE-0000-4000-8000-00010000AAAA/access-tokens returns 410")
+		@DisplayName("POST /vaults/7E57C0DE-0000-4000-8000-00010000AAAA/access-tokens returns 200 for user1 and vault archived")
 		public void testGrantAccessArchived() {
 			given().contentType(ContentType.JSON).body(Map.of("user1", "jwe.jwe.jwe.vaultAAA.user1"))
 					.when().post("/vaults/{vaultId}/access-tokens/", "7E57C0DE-0000-4000-8000-00010000AAAA")
-					.then().statusCode(410);
+					.then().statusCode(200);
 		}
 
 	}


### PR DESCRIPTION
Posting new access-tokens does not harm for archived vaults. Hard and soft boundaries are still respected.

Fixes #269

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed restrictions on accessing archived vaults, allowing users to access their archived content without limitations.
	- Updated the response behavior for accessing archived vaults, ensuring users receive a successful status, enhancing usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->