### PR TITLE
Feature: Add "Browser Language" Option to Language Selection

### DIFF
--- a/frontend/src/components/UserProfile.vue
+++ b/frontend/src/components/UserProfile.vue
@@ -33,7 +33,7 @@
               </ListboxButton>
               <transition leave-active-class="transition ease-in duration-100" leave-from-class="opacity-100" leave-to-class="opacity-0">
                 <ListboxOptions class="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 shadow-lg ring-1 ring-black/5 focus:outline-hidden text-sm">
-                  <ListboxOption v-slot="{ active, selected }" :value="browserLocale" class="relative cursor-default select-none py-2 pl-3 pr-9 ui-not-active:text-gray-900 ui-active:text-white ui-active:bg-primary" @click="setBrowserLanguage()">
+                  <ListboxOption v-slot="{ active, selected }" :value="browserLocale" class="relative cursor-default select-none py-2 pl-3 pr-9 ui-not-active:text-gray-900 ui-active:text-white ui-active:bg-primary" @click="saveLanguage(undefined)">
                     <span :class="[selected || active ? 'font-semibold' : 'font-normal', 'block truncate']">
                       {{ t('userProfile.actions.useBrowserLanguage') }}          
                     </span>
@@ -110,21 +110,13 @@ async function fetchData() {
   }
 }
 
