### PR TITLE
Feature: Strip Whitespace from Entered Account Key

### DIFF
--- a/frontend/src/components/InitialSetup.vue
+++ b/frontend/src/components/InitialSetup.vue
@@ -281,6 +281,7 @@ async function recoverUserKey() {
   onRecoverError.value = null;
   try {
     processing.value = true;
+    setupCode.value = setupCode.value.trim();
 
     const me = await userdata.me;
     const userKeys = await userdata.decryptUserKeysWithSetupCode(setupCode.value);


### PR DESCRIPTION
This PR addresses issue https://github.com/cryptomator/hub/issues/280, where Cryptomator Hub was not accepting account keys that contained leading or trailing spaces.
To resolve this, trim() has been added to the account key input handling, ensuring that any pre- or post-fixed whitespace is removed before the key is processed.