### PR TITLE
Feature: Add member count for groups in VaultDetail view

### DIFF
--- a/backend/src/main/java/org/cryptomator/hub/api/AuthorityDto.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/AuthorityDto.java
@@ -33,7 +33,7 @@ abstract sealed class AuthorityDto permits UserDto, GroupDto, MemberDto {
 	}
 
 	@Inject
-	static User.Repository userRepo; // Inject User Repository für die neue Berechnung
+	static User.Repository userRepo;
 
 	static AuthorityDto fromEntity(Authority a) {
 		return switch (a) {

--- a/backend/src/main/java/org/cryptomator/hub/api/AuthorityDto.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/AuthorityDto.java
@@ -33,7 +33,7 @@ abstract sealed class AuthorityDto permits UserDto, GroupDto, MemberDto {
 	static AuthorityDto fromEntity(Authority a) {
 		return switch (a) {
 			case User u -> UserDto.justPublicInfo(u);
-			case Group g -> GroupDto.fromEntity(g);
+			case Group g -> new GroupDto(g.getId(), g.getName(), (int) g.getMemberCount());
 			default -> throw new IllegalStateException("authority is not of type user or group");
 		};
 	}

--- a/backend/src/main/java/org/cryptomator/hub/api/AuthorityDto.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/AuthorityDto.java
@@ -5,6 +5,8 @@ import org.cryptomator.hub.entities.Authority;
 import org.cryptomator.hub.entities.Group;
 import org.cryptomator.hub.entities.User;
 
+import jakarta.inject.Inject;
+
 abstract sealed class AuthorityDto permits UserDto, GroupDto, MemberDto {
 
 	public enum Type {
@@ -30,10 +32,13 @@ abstract sealed class AuthorityDto permits UserDto, GroupDto, MemberDto {
 		this.pictureUrl = pictureUrl;
 	}
 
+	@Inject
+	static User.Repository userRepo; // Inject User Repository für die neue Berechnung
+
 	static AuthorityDto fromEntity(Authority a) {
 		return switch (a) {
 			case User u -> UserDto.justPublicInfo(u);
-			case Group g -> new GroupDto(g.getId(), g.getName(), (int) g.getMemberCount());
+			case Group g -> new GroupDto(g.getId(), g.getName(), (int) userRepo.getEffectiveGroupUsers(g.getId()).count()); 
 			default -> throw new IllegalStateException("authority is not of type user or group");
 		};
 	}

--- a/backend/src/main/java/org/cryptomator/hub/api/AuthorityResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/AuthorityResource.java
@@ -25,7 +25,7 @@ public class AuthorityResource {
 	Authority.Repository authorityRepo;
 	
 	@Inject
-	User.Repository userRepo; // UserRepo wird hier für die Gruppen-Mitgliederanzahl benötigt
+	User.Repository userRepo;
 
 	@GET
 	@Path("/search")
@@ -36,7 +36,7 @@ public class AuthorityResource {
 	public List<AuthorityDto> search(@QueryParam("query") @NotBlank String query) {
 		List<Authority> authorities = authorityRepo.byName(query).toList(); 
 		return authorities.stream()
-			.map(this::convertToDto) // Neue Methode für die Konvertierung mit Member-Anzahl
+			.map(this::convertToDto)
 			.toList();
 	}
 
@@ -49,14 +49,10 @@ public class AuthorityResource {
 	@APIResponse(responseCode = "200")
 	public List<AuthorityDto> getSome(@QueryParam("ids") List<String> authorityIds) {
 		return authorityRepo.findAllInList(authorityIds)
-			.map(this::convertToDto) // Neue Methode wird hier genutzt
+			.map(this::convertToDto)
 			.toList();
 	}
 
-	/**
-	 * Konvertiert eine Authority-Entity in das passende DTO,
-	 * inklusive der Gruppen-Mitgliederanzahl für Gruppen.
-	 */
 	private AuthorityDto convertToDto(Authority a) {
 		if (a instanceof User u) {
 			return UserDto.justPublicInfo(u);

--- a/backend/src/main/java/org/cryptomator/hub/api/AuthorityResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/AuthorityResource.java
@@ -29,7 +29,10 @@ public class AuthorityResource {
 	@NoCache
 	@Operation(summary = "search authority by name")
 	public List<AuthorityDto> search(@QueryParam("query") @NotBlank String query) {
-		return authorityRepo.byName(query).map(AuthorityDto::fromEntity).toList();
+		List<Authority> authorities = authorityRepo.byName(query).toList(); 
+		return authorities.stream()
+			.map(AuthorityDto::fromEntity)
+			.toList();
 	}
 
 	@GET

--- a/backend/src/main/java/org/cryptomator/hub/api/AuthorityResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/AuthorityResource.java
@@ -9,6 +9,8 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import org.cryptomator.hub.entities.Authority;
+import org.cryptomator.hub.entities.Group;
+import org.cryptomator.hub.entities.User;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.jboss.resteasy.reactive.NoCache;
@@ -21,6 +23,9 @@ public class AuthorityResource {
 
 	@Inject
 	Authority.Repository authorityRepo;
+	
+	@Inject
+	User.Repository userRepo; // UserRepo wird hier für die Gruppen-Mitgliederanzahl benötigt
 
 	@GET
 	@Path("/search")
@@ -31,7 +36,7 @@ public class AuthorityResource {
 	public List<AuthorityDto> search(@QueryParam("query") @NotBlank String query) {
 		List<Authority> authorities = authorityRepo.byName(query).toList(); 
 		return authorities.stream()
-			.map(AuthorityDto::fromEntity)
+			.map(this::convertToDto) // Neue Methode für die Konvertierung mit Member-Anzahl
 			.toList();
 	}
 
@@ -43,7 +48,24 @@ public class AuthorityResource {
 	@Operation(summary = "lists all authorities matching the given ids", description = "lists for each id in the list its corresponding authority. Ignores all id's where an authority cannot be found")
 	@APIResponse(responseCode = "200")
 	public List<AuthorityDto> getSome(@QueryParam("ids") List<String> authorityIds) {
-		return authorityRepo.findAllInList(authorityIds).map(AuthorityDto::fromEntity).toList();
+		return authorityRepo.findAllInList(authorityIds)
+			.map(this::convertToDto) // Neue Methode wird hier genutzt
+			.toList();
+	}
+
+	/**
+	 * Konvertiert eine Authority-Entity in das passende DTO,
+	 * inklusive der Gruppen-Mitgliederanzahl für Gruppen.
+	 */
+	private AuthorityDto convertToDto(Authority a) {
+		if (a instanceof User u) {
+			return UserDto.justPublicInfo(u);
+		} else if (a instanceof Group g) {
+			int memberCount = (int) userRepo.getEffectiveGroupUsers(g.getId()).count();
+			return new GroupDto(g.getId(), g.getName(), memberCount);
+		} else {
+			throw new IllegalStateException("authority is not of type user or group");
+		}
 	}
 
 }

--- a/backend/src/main/java/org/cryptomator/hub/api/GroupDto.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/GroupDto.java
@@ -5,12 +5,19 @@ import org.cryptomator.hub.entities.Group;
 
 public final class GroupDto extends AuthorityDto {
 
-	GroupDto(@JsonProperty("id") String id, @JsonProperty("name") String name) {
-		super(id, Type.GROUP, name, null);
-	}
+    private final int memberCount;
 
-	public static GroupDto fromEntity(Group group) {
-		return new GroupDto(group.getId(), group.getName());
-	}
+    GroupDto(@JsonProperty("id") String id, @JsonProperty("name") String name, @JsonProperty("memberCount") int memberCount) {
+        super(id, Type.GROUP, name, null);
+        this.memberCount = memberCount;
+    }
 
+    @JsonProperty("memberCount")
+    public int getMemberCount() {
+        return memberCount;
+    }
+
+    public static GroupDto fromEntity(Group group, int memberCount) {
+        return new GroupDto(group.getId(), group.getName(), memberCount);
+    }
 }

--- a/backend/src/main/java/org/cryptomator/hub/api/GroupsResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/GroupsResource.java
@@ -33,20 +33,7 @@ public class GroupsResource {
 	@Operation(summary = "list all groups")
 	public List<GroupDto> getAll() {
 		List<Group> groups = groupRepo.findAll().list();
-		return groups.stream().map(group -> {
-			long memberCount = groupRepo.countMembers(group.getId());
-			return new GroupDto(group.getId(), group.getName(), (int) memberCount);
-		}).toList();
-	}
-
-	@GET
-	@Path("/{groupId}/memberCount")
-	@RolesAllowed("user")
-	@Produces(MediaType.APPLICATION_JSON)
-	@Operation(summary = "Get member count of a group")
-	public Response getMemberCount(@PathParam("groupId") String groupId) {
-		long count = userRepo.getEffectiveGroupUsers(groupId).count();
-		return Response.ok(Map.of("count", count)).build();
+		return groups.stream().map(group -> GroupDto.fromEntity(group, groupRepo.countMembers(group.getId()))).toList();
 	}
 
 	@GET

--- a/backend/src/main/java/org/cryptomator/hub/api/GroupsResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/GroupsResource.java
@@ -2,21 +2,20 @@ package org.cryptomator.hub.api;
 
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
-
 import org.cryptomator.hub.entities.Group;
 import org.cryptomator.hub.entities.User;
 import org.cryptomator.hub.validation.ValidId;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 
-import jakarta.ws.rs.core.Response;
-import java.util.Map;
-import java.util.HashMap;
 import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
 @Path("/groups")
 public class GroupsResource {

--- a/backend/src/main/java/org/cryptomator/hub/entities/Group.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/Group.java
@@ -33,7 +33,18 @@ public class Group extends Authority {
 		this.members = members;
 	}
 
+	public int getMemberCount() {
+		return members != null ? members.size() : 0;
+	}
+
 	@ApplicationScoped
 	public static class Repository implements PanacheRepositoryBase<Group, String> {
+
+		public long countMembers(String groupId) {
+			return getEntityManager()
+					.createQuery("SELECT COUNT(m) FROM Group g JOIN g.members m WHERE g.id = :groupId", Long.class)
+					.setParameter("groupId", groupId)
+					.getSingleResult();
+		}
 	}
 }

--- a/backend/src/main/java/org/cryptomator/hub/entities/Group.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/Group.java
@@ -13,7 +13,7 @@ import java.util.Set;
 @DiscriminatorValue("GROUP")
 public class Group extends Authority {
 
-	@ManyToMany(cascade = {CascadeType.REMOVE}, fetch = FetchType.LAZY)
+	@ManyToMany(cascade = {CascadeType.REMOVE})
 	@JoinTable(name = "group_membership",
 			joinColumns = @JoinColumn(name = "group_id", referencedColumnName = "id"),
 			inverseJoinColumns = @JoinColumn(name = "member_id", referencedColumnName = "id")
@@ -31,14 +31,12 @@ public class Group extends Authority {
 		this.members = members;
 	}
 
-
 	public int getMemberCount() {
-		return groupRepo.countMembers(this.getId()); // Verwende das injectete Repository
+		return groupRepo.countMembers(this.getId());
 	}
 
 	@ApplicationScoped
 	public static class Repository implements PanacheRepositoryBase<Group, String> {
-
 		public int countMembers(String groupId) {
 			return getEntityManager()
 					.createQuery("SELECT SIZE(g.members) FROM Group g WHERE g.id = :groupId", Integer.class)

--- a/frontend/src/common/backend.ts
+++ b/frontend/src/common/backend.ts
@@ -89,9 +89,9 @@ export type GroupDto = {
 
 class GroupService {
   public async getMemberCount(groupId: string): Promise<number> {
-    return axiosAuth.get<{ count: number }>(`/groups/${groupId}/memberCount`)
-      .then(response => response.data.count)
-      .catch(error => rethrowAndConvertIfExpected(error, 404));
+    return axiosAuth.get<UserDto[]>(`/groups/${groupId}/effective-members`)
+      .then(response => response.data.length)
+      .catch(() => 0);
   }
 }
 

--- a/frontend/src/common/backend.ts
+++ b/frontend/src/common/backend.ts
@@ -84,6 +84,15 @@ export type GroupDto = {
   id: string;
   name: string;
   pictureUrl?: string;
+  memberCount: number;
+}
+
+class GroupService {
+  public async getMemberCount(groupId: string): Promise<number> {
+    return axiosAuth.get<{ count: number }>(`/groups/${groupId}/memberCount`)
+      .then(response => response.data.count)
+      .catch(error => rethrowAndConvertIfExpected(error, 404));
+  }
 }
 
 export type AuthorityDto = UserDto | GroupDto;
@@ -385,7 +394,8 @@ const services = {
   billing: new BillingService(),
   version: new VersionService(),
   license: new LicenseService(),
-  settings: new SettingsService()
+  settings: new SettingsService(),
+  groups: new GroupService()
 };
 
 export default services;

--- a/frontend/src/components/SearchInputGroup.vue
+++ b/frontend/src/components/SearchInputGroup.vue
@@ -5,18 +5,32 @@
         <div class="relative">
           <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
             <UsersIcon v-if="selectedItem == null" class="h-5 w-5 text-gray-400" aria-hidden="true" />
-            <img v-else :src="selectedItem.pictureUrl ?? ''" alt="" class="w-5 h-5 rounded-full" >
+            <img v-else :src="selectedItem.pictureUrl ?? ''" alt="" class="w-5 h-5 rounded-full">
           </div>
 
-          <ComboboxInput v-if="selectedItem == null" v-focus class="w-full h-10 rounded-l-md border border-gray-300 bg-white py-2 px-10 shadow-xs focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary sm:text-sm disabled:bg-primary-l2" placeholder="John Doe" @change="query = $event.target.value"/>
-          <input v-else v-model="selectedItem.name" class="w-full h-10 rounded-l-md border border-gray-300 bg-primary-l2 py-2 px-10 shadow-xs focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary sm:text-sm" readonly />
-        </div>
+          <ComboboxInput 
+            v-if="selectedItem == null" 
+            v-focus 
+            class="w-full h-10 rounded-l-md border border-gray-300 bg-white py-2 pl-10 pr-3 shadow-xs focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary sm:text-sm disabled:bg-primary-l2" 
+            placeholder="John Doe" 
+            @change="query = $event.target.value"
+          />
 
+          <div v-else class="w-full h-10 rounded-l-md border border-gray-300 bg-primary-l2 py-2 pl-10 pr-3 flex items-center justify-between shadow-xs sm:text-sm">
+            <span class="truncate">{{ selectedItem.name }}</span>
+            <span v-if="selectedItem.type === 'GROUP' && 'memberCount' in selectedItem" class="text-gray-500 text-xs italic mr-6">
+              {{ selectedItem.memberCount }} {{ t('vaultDetails.sharedWith.members') }}
+            </span>
+          </div>
+        </div>
         <ComboboxOptions v-if="selectedItem == null && filteredItems.length > 0" class="absolute z-10 mt-1 max-h-56 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black/5 focus:outline-hidden sm:text-sm">
           <ComboboxOption v-for="item in filteredItems" :key="item.id" :value="item" class="relative cursor-default select-none py-2 pl-3 pr-9 ui-not-active:text-gray-900 ui-active:bg-primary ui-active:text-white">
             <div class="flex items-center">
               <img :src="item.pictureUrl ?? ''" alt="" class="h-6 w-6 shrink-0 rounded-full" >
               <span class="ml-3 truncate">{{ item.name }}</span>
+              <span v-if="'memberCount' in item && item.memberCount !== undefined" class="ml-auto text-xs text-gray-500 italic">
+                {{ item.memberCount }} {{ t('vaultDetails.sharedWith.members') }}
+              </span>
             </div>
           </ComboboxOption>
         </ComboboxOptions>
@@ -38,12 +52,15 @@ import { Combobox, ComboboxInput, ComboboxOption, ComboboxOptions } from '@headl
 import { UsersIcon, XCircleIcon } from '@heroicons/vue/24/solid';
 import { computed, nextTick, ref, shallowRef, watch } from 'vue';
 import { debounce } from '../common/util';
+import { useI18n } from 'vue-i18n';
 
 export type Item = {
   id: string;
   name: string;
   pictureUrl?: string;
 }
+
+const { t } = useI18n({ useScope: 'global' });
 
 const props = defineProps<{
   actionTitle: string

--- a/frontend/src/components/SearchInputGroup.vue
+++ b/frontend/src/components/SearchInputGroup.vue
@@ -5,7 +5,7 @@
         <div class="relative">
           <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
             <UsersIcon v-if="selectedItem == null" class="h-5 w-5 text-gray-400" aria-hidden="true" />
-            <img v-else :src="selectedItem.pictureUrl ?? ''" alt="" class="w-5 h-5 rounded-full">
+            <img v-else :src="selectedItem.pictureUrl ?? ''" alt="" class="w-5 h-5 rounded-full" >
           </div>
 
           <ComboboxInput 

--- a/frontend/src/components/VaultDetails.vue
+++ b/frontend/src/components/VaultDetails.vue
@@ -308,8 +308,7 @@ async function fetchOwnerData() {
     for (const member of fetchedMembers) {
       if (member.type === "GROUP") {
         try {
-          const res = await backend.groups.getMemberCount(member.id);
-          const count = typeof res === "number" ? res : (res as { count: number })?.count ?? 0;
+          const count = await backend.groups.getMemberCount(member.id);
           members.value.set(member.id, { ...member, memberCount: count });
         } catch (error) {
           members.value.set(member.id, { ...member, memberCount: 0 });
@@ -339,14 +338,15 @@ async function fetchOwnerData() {
 }
 
 const groupMemberCounts = computed(() => {
-  const counts = new Map<string, number>();
-  members.value.forEach((member) => {
-    if (member.type === 'GROUP') {
-      counts.set(member.id, member.memberCount ?? 0);
-    }
-  });
-  return counts;
+    const counts = new Map<string, number>();
+    members.value.forEach((member) => {
+        if (member.type === 'GROUP' && 'memberCount' in member) {
+            counts.set(member.id, member.memberCount);
+        }
+    });
+    return counts;
 });
+
 
 async function loadVaultKeys(vaultKeyJwe: string): Promise<VaultKeys> {
   const userKeys = await userdata.decryptUserKeysWithBrowser();
@@ -515,8 +515,7 @@ async function searchAuthority(query: string): Promise<(AuthorityDto & { memberC
     filtered.map(async authority => {
       if (authority.type === "GROUP") {
         try {
-          const res = await backend.groups.getMemberCount(authority.id);
-          const count = typeof res === "number" ? res : (res as { count: number })?.count ?? 0;
+          const count = await backend.groups.getMemberCount(authority.id);
           return { ...authority, memberCount: count };
         } catch (error) {
           return { ...authority, memberCount: 0 };

--- a/frontend/src/components/VaultDetails.vue
+++ b/frontend/src/components/VaultDetails.vue
@@ -347,7 +347,6 @@ const groupMemberCounts = computed(() => {
     return counts;
 });
 
-
 async function loadVaultKeys(vaultKeyJwe: string): Promise<VaultKeys> {
   const userKeys = await userdata.decryptUserKeysWithBrowser();
   return VaultKeys.decryptWithUserKey(vaultKeyJwe, userKeys.ecdhKeyPair.privateKey);
@@ -496,16 +495,7 @@ function refreshVault(updatedVault: VaultDto) {
   emit('vaultUpdated', updatedVault);
 }
 
-const searchQuery = ref('');
 const searchResults = ref<Array<AuthorityDto & { memberCount?: number }>>([]);
-
-async function onSearch() {
-  if (!searchQuery.value) {
-    searchResults.value = [];
-    return;
-  }
-  searchResults.value = await searchAuthority(searchQuery.value);
-}
 
 async function searchAuthority(query: string): Promise<(AuthorityDto & { memberCount?: number })[]> {
   const results = await backend.authorities.search(query);
@@ -526,16 +516,6 @@ async function searchAuthority(query: string): Promise<(AuthorityDto & { memberC
   );
   return enhanced.sort((a, b) => a.name.localeCompare(b.name));
 }
-
-const searchGroupMemberCounts = computed(() => {
-  const counts = new Map<string, number>();
-  searchResults.value.forEach((result) => {
-    if (result.type === 'GROUP') {
-      counts.set(result.id, result.memberCount ?? 0);
-    }
-  });
-  return counts;
-});
 
 async function updateMemberRole(member: MemberDto, role: VaultRole) {
   delete onUpdateVaultMembershipError.value[member.id];

--- a/frontend/src/i18n/en-US.json
+++ b/frontend/src/i18n/en-US.json
@@ -257,6 +257,7 @@
   "vaultDetails.sharedWith.title": "Shared with",
   "vaultDetails.sharedWith.badge.owner": "Owner",
   "vaultDetails.sharedWith.grantOwnership": "Grant Ownership",
+  "vaultDetails.sharedWith.members": "Members",
   "vaultDetails.sharedWith.revokeOwnership": "Revoke Ownership",
   "vaultDetails.actions.title": "Actions",
   "vaultDetails.actions.updatePermissions": "Update Permissions",


### PR DESCRIPTION
This PR addresses [#173](https://github.com/cryptomator/hub/issues/173) by displaying the number of members for shared groups in the VaultDetail view. 

The member count appears as italicized gray text (e.g., 3 Members) next to group names. 

This information is visible both in the search results and the "Shared with" list, helping distinguish groups from individual users.
<img width="449" alt="Search output" src="https://github.com/user-attachments/assets/b175b811-459b-4c9f-b6d1-34af58bc61e5" />
<img width="452" alt="Search selected" src="https://github.com/user-attachments/assets/ae5ed718-0d9e-47d6-a51c-cc1a546fdb3f" />
<img width="445" alt="Shared with list" src="https://github.com/user-attachments/assets/25d3371e-3b72-4d1b-a67b-a117f8c6f871" />
