### PR TITLE
Add `create-vaults` role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - This CHANGELOG file
 - WoT: Users will now have an ECDH as well as ECDSA key (#282)
 - WoT: Users can now mutually verify their identity, hardening Hub against injection of malicious public keys (#281)
+- Permission to create new vaults can now be controlled via the `create-vaults` role in Keycloak (#206)
 
 ### Changed
 

--- a/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
@@ -388,7 +388,7 @@ public class VaultResource {
 
 	@PUT
 	@Path("/{vaultId}")
-	@RolesAllowed("user")
+	@RolesAllowed("create-vaults")
 	@VaultRole(value = VaultAccess.Role.OWNER, onMissingVault = VaultRole.OnMissingVault.PASS)
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
@@ -439,7 +439,7 @@ public class VaultResource {
 
 	@POST
 	@Path("/{vaultId}/claim-ownership")
-	@RolesAllowed("user")
+	@RolesAllowed("create-vaults")
 	@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
 	@Transactional
 	@Operation(summary = "claims ownership of a vault",

--- a/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
@@ -388,8 +388,8 @@ public class VaultResource {
 
 	@PUT
 	@Path("/{vaultId}")
-	@RolesAllowed("create-vaults")
-	@VaultRole(value = VaultAccess.Role.OWNER, onMissingVault = VaultRole.OnMissingVault.PASS)
+	@RolesAllowed("user") // general authentication. VaultRole filter will check for specific access rights
+	@VaultRole(value = VaultAccess.Role.OWNER, onMissingVault = VaultRole.OnMissingVault.REQUIRE_REALM_ROLE, realmRole = "create-vaults")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
 	@Transactional
@@ -439,7 +439,7 @@ public class VaultResource {
 
 	@POST
 	@Path("/{vaultId}/claim-ownership")
-	@RolesAllowed("create-vaults")
+	@RolesAllowed("user")
 	@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
 	@Transactional
 	@Operation(summary = "claims ownership of a vault",

--- a/backend/src/main/java/org/cryptomator/hub/filters/VaultRole.java
+++ b/backend/src/main/java/org/cryptomator/hub/filters/VaultRole.java
@@ -31,5 +31,13 @@ public @interface VaultRole {
 	 * @return How to treat the case when a vault does not exist.
 	 */
 	OnMissingVault onMissingVault() default OnMissingVault.FORBIDDEN;
-	enum OnMissingVault { FORBIDDEN, NOT_FOUND, PASS }
+	enum OnMissingVault { FORBIDDEN, NOT_FOUND, PASS, REQUIRE_REALM_ROLE }
+
+	/**
+	 * Which additional realm role is required to access the annotated resource.
+	 *
+	 * Only relevant if {@link #onMissingVault()} is set to {@link OnMissingVault#REQUIRE_REALM_ROLE}.
+	 * @return realm role required to access the annotated resource.
+	 */
+	String realmRole() default "";
 }

--- a/backend/src/main/java/org/cryptomator/hub/filters/VaultRoleFilter.java
+++ b/backend/src/main/java/org/cryptomator/hub/filters/VaultRoleFilter.java
@@ -32,6 +32,7 @@ public class VaultRoleFilter implements ContainerRequestFilter {
 
 	@Inject
 	EffectiveVaultAccess.Repository effectiveVaultAccessRepo;
+
 	@Inject
 	Vault.Repository vaultRepo;
 
@@ -67,6 +68,11 @@ public class VaultRoleFilter implements ContainerRequestFilter {
 				case FORBIDDEN -> throw new ForbiddenException(forbiddenMsg);
 				case NOT_FOUND -> throw new NotFoundException("Vault not found");
 				case PASS -> {}
+				case REQUIRE_REALM_ROLE -> {
+					if (!requestContext.getSecurityContext().isUserInRole(annotation.realmRole())) {
+						throw new ForbiddenException("Missing role " + annotation.realmRole());
+					}
+				}
 			}
 		}
 	}

--- a/backend/src/main/resources/dev-realm.json
+++ b/backend/src/main/resources/dev-realm.json
@@ -17,12 +17,18 @@
         "composite": false
       },
       {
+        "name": "create-vaults",
+        "description": "Can create vaults",
+        "composite": false
+      },
+      {
         "name": "admin",
         "description": "Administrator",
         "composite": true,
         "composites": {
           "realm": [
-            "user"
+            "user",
+            "create-vaults"
           ],
           "client": {
             "realm-management": [
@@ -73,7 +79,7 @@
       "email": "alice@localhost",
       "enabled": true,
       "credentials": [{"type": "password", "value": "asd"}],
-      "realmRoles": ["user"]
+      "realmRoles": ["user", "create-vaults"]
     },
     {
       "username": "bob",
@@ -82,7 +88,7 @@
       "email": "bob@localhost",
       "enabled": true,
       "credentials": [{"type": "password", "value": "asd"}],
-      "realmRoles": ["user"]
+      "realmRoles": ["user", "create-vaults"]
     },
     {
       "username": "carol",

--- a/backend/src/test/java/org/cryptomator/hub/api/VaultResourceIT.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/VaultResourceIT.java
@@ -241,22 +241,10 @@ public class VaultResourceIT {
 			when().get("/vaults/{vaultId}/access-token", "7E57C0DE-0000-4000-8000-000100001111")
 					.then().statusCode(449);
 		}
-	}
-
-	@Nested
-	@DisplayName("As vault admin user1")
-	@TestSecurity(user = "User Name 1", roles = {"create-vaults"})
-	@OidcSecurity(claims = {
-			@Claim(key = "sub", value = "user1")
-	})
-	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-	public class CreateVaults {
 
 		@Test
-		@Order(1)
-		@TestSecurity(user = "User Name 1", roles = {"user"})
 		@DisplayName("PUT /vaults/7E57C0DE-0000-4000-8000-000100003333 returns 403 for missing role")
-		public void testCreteVaultWithMissingRole() {
+		public void testCreateVaultWithMissingRole() {
 			var uuid = UUID.fromString("7E57C0DE-0000-4000-8000-000100003333");
 			var vaultDto = new VaultResource.VaultDto(uuid, "My Vault", "Test vault 3", false, Instant.parse("2112-12-21T21:12:21Z"), "masterkey3", 42, "NaCl", "authPubKey3", "authPrvKey3");
 
@@ -264,6 +252,17 @@ public class VaultResourceIT {
 					.when().put("/vaults/{vaultId}", "7E57C0DE-0000-4000-8000-000100003333")
 					.then().statusCode(403);
 		}
+
+	}
+
+	@Nested
+	@DisplayName("As vault admin user1")
+	@TestSecurity(user = "User Name 1", roles = {"user", "create-vaults"})
+	@OidcSecurity(claims = {
+			@Claim(key = "sub", value = "user1")
+	})
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	public class CreateVaults {
 
 		@Test
 		@Order(1)
@@ -845,7 +844,7 @@ public class VaultResourceIT {
 
 	@Nested
 	@DisplayName("Claim Ownership")
-	@TestSecurity(user = "User Name 1", roles = {"create-vaults"})
+	@TestSecurity(user = "User Name 1", roles = {"user"})
 	@OidcSecurity(claims = {
 			@Claim(key = "sub", value = "user1")
 	})
@@ -1005,23 +1004,6 @@ public class VaultResourceIT {
 			given().param("proof", proof)
 					.when().post("/vaults/{vaultId}/claim-ownership", "7E57C0DE-0000-4000-8000-BADBADBADBAD")
 					.then().statusCode(404);
-		}
-
-		@Test
-		@Order(1)
-		@TestSecurity(user = "User Name 1", roles = {"user"})
-		@DisplayName("POST /vaults/7E57C0DE-0000-4000-8000-000100009999/claim-ownership returns 403 for missing role")
-		public void testClaimOwnershipWithMissingRole() {
-			var proof = JWT.create()
-					.withNotBefore(Instant.now().minusSeconds(10))
-					.withExpiresAt(Instant.now().plusSeconds(10))
-					.withSubject("user1")
-					.withClaim("vaultId", "7E57C0DE-0000-4000-8000-000100009999".toLowerCase())
-					.sign(JWT_ALG);
-
-			given().param("proof", proof)
-					.when().post("/vaults/{vaultId}/claim-ownership", "7E57C0DE-0000-4000-8000-000100009999")
-					.then().statusCode(403);
 		}
 
 		@Test

--- a/frontend/src/common/auth.ts
+++ b/frontend/src/common/auth.ts
@@ -45,12 +45,8 @@ class Auth {
     return this.keycloak.token;
   }
 
-  public isAdmin(): boolean {
-    return this.keycloak.tokenParsed?.realm_access?.roles.includes('admin') ?? false;
-  }
-
-  public isUser(): boolean {
-    return this.keycloak.tokenParsed?.realm_access?.roles.includes('user') ?? false;
+  public hasRole(role: string): boolean {
+    return this.keycloak.tokenParsed?.realm_access?.roles.includes(role) ?? false;
   }
 }
 

--- a/frontend/src/components/Forbidden.vue
+++ b/frontend/src/components/Forbidden.vue
@@ -1,0 +1,18 @@
+<template>
+  <div class="bg-white min-h-full px-4 py-16 sm:px-6 sm:py-24 md:grid md:place-items-center lg:px-8">
+    <div class="max-w-max mx-auto">
+      <main class="sm:flex">
+        <p class="text-4xl font-extrabold text-primary sm:text-5xl">403</p>
+        <div class="sm:ml-6">
+          <div class="sm:border-l sm:border-gray-200 sm:pl-6">
+            <h1 class="text-4xl font-extrabold text-gray-900 tracking-tight sm:text-5xl">Forbidden</h1>
+            <p class="mt-1 text-base text-gray-500">You don't have the permission to access this page.</p>
+          </div>
+          <div class="mt-10 flex space-x-3 sm:border-l sm:border-transparent sm:pl-6">
+            <router-link to="/app/vaults" class="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-primary focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"> Go back home </router-link>
+          </div>
+        </div>
+      </main>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/NavigationBar.vue
+++ b/frontend/src/components/NavigationBar.vue
@@ -107,7 +107,7 @@ const props = defineProps<{
 }>();
 
 onMounted(async () => {
-  if ((await auth).isAdmin()) {
+  if ((await auth).hasRole('admin')) {
     profileDropdown.value = [profileDropdownSections.infoSection, profileDropdownSections.adminSection, profileDropdownSections.hubSection];
   } else {
     profileDropdown.value = [profileDropdownSections.infoSection, profileDropdownSections.hubSection];

--- a/frontend/src/components/VaultDetails.vue
+++ b/frontend/src/components/VaultDetails.vue
@@ -283,7 +283,7 @@ onMounted(fetchData);
 async function fetchData() {
   onFetchError.value = null;
   try {
-    isAdmin.value = (await auth).isAdmin();
+    isAdmin.value = (await auth).hasRole('admin');
     vault.value = await backend.vaults.get(props.vaultId);
     me.value = await userdata.me;
     license.value = await backend.license.getUserInfo();

--- a/frontend/src/components/VaultList.vue
+++ b/frontend/src/components/VaultList.vue
@@ -177,7 +177,7 @@ onMounted(fetchData);
 async function fetchData() {
   onFetchError.value = null;
   try {
-    isAdmin.value = (await auth).isAdmin();
+    isAdmin.value = (await auth).hasRole('admin');
 
     if (isAdmin.value) {
       filterOptions.value['allVaults'] = t('vaultList.filter.entry.allVaults');

--- a/frontend/src/components/VaultList.vue
+++ b/frontend/src/components/VaultList.vue
@@ -40,7 +40,7 @@
 
     <Menu as="div" class="relative inline-block text-left">
       <div>
-        <MenuButton :disabled="isLicenseViolated || !canCreateVaults" class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary hover:bg-primary-d1 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary" :class="{ 'cursor-not-allowed opacity-50': isLicenseViolated || !canCreateVaults }">
+        <MenuButton :disabled="isLicenseViolated || !canCreateVaults" class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary hover:bg-primary-d1 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary disabled:cursor-not-allowed disabled:opacity-50">
           {{ t('vaultList.addVault') }}
           <ChevronDownIcon class="-mr-1 ml-2 h-5 w-5" aria-hidden="true" />
         </MenuButton>
@@ -147,8 +147,8 @@ const roleOfSelectedVault = computed<VaultRole | 'NONE'>(() => {
   }
 });
 
-const isAdmin = ref<boolean>();
-const canCreateVaults = ref<boolean>();
+const isAdmin = ref<boolean>(false);
+const canCreateVaults = ref<boolean>(false);
 const licenseStatus = ref<LicenseUserInfoDto>();
 const isLicenseViolated = computed(() => {
   if (licenseStatus.value) {

--- a/frontend/src/components/VaultList.vue
+++ b/frontend/src/components/VaultList.vue
@@ -40,7 +40,7 @@
 
     <Menu as="div" class="relative inline-block text-left">
       <div>
-        <MenuButton :disabled="isLicenseViolated || !canCreateVaults" class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary hover:bg-primary-d1 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary disabled:cursor-not-allowed disabled:opacity-50">
+        <MenuButton :disabled="isLicenseViolated || !canCreateVaults" class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary hover:bg-primary-d1 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary disabled:cursor-not-allowed disabled:opacity-50" :title="isLicenseViolated ? t('vaultList.addVault.disabled.licenseViolation') : canCreateVaults ? undefined : t('vaultList.addVault.disabled.missingPermission')">
           {{ t('vaultList.addVault') }}
           <ChevronDownIcon class="-mr-1 ml-2 h-5 w-5" aria-hidden="true" />
         </MenuButton>
@@ -98,7 +98,7 @@
       <path vector-effect="non-scaling-stroke" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10.5v6m3-3H9m4.06-7.19l-2.12-2.12a1.5 1.5 0 00-1.061-.44H4.5A2.25 2.25 0 002.25 6v12a2.25 2.25 0 002.25 2.25h15A2.25 2.25 0 0021.75 18V9a2.25 2.25 0 00-2.25-2.25h-5.379a1.5 1.5 0 01-1.06-.44z" />
     </svg>
     <h3 class="mt-2 text-sm font-medium text-gray-900">{{ t('vaultList.empty.title') }}</h3>
-    <p class="mt-1 text-sm text-gray-500">{{ t('vaultList.empty.description') }}</p>
+    <p v-if="canCreateVaults" class="mt-1 text-sm text-gray-500">{{ t('vaultList.empty.description') }}</p>
   </div>
 
   <div v-else-if="query !== '' && filteredVaults != null && filteredVaults.length == 0" class="mt-3 text-center">

--- a/frontend/src/components/VaultList.vue
+++ b/frontend/src/components/VaultList.vue
@@ -40,7 +40,7 @@
 
     <Menu as="div" class="relative inline-block text-left">
       <div>
-        <MenuButton :disabled="isLicenseViolated" class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary hover:bg-primary-d1 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary" :class="{ 'cursor-not-allowed opacity-50': isLicenseViolated }">
+        <MenuButton :disabled="isLicenseViolated || !canCreateVaults" class="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary hover:bg-primary-d1 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary" :class="{ 'cursor-not-allowed opacity-50': isLicenseViolated || !canCreateVaults }">
           {{ t('vaultList.addVault') }}
           <ChevronDownIcon class="-mr-1 ml-2 h-5 w-5" aria-hidden="true" />
         </MenuButton>
@@ -148,6 +148,7 @@ const roleOfSelectedVault = computed<VaultRole | 'NONE'>(() => {
 });
 
 const isAdmin = ref<boolean>();
+const canCreateVaults = ref<boolean>();
 const licenseStatus = ref<LicenseUserInfoDto>();
 const isLicenseViolated = computed(() => {
   if (licenseStatus.value) {
@@ -178,6 +179,7 @@ async function fetchData() {
   onFetchError.value = null;
   try {
     isAdmin.value = (await auth).hasRole('admin');
+    canCreateVaults.value = (await auth).hasRole('create-vaults');
 
     if (isAdmin.value) {
       filterOptions.value['allVaults'] = t('vaultList.filter.entry.allVaults');

--- a/frontend/src/i18n/de-DE.json
+++ b/frontend/src/i18n/de-DE.json
@@ -244,6 +244,8 @@
   "vaultList.empty.title": "Keine Tresore",
   "vaultList.empty.description": "Beginne mit der Erstellung eines neuen Tresors.",
   "vaultList.addVault": "Hinzufügen",
+  "vaultList.addVault.disabled.licenseViolation": "Lizenz überschritten.",
+  "vaultList.addVault.disabled.missingPermission": "Die fehlt die Berechtigung zur Erstellung von Tresoren.",
   "vaultList.addVault.create": "Neu erstellen",
   "vaultList.addVault.recover": "Wiederherstellen",
   "vaultList.filter": "Filter",

--- a/frontend/src/i18n/en-US.json
+++ b/frontend/src/i18n/en-US.json
@@ -245,6 +245,8 @@
   "vaultList.empty.title": "No vaults",
   "vaultList.empty.description": "Get started by creating a new vault.",
   "vaultList.addVault": "Add",
+  "vaultList.addVault.disabled.licenseViolation": "License limit exceeded.",
+  "vaultList.addVault.disabled.missingPermission": "You don't have permission to create a vault.",
   "vaultList.addVault.create": "Create New",
   "vaultList.addVault.recover": "Recover Existing",
   "vaultList.filter": "Filter",

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -17,11 +17,12 @@ import VaultList from '../components/VaultList.vue';
 import Forbidden from '../components/Forbidden.vue';
 
 function checkRole(role: string): NavigationGuardWithThis<undefined> {
-  return async () => {
+  return async (to, _) => {
     const auth = await authPromise;
     if (auth.hasRole(role)) {
       return true;
     } else {
+      console.warn(`Access denied: User requires role ${role} to access ${to.fullPath}`);
       return { path: '/app/forbidden', replace: true };
     }
   };

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -72,7 +72,7 @@ const routes: RouteRecordRaw[] = [
         path: 'admin',
         beforeEnter: async () => {
           const auth = await authPromise;
-          return auth.isAdmin(); //TODO: reroute to NotFound Screen/ AccessDeniedScreen?
+          return auth.hasRole('admin'); //TODO: reroute to NotFound Screen/ AccessDeniedScreen?
         },
         children: [
           {


### PR DESCRIPTION
This PR fixes #206 by introducing the `create-vaults` role.

Note that the `dev-realm` adds this role only for users `admin`, `alice` and `bob`, while the users `carol`, `dave` and `erin` are not allowed to create vaults.