-async function saveLanguage(selectedLocale: Locale) {
-  locale.value = selectedLocale;
+async function saveLanguage(selectedLocale?: Locale) {
+  locale.value = selectedLocale ?? browserLocale.value;
   const updatedUser = me.value;
   if (updatedUser !== undefined) {
-    updatedUser.language = selectedLocale.toString();
+    updatedUser.language = selectedLocale?.toString();
     await backend.users.putMe(updatedUser);
     me.value = updatedUser;
-  }
-}
-
-async function setBrowserLanguage() {
-  locale.value = browserLocale.value;
-  if (me.value !== undefined) {
-    me.value.language = '';
-    await backend.users.putMe(me.value);
   }
 }
 

--- a/frontend/src/components/UserProfile.vue
+++ b/frontend/src/components/UserProfile.vue
@@ -34,17 +34,13 @@
               <transition leave-active-class="transition ease-in duration-100" leave-from-class="opacity-100" leave-to-class="opacity-0">
                 <ListboxOptions class="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 shadow-lg ring-1 ring-black/5 focus:outline-hidden text-sm">
                   <ListboxOption v-slot="{ active, selected }" :value="browserLocale" class="relative cursor-default select-none py-2 pl-3 pr-9 ui-not-active:text-gray-900 ui-active:text-white ui-active:bg-primary" @click="saveLanguage(undefined)">
-                    <span :class="[selected || active ? 'font-semibold' : 'font-normal', 'block truncate']">
-                      {{ t('userProfile.actions.useBrowserLanguage') }}          
-                    </span>
+                    <span :class="[selected || active ? 'font-semibold' : 'font-normal', 'block truncate']">{{ t('userProfile.actions.changeLanguage.entry.browser') }}</span>
                     <span v-if="selected" :class="['absolute inset-y-0 right-0 flex items-center pr-4', selected ? 'text-primary' : 'text-gray-400']">
                       <CheckIcon class="h-5 w-5" aria-hidden="true" />
                     </span>   
                   </ListboxOption>
-                  <ListboxOption v-for="locale in Locale" :key="locale" v-slot="{ active, selected }" class="relative cursor-default select-none py-2 pl-3 pr-9 ui-not-active:text-gray-900 ui-active:text-white ui-active:bg-primary" :value="locale" @click="saveLanguage(locale)">
-                    <span :class="[selected || active ? 'font-semibold' : 'font-normal', 'block truncate']">
-                      {{ t(`locale.${locale}`) }}
-                    </span>
+                  <ListboxOption v-for="availableLocale in Locale" :key="availableLocale" v-slot="{ active, selected }" class="relative cursor-default select-none py-2 pl-3 pr-9 ui-not-active:text-gray-900 ui-active:text-white ui-active:bg-primary" :value="availableLocale" @click="saveLanguage(availableLocale)">
+                    <span :class="[selected || active ? 'font-semibold' : 'font-normal', 'block truncate']">{{ t(`locale.${availableLocale}`) }}</span>
                     <span v-if="selected" :class="['absolute inset-y-0 right-0 flex items-center pr-4', selected ? 'text-primary' : 'text-gray-400']">
                       <CheckIcon class="h-5 w-5" aria-hidden="true" />
                     </span>   

--- a/frontend/src/components/UserProfile.vue
+++ b/frontend/src/components/UserProfile.vue
@@ -33,7 +33,7 @@
               </ListboxButton>
               <transition leave-active-class="transition ease-in duration-100" leave-from-class="opacity-100" leave-to-class="opacity-0">
                 <ListboxOptions class="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 shadow-lg ring-1 ring-black/5 focus:outline-hidden text-sm">
-                  <ListboxOption v-slot="{ active, selected }" :value="browserLocale" class="relative cursor-default select-none py-2 pl-3 pr-9 ui-not-active:text-gray-900 ui-active:text-white ui-active:bg-primary" @click="setBrowserLanguage(locale)">
+                  <ListboxOption v-slot="{ active, selected }" :value="browserLocale" class="relative cursor-default select-none py-2 pl-3 pr-9 ui-not-active:text-gray-900 ui-active:text-white ui-active:bg-primary" @click="setBrowserLanguage()">
                     <span :class="[selected ? 'font-semibold' : 'font-normal', 'block truncate']">
                       {{ t('userProfile.actions.useBrowserLanguage') }} ({{ browserLocale }})                
                     </span>

--- a/frontend/src/components/UserProfile.vue
+++ b/frontend/src/components/UserProfile.vue
@@ -37,13 +37,13 @@
                     <span :class="[selected || active ? 'font-semibold' : 'font-normal', 'block truncate']">{{ t('userProfile.actions.changeLanguage.entry.browser') }}</span>
                     <span v-if="selected" :class="['absolute inset-y-0 right-0 flex items-center pr-4', selected ? 'text-primary' : 'text-gray-400']">
                       <CheckIcon class="h-5 w-5" aria-hidden="true" />
-                    </span>   
+                    </span>
                   </ListboxOption>
                   <ListboxOption v-for="availableLocale in Locale" :key="availableLocale" v-slot="{ active, selected }" class="relative cursor-default select-none py-2 pl-3 pr-9 ui-not-active:text-gray-900 ui-active:text-white ui-active:bg-primary" :value="availableLocale" @click="saveLanguage(availableLocale)">
                     <span :class="[selected || active ? 'font-semibold' : 'font-normal', 'block truncate']">{{ t(`locale.${availableLocale}`) }}</span>
                     <span v-if="selected" :class="['absolute inset-y-0 right-0 flex items-center pr-4', selected ? 'text-primary' : 'text-gray-400']">
                       <CheckIcon class="h-5 w-5" aria-hidden="true" />
-                    </span>   
+                    </span>
                   </ListboxOption>
                 </ListboxOptions>
               </transition>
@@ -81,7 +81,7 @@ import FetchError from './FetchError.vue';
 import ManageSetupCode from './ManageSetupCode.vue';
 import UserkeyFingerprint from './UserkeyFingerprint.vue';
 
-const { t, locale } = useI18n({ useScope: 'global' });
+const { locale, t } = useI18n({ useScope: 'global' });
 
 const me = ref<UserDto>();
 const keycloakUserAccountURL = ref<string>();

--- a/frontend/src/components/UserProfile.vue
+++ b/frontend/src/components/UserProfile.vue
@@ -22,7 +22,7 @@
             <ArrowTopRightOnSquareIcon class="-ml-1 mr-2 h-5 w-5" aria-hidden="true" />
             {{ t('userProfile.actions.manageAccount') }}
           </button>
-          <Listbox v-model="$i18n.locale" as="div">
+          <Listbox v-model="currentLocale" as="div">
             <div class="relative">
               <ListboxButton class="relative w-full inline-flex items-center justify-center px-4 py-2 border border-gray-300 shadow-xs text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-primary">
                 <LanguageIcon class="-ml-1 mr-2 h-5 w-5" aria-hidden="true" />
@@ -33,9 +33,19 @@
               </ListboxButton>
               <transition leave-active-class="transition ease-in duration-100" leave-from-class="opacity-100" leave-to-class="opacity-0">
                 <ListboxOptions class="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 shadow-lg ring-1 ring-black/5 focus:outline-hidden text-sm">
+                  <ListboxOption v-slot="{ active, selected }" :value="browserLocale" class="relative cursor-default select-none py-2 pl-3 pr-9 ui-not-active:text-gray-900 ui-active:text-white ui-active:bg-primary" @click="setBrowserLanguage(locale)">
+                    <span :class="[selected ? 'font-semibold' : 'font-normal', 'block truncate']">
+                      {{ t('userProfile.actions.useBrowserLanguage') }} ({{ browserLocale }})                
+                    </span>
+                    <span v-if="currentLocale === browserLocale" :class="[active ? 'text-white' : 'text-primary', 'absolute inset-y-0 right-0 flex items-center pr-4']">
+                      <CheckIcon class="h-5 w-5" aria-hidden="true" />
+                    </span>
+                  </ListboxOption>
                   <ListboxOption v-for="locale in Locale" :key="locale" v-slot="{ active, selected }" class="relative cursor-default select-none py-2 pl-3 pr-9 ui-not-active:text-gray-900 ui-active:text-white ui-active:bg-primary" :value="locale" @click="saveLanguage(locale)">
-                    <span :class="[selected ? 'font-semibold' : 'font-normal', 'block truncate']">{{ t(`locale.${locale}`) }}</span>
-                    <span v-if="selected" :class="[active ? 'text-white' : 'text-primary', 'absolute inset-y-0 right-0 flex items-center pr-4']">
+                    <span :class="[selected ? 'font-semibold' : 'font-normal', 'block truncate']">
+                      {{ t(`locale.${locale}`) }}
+                    </span>
+                    <span v-if="currentLocale === locale" :class="[active ? 'text-white' : 'text-primary', 'absolute inset-y-0 right-0 flex items-center pr-4']">
                       <CheckIcon class="h-5 w-5" aria-hidden="true" />
                     </span>
                   </ListboxOption>
@@ -75,12 +85,14 @@ import FetchError from './FetchError.vue';
 import ManageSetupCode from './ManageSetupCode.vue';
 import UserkeyFingerprint from './UserkeyFingerprint.vue';
 
-const { t } = useI18n({ useScope: 'global' });
+const { t, locale } = useI18n({ useScope: 'global' });
 
 const me = ref<UserDto>();
 const keycloakUserAccountURL = ref<string>();
 const version = ref<VersionDto>();
 const onFetchError = ref<Error | null>();
+const browserLocale = ref<string>(navigator.language);
+const currentLocale = ref<string>(locale.value);
 
 onMounted(async () => {
   const cfg = config.get();
@@ -99,10 +111,23 @@ async function fetchData() {
   }
 }
 
-async function saveLanguage(locale: Locale) {
+async function saveLanguage(selectedLocale: Locale) {
+  currentLocale.value = selectedLocale;
+  locale.value = selectedLocale;
   const updatedUser = me.value;
   if (updatedUser !== undefined) {
-    updatedUser.language = locale.toString();
+    updatedUser.language = selectedLocale.toString();
+    await backend.users.putMe(updatedUser);
+    me.value = updatedUser;
+  }
+}
+
+async function setBrowserLanguage() {
+  locale.value = browserLocale.value;
+  
+  const updatedUser = me.value;
+  if (updatedUser !== undefined) {
+    updatedUser.language = '';
     await backend.users.putMe(updatedUser);
     me.value = updatedUser;
   }
@@ -111,5 +136,4 @@ async function saveLanguage(locale: Locale) {
 function openKeycloakUserAccount() {
   window.open(keycloakUserAccountURL.value, '_blank');
 }
-
 </script>

--- a/frontend/src/components/UserProfile.vue
+++ b/frontend/src/components/UserProfile.vue
@@ -22,7 +22,7 @@
             <ArrowTopRightOnSquareIcon class="-ml-1 mr-2 h-5 w-5" aria-hidden="true" />
             {{ t('userProfile.actions.manageAccount') }}
           </button>
-          <Listbox v-model="currentLocale" as="div">
+          <Listbox v-model="locale" as="div">
             <div class="relative">
               <ListboxButton class="relative w-full inline-flex items-center justify-center px-4 py-2 border border-gray-300 shadow-xs text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-primary">
                 <LanguageIcon class="-ml-1 mr-2 h-5 w-5" aria-hidden="true" />
@@ -34,20 +34,20 @@
               <transition leave-active-class="transition ease-in duration-100" leave-from-class="opacity-100" leave-to-class="opacity-0">
                 <ListboxOptions class="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 shadow-lg ring-1 ring-black/5 focus:outline-hidden text-sm">
                   <ListboxOption v-slot="{ active, selected }" :value="browserLocale" class="relative cursor-default select-none py-2 pl-3 pr-9 ui-not-active:text-gray-900 ui-active:text-white ui-active:bg-primary" @click="setBrowserLanguage()">
-                    <span :class="[selected ? 'font-semibold' : 'font-normal', 'block truncate']">
-                      {{ t('userProfile.actions.useBrowserLanguage') }} ({{ browserLocale }})                
+                    <span :class="[selected || active ? 'font-semibold' : 'font-normal', 'block truncate']">
+                      {{ t('userProfile.actions.useBrowserLanguage') }}          
                     </span>
-                    <span v-if="currentLocale === browserLocale" :class="[active ? 'text-white' : 'text-primary', 'absolute inset-y-0 right-0 flex items-center pr-4']">
+                    <span v-if="selected" :class="['absolute inset-y-0 right-0 flex items-center pr-4', selected ? 'text-primary' : 'text-gray-400']">
                       <CheckIcon class="h-5 w-5" aria-hidden="true" />
-                    </span>
+                    </span>   
                   </ListboxOption>
                   <ListboxOption v-for="locale in Locale" :key="locale" v-slot="{ active, selected }" class="relative cursor-default select-none py-2 pl-3 pr-9 ui-not-active:text-gray-900 ui-active:text-white ui-active:bg-primary" :value="locale" @click="saveLanguage(locale)">
-                    <span :class="[selected ? 'font-semibold' : 'font-normal', 'block truncate']">
+                    <span :class="[selected || active ? 'font-semibold' : 'font-normal', 'block truncate']">
                       {{ t(`locale.${locale}`) }}
                     </span>
-                    <span v-if="currentLocale === locale" :class="[active ? 'text-white' : 'text-primary', 'absolute inset-y-0 right-0 flex items-center pr-4']">
+                    <span v-if="selected" :class="['absolute inset-y-0 right-0 flex items-center pr-4', selected ? 'text-primary' : 'text-gray-400']">
                       <CheckIcon class="h-5 w-5" aria-hidden="true" />
-                    </span>
+                    </span>   
                   </ListboxOption>
                 </ListboxOptions>
               </transition>
@@ -92,7 +92,6 @@ const keycloakUserAccountURL = ref<string>();
 const version = ref<VersionDto>();
 const onFetchError = ref<Error | null>();
 const browserLocale = ref<string>(navigator.language);
-const currentLocale = ref<string>(locale.value);
 
 onMounted(async () => {
   const cfg = config.get();
@@ -112,7 +111,6 @@ async function fetchData() {
 }
 
 async function saveLanguage(selectedLocale: Locale) {
-  currentLocale.value = selectedLocale;
   locale.value = selectedLocale;
   const updatedUser = me.value;
   if (updatedUser !== undefined) {
@@ -124,12 +122,9 @@ async function saveLanguage(selectedLocale: Locale) {
 
 async function setBrowserLanguage() {
   locale.value = browserLocale.value;
-  
-  const updatedUser = me.value;
-  if (updatedUser !== undefined) {
-    updatedUser.language = '';
-    await backend.users.putMe(updatedUser);
-    me.value = updatedUser;
+  if (me.value !== undefined) {
+    me.value.language = '';
+    await backend.users.putMe(me.value);
   }
 }
 

--- a/frontend/src/i18n/en-US.json
+++ b/frontend/src/i18n/en-US.json
@@ -243,7 +243,7 @@
   "userProfile.title": "Profile",
   "userProfile.actions.manageAccount": "Manage Account",
   "userProfile.actions.changeLanguage": "Change Language",
-  "userProfile.actions.useBrowserLanguage": "Browser Default",
+  "userProfile.actions.useBrowserLanguage": "Browser Language",
 
   "unlockSuccess.title": "Vault unlocked successfully",
   "unlockSuccess.description": "You may now close this browser tab and return to Cryptomator.",

--- a/frontend/src/i18n/en-US.json
+++ b/frontend/src/i18n/en-US.json
@@ -243,6 +243,7 @@
   "userProfile.title": "Profile",
   "userProfile.actions.manageAccount": "Manage Account",
   "userProfile.actions.changeLanguage": "Change Language",
+  "userProfile.actions.useBrowserLanguage": "Browser Default",
 
   "unlockSuccess.title": "Vault unlocked successfully",
   "unlockSuccess.description": "You may now close this browser tab and return to Cryptomator.",

--- a/frontend/src/i18n/en-US.json
+++ b/frontend/src/i18n/en-US.json
@@ -243,7 +243,7 @@
   "userProfile.title": "Profile",
   "userProfile.actions.manageAccount": "Manage Account",
   "userProfile.actions.changeLanguage": "Change Language",
-  "userProfile.actions.useBrowserLanguage": "Browser Language",
+  "userProfile.actions.changeLanguage.entry.browser": "Browser Language",
 
   "unlockSuccess.title": "Vault unlocked successfully",
   "unlockSuccess.description": "You may now close this browser tab and return to Cryptomator.",


### PR DESCRIPTION
Currently, when selecting a language in the user profile, no selection is shown until the user explicitly picks one. In this initial state, the application defaults to the browser's language for localization. Once a language is selected, there is no way to revert to the previous behavior.

With this PR, a new option titled "Browser Language" is added to the language selection list. This ensures that:
- A selection is visible in the dropdown upon first login.
- Users can revert to the browser's language preference after manually selecting another language.

Changes
- Added "Browser Language" as an option in the language selection dropdown.
- Ensured this option is pre-selected if no explicit choice has been made.
- Allowed users to revert back to the browser's language after making a manual selection.