### PR TITLE
Feature: Add member count for groups in VaultDetail view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Show last IP address and last vault access timestamp of devices in user profile (#320)
 - Italian, Korean, Dutch and Portuguese translation
 - Added provenance attestation for our container images (#322)
+- Show direct member count of groups in vault details (#329)
 
 ### Changed
 

--- a/backend/src/main/java/org/cryptomator/hub/api/AuthorityDto.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/AuthorityDto.java
@@ -31,9 +31,13 @@ abstract sealed class AuthorityDto permits UserDto, GroupDto, MemberDto {
 	}
 
 	static AuthorityDto fromEntity(Authority a) {
+		return fromEntity(a, false);
+	}
+
+	static AuthorityDto fromEntity(Authority a, boolean withMemberSize) {
 		return switch (a) {
 			case User u -> UserDto.justPublicInfo(u);
-			case Group g -> GroupDto.fromEntity(g);
+			case Group g -> GroupDto.fromEntity(g, withMemberSize);
 			default -> throw new IllegalStateException("authority is not of type user or group");
 		};
 	}

--- a/backend/src/main/java/org/cryptomator/hub/api/AuthorityResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/AuthorityResource.java
@@ -2,6 +2,7 @@ package org.cryptomator.hub.api;
 
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -28,8 +29,9 @@ public class AuthorityResource {
 	@Produces(MediaType.APPLICATION_JSON)
 	@NoCache
 	@Operation(summary = "search authority by name")
-	public List<AuthorityDto> search(@QueryParam("query") @NotBlank String query) {
-		return authorityRepo.byName(query).map(AuthorityDto::fromEntity).toList();
+	@Transactional
+	public List<AuthorityDto> search(@QueryParam("query") @NotBlank String query, @QueryParam("withMemberSize") boolean withMemberSize) {
+		return authorityRepo.byName(query).map(authority -> AuthorityDto.fromEntity(authority, withMemberSize)).toList();
 	}
 
 	@GET

--- a/backend/src/main/java/org/cryptomator/hub/api/GroupDto.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/GroupDto.java
@@ -5,12 +5,20 @@ import org.cryptomator.hub.entities.Group;
 
 public final class GroupDto extends AuthorityDto {
 
-	GroupDto(@JsonProperty("id") String id, @JsonProperty("name") String name) {
+	@JsonProperty("memberSize")
+	public final Integer memberSize;
+
+	GroupDto(@JsonProperty("id") String id, @JsonProperty("name") String name, @JsonProperty("memberSize") Integer memberSize) {
 		super(id, Type.GROUP, name, null);
+		this.memberSize = memberSize;
 	}
 
 	public static GroupDto fromEntity(Group group) {
-		return new GroupDto(group.getId(), group.getName());
+		return fromEntity(group, false);
 	}
 
+	public static GroupDto fromEntity(Group group, boolean withMemberSize) {
+		Integer memberSize = withMemberSize ? group.getMemberSize() : null;
+		return new GroupDto(group.getId(), group.getName(), memberSize);
+	}
 }

--- a/backend/src/main/java/org/cryptomator/hub/api/MemberDto.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/MemberDto.java
@@ -13,20 +13,23 @@ public final class MemberDto extends AuthorityDto {
 	public final String ecdsaPublicKey;
 	@JsonProperty("role")
 	public final VaultAccess.Role role;
+	@JsonProperty("memberSize")
+	public final Integer memberSize;
 
-	MemberDto(@JsonProperty("id") String id, @JsonProperty("type") Type type, @JsonProperty("name") String name, @JsonProperty("pictureUrl") String pictureUrl, @JsonProperty("ecdhPublicKey") String ecdhPublicKey, @JsonProperty("ecdsaPublicKey") String ecdsaPublicKey, @JsonProperty("role") VaultAccess.Role role) {
+	MemberDto(@JsonProperty("id") String id, @JsonProperty("type") Type type, @JsonProperty("name") String name, @JsonProperty("pictureUrl") String pictureUrl, @JsonProperty("ecdhPublicKey") String ecdhPublicKey, @JsonProperty("ecdsaPublicKey") String ecdsaPublicKey, @JsonProperty("role") VaultAccess.Role role, @JsonProperty("memberSize") Integer memberSize) {
 		super(id, type, name, pictureUrl);
 		this.ecdhPublicKey = ecdhPublicKey;
 		this.ecdsaPublicKey = ecdsaPublicKey;
 		this.role = role;
+		this.memberSize = memberSize;
 	}
 
 	public static MemberDto fromEntity(User user, VaultAccess.Role role) {
-		return new MemberDto(user.getId(), Type.USER, user.getName(), user.getPictureUrl(), user.getEcdhPublicKey(), user.getEcdsaPublicKey(), role);
+		return new MemberDto(user.getId(), Type.USER, user.getName(), user.getPictureUrl(), user.getEcdhPublicKey(), user.getEcdsaPublicKey(), role, null);
 	}
 
 	public static MemberDto fromEntity(Group group, VaultAccess.Role role) {
-		return new MemberDto(group.getId(), Type.GROUP, group.getName(), null, null, null, role);
+		return new MemberDto(group.getId(), Type.GROUP, group.getName(), null, null, null, role, group.getMemberSize());
 	}
 
 }

--- a/backend/src/main/java/org/cryptomator/hub/entities/Group.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/Group.java
@@ -9,6 +9,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -31,6 +32,11 @@ public class Group extends Authority {
 
 	public void setMembers(Set<Authority> members) {
 		this.members = members;
+	}
+
+	@Transient
+	public int getMemberSize() {
+		return members.size();
 	}
 
 	@ApplicationScoped

--- a/backend/src/test/java/org/cryptomator/hub/api/AuthorityResourceIT.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/AuthorityResourceIT.java
@@ -5,6 +5,7 @@ import io.quarkus.test.security.TestSecurity;
 import io.quarkus.test.security.oidc.Claim;
 import io.quarkus.test.security.oidc.OidcSecurity;
 import io.restassured.RestAssured;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -13,9 +14,7 @@ import org.junit.jupiter.api.Test;
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
 import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.*;
 
 @QuarkusTest
 @DisplayName("Resource /authorities")
@@ -79,7 +78,17 @@ public class AuthorityResourceIT {
 		public void testGetSameUserGroupName() {
 			when().get("/authorities/search?query=1")
 					.then().statusCode(200)
-					.body("id", hasItems("user1", "group1"));
+					.body("find { it.id == 'user1' }.memberSize", nullValue())
+					.body("find { it.id == 'group1' }.memberSize", nullValue());
+		}
+
+		@Test
+		@DisplayName("GET /search?query=1&withMemberSize=true returns 200 with \"group1\" and \"memberSize\"=true")
+		public void testGetSameUserGroupNameWithMemberSize() {
+			when().get("/authorities/search?query=1&withMemberSize=true")
+					.then().statusCode(200)
+					.body("find { it.id == 'user1' }.memberSize", nullValue())
+					.body("find { it.id == 'group1' }.memberSize", equalTo(1));
 		}
 	}
 

--- a/backend/src/test/java/org/cryptomator/hub/api/VaultResourceIT.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/VaultResourceIT.java
@@ -56,6 +56,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.comparesEqualTo;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.text.IsEqualIgnoringCase.equalToIgnoringCase;
 
 @QuarkusTest
@@ -613,11 +614,11 @@ public class VaultResourceIT {
 
 		@Test
 		@Order(3)
-		@DisplayName("GET /vaults/7E57C0DE-0000-4000-8000-000100001111/members does contain group2")
+		@DisplayName("GET /vaults/7E57C0DE-0000-4000-8000-000100001111/members does contain group2 with memberSize=2")
 		public void getMembersOfVault1a() {
 			given().when().get("/vaults/{vaultId}/members", "7E57C0DE-0000-4000-8000-000100001111")
 					.then().statusCode(200)
-					.body("id", hasItems("group2"));
+					.body("find { it.id == 'group2' }.memberSize", equalTo(2));
 		}
 
 		@Test

--- a/frontend/src/common/backend.ts
+++ b/frontend/src/common/backend.ts
@@ -283,8 +283,8 @@ class TrustService {
 }
 
 class AuthorityService {
-  public async search(query: string): Promise<AuthorityDto[]> {
-    return axiosAuth.get<AuthorityDto[]>(`/authorities/search?query=${query}&withMemberSize=true`).then(response => response.data.map(AuthorityService.fillInMissingPicture));
+  public async search(query: string, withMemberSize: boolean = false): Promise<AuthorityDto[]> {
+    return axiosAuth.get<AuthorityDto[]>(`/authorities/search?query=${query}&withMemberSize=${withMemberSize}`).then(response => response.data.map(AuthorityService.fillInMissingPicture));
   }
 
   public async listSome(authorityIds: string[]): Promise<AuthorityDto[]> {

--- a/frontend/src/common/backend.ts
+++ b/frontend/src/common/backend.ts
@@ -86,6 +86,7 @@ export type GroupDto = {
   id: string;
   name: string;
   pictureUrl?: string;
+  memberSize?: number;
 }
 
 export type AuthorityDto = UserDto | GroupDto;
@@ -283,7 +284,7 @@ class TrustService {
 
 class AuthorityService {
   public async search(query: string): Promise<AuthorityDto[]> {
-    return axiosAuth.get<AuthorityDto[]>(`/authorities/search?query=${query}`).then(response => response.data.map(AuthorityService.fillInMissingPicture));
+    return axiosAuth.get<AuthorityDto[]>(`/authorities/search?query=${query}&withMemberSize=true`).then(response => response.data.map(AuthorityService.fillInMissingPicture));
   }
 
   public async listSome(authorityIds: string[]): Promise<AuthorityDto[]> {

--- a/frontend/src/components/SearchInputGroup.vue
+++ b/frontend/src/components/SearchInputGroup.vue
@@ -12,7 +12,7 @@
           <div v-else class="w-full h-10 rounded-l-md border border-gray-300 bg-primary-l2 py-2 px-10 flex items-center justify-between shadow-xs sm:text-sm">
             <span class="truncate">{{ selectedItem.name }}</span>
             <span v-if="selectedItem.type === 'GROUP'" class="text-gray-500 text-xs italic mr-6">
-              {{ selectedItem.memberSize }} {{ t('vaultDetails.sharedWith.members') }}
+              {{ t('common.xMembers', [selectedItem.memberSize]) }}
             </span>
           </div>
         </div>
@@ -23,7 +23,7 @@
               <img :src="item.pictureUrl ?? ''" alt="" class="h-6 w-6 shrink-0 rounded-full" >
               <span class="ml-3 truncate">{{ item.name }}</span>
               <span v-if="item.type === 'GROUP'" class="ml-auto text-xs text-gray-500 italic">
-                {{ item.memberSize }} {{ t('vaultDetails.sharedWith.members') }}
+                {{ t('common.xMembers', [item.memberSize]) }}
               </span>
             </div>
           </ComboboxOption>

--- a/frontend/src/components/SearchInputGroup.vue
+++ b/frontend/src/components/SearchInputGroup.vue
@@ -11,9 +11,7 @@
           <ComboboxInput v-if="selectedItem == null" v-focus class="w-full h-10 rounded-l-md border border-gray-300 bg-white py-2 px-10 shadow-xs focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary sm:text-sm disabled:bg-primary-l2" placeholder="John Doe" @change="query = $event.target.value"/>
           <div v-else class="w-full h-10 rounded-l-md border border-gray-300 bg-primary-l2 py-2 px-10 flex items-center justify-between shadow-xs sm:text-sm">
             <span class="truncate">{{ selectedItem.name }}</span>
-            <span v-if="selectedItem.type === 'GROUP'" class="text-gray-500 text-xs italic mr-6">
-              {{ t('common.xMembers', [selectedItem.memberSize]) }}
-            </span>
+            <span v-if="selectedItem.type === 'GROUP'" class="ml-3 text-gray-500 text-xs italic whitespace-nowrap">{{ t('common.xMembers', [selectedItem.memberSize]) }}</span>
           </div>
         </div>
 
@@ -22,9 +20,7 @@
             <div class="flex items-center">
               <img :src="item.pictureUrl ?? ''" alt="" class="h-6 w-6 shrink-0 rounded-full" >
               <span class="ml-3 truncate">{{ item.name }}</span>
-              <span v-if="item.type === 'GROUP'" class="ml-auto text-xs text-gray-500 italic">
-                {{ t('common.xMembers', [item.memberSize]) }}
-              </span>
+              <span v-if="item.type === 'GROUP'" class="ml-3 text-gray-500 text-xs italic whitespace-nowrap">{{ t('common.xMembers', [item.memberSize]) }}</span>
             </div>
           </ComboboxOption>
         </ComboboxOptions>
@@ -45,8 +41,8 @@
 import { Combobox, ComboboxInput, ComboboxOption, ComboboxOptions } from '@headlessui/vue';
 import { UsersIcon, XCircleIcon } from '@heroicons/vue/24/solid';
 import { computed, nextTick, ref, shallowRef, watch } from 'vue';
-import { debounce } from '../common/util';
 import { useI18n } from 'vue-i18n';
+import { debounce } from '../common/util';
 
 export type Item = {
   id: string;

--- a/frontend/src/components/SearchInputGroup.vue
+++ b/frontend/src/components/SearchInputGroup.vue
@@ -9,7 +9,12 @@
           </div>
 
           <ComboboxInput v-if="selectedItem == null" v-focus class="w-full h-10 rounded-l-md border border-gray-300 bg-white py-2 px-10 shadow-xs focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary sm:text-sm disabled:bg-primary-l2" placeholder="John Doe" @change="query = $event.target.value"/>
-          <input v-else v-model="selectedItem.name" class="w-full h-10 rounded-l-md border border-gray-300 bg-primary-l2 py-2 px-10 shadow-xs focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary sm:text-sm" readonly />
+          <div v-else class="w-full h-10 rounded-l-md border border-gray-300 bg-primary-l2 py-2 px-10 flex items-center justify-between shadow-xs sm:text-sm">
+            <span class="truncate">{{ selectedItem.name }}</span>
+            <span v-if="selectedItem.type === 'GROUP'" class="text-gray-500 text-xs italic mr-6">
+              {{ selectedItem.memberSize }} {{ t('vaultDetails.sharedWith.members') }}
+            </span>
+          </div>
         </div>
 
         <ComboboxOptions v-if="selectedItem == null && filteredItems.length > 0" class="absolute z-10 mt-1 max-h-56 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black/5 focus:outline-hidden sm:text-sm">
@@ -17,6 +22,9 @@
             <div class="flex items-center">
               <img :src="item.pictureUrl ?? ''" alt="" class="h-6 w-6 shrink-0 rounded-full" >
               <span class="ml-3 truncate">{{ item.name }}</span>
+              <span v-if="item.type === 'GROUP'" class="ml-auto text-xs text-gray-500 italic">
+                {{ item.memberSize }} {{ t('vaultDetails.sharedWith.members') }}
+              </span>
             </div>
           </ComboboxOption>
         </ComboboxOptions>
@@ -38,12 +46,17 @@ import { Combobox, ComboboxInput, ComboboxOption, ComboboxOptions } from '@headl
 import { UsersIcon, XCircleIcon } from '@heroicons/vue/24/solid';
 import { computed, nextTick, ref, shallowRef, watch } from 'vue';
 import { debounce } from '../common/util';
+import { useI18n } from 'vue-i18n';
 
 export type Item = {
   id: string;
   name: string;
   pictureUrl?: string;
+  type?: string;
+  memberSize?: number;
 }
+
+const { t } = useI18n({ useScope: 'global' });
 
 const props = defineProps<{
   actionTitle: string

--- a/frontend/src/components/VaultDetails.vue
+++ b/frontend/src/components/VaultDetails.vue
@@ -48,7 +48,7 @@
                   <img :src="member.pictureUrl" alt="" class="w-8 h-8 rounded-full" />
                   <p class="w-full ml-4 text-sm font-medium text-gray-900 truncate">{{ member.name }}</p>
                   <span v-if="member.type === 'GROUP'" class="ml-auto text-xs text-gray-500 italic">
-                    {{ member.memberSize }} {{ t('vaultDetails.sharedWith.members') }}
+                    {{ t('common.xMembers', [member.memberSize]) }}
                   </span>
                   <TrustDetails v-if="member.type === 'USER'" :trusted-user="member" :trusts="trusts" @trust-changed="refreshTrusts()"/>
                   <div v-if="member.role == 'OWNER'" class="ml-3 inline-flex items-center rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10">{{ t('vaultDetails.sharedWith.badge.owner') }}</div>
@@ -470,7 +470,7 @@ function refreshVault(updatedVault: VaultDto) {
 }
 
 async function searchAuthority(query: string): Promise<AuthorityDto[]> {
-  return (await backend.authorities.search(query))
+  return (await backend.authorities.search(query,true))
     .filter(authority => !members.value.has(authority.id))
     .sort((a, b) => a.name.localeCompare(b.name));
 }

--- a/frontend/src/components/VaultDetails.vue
+++ b/frontend/src/components/VaultDetails.vue
@@ -47,9 +47,7 @@
                 <div class="flex items-center whitespace-nowrap w-full" :title="member.name">
                   <img :src="member.pictureUrl" alt="" class="w-8 h-8 rounded-full" />
                   <p class="w-full ml-4 text-sm font-medium text-gray-900 truncate">{{ member.name }}</p>
-                  <span v-if="member.type === 'GROUP'" class="ml-auto text-xs text-gray-500 italic">
-                    {{ t('common.xMembers', [member.memberSize]) }}
-                  </span>
+                  <span v-if="member.type === 'GROUP'" class="ml-3 text-xs text-gray-500 italic whitespace-nowrap">{{ t('common.xMembers', [member.memberSize]) }}</span>
                   <TrustDetails v-if="member.type === 'USER'" :trusted-user="member" :trusts="trusts" @trust-changed="refreshTrusts()"/>
                   <div v-if="member.role == 'OWNER'" class="ml-3 inline-flex items-center rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10">{{ t('vaultDetails.sharedWith.badge.owner') }}</div>
                   <Menu v-if="member.id != me?.id" as="div" class="relative ml-2 inline-block shrink-0 text-left">
@@ -470,7 +468,7 @@ function refreshVault(updatedVault: VaultDto) {
 }
 
 async function searchAuthority(query: string): Promise<AuthorityDto[]> {
-  return (await backend.authorities.search(query,true))
+  return (await backend.authorities.search(query, true))
     .filter(authority => !members.value.has(authority.id))
     .sort((a, b) => a.name.localeCompare(b.name));
 }

--- a/frontend/src/components/VaultDetails.vue
+++ b/frontend/src/components/VaultDetails.vue
@@ -47,6 +47,9 @@
                 <div class="flex items-center whitespace-nowrap w-full" :title="member.name">
                   <img :src="member.pictureUrl" alt="" class="w-8 h-8 rounded-full" />
                   <p class="w-full ml-4 text-sm font-medium text-gray-900 truncate">{{ member.name }}</p>
+                  <span v-if="member.type === 'GROUP'" class="ml-auto text-xs text-gray-500 italic">
+                    {{ member.memberSize }} {{ t('vaultDetails.sharedWith.members') }}
+                  </span>
                   <TrustDetails v-if="member.type === 'USER'" :trusted-user="member" :trusts="trusts" @trust-changed="refreshTrusts()"/>
                   <div v-if="member.role == 'OWNER'" class="ml-3 inline-flex items-center rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10">{{ t('vaultDetails.sharedWith.badge.owner') }}</div>
                   <Menu v-if="member.id != me?.id" as="div" class="relative ml-2 inline-block shrink-0 text-left">

--- a/frontend/src/i18n/en-US.json
+++ b/frontend/src/i18n/en-US.json
@@ -263,6 +263,7 @@
   "vaultDetails.sharedWith.title": "Shared with",
   "vaultDetails.sharedWith.badge.owner": "Owner",
   "vaultDetails.sharedWith.grantOwnership": "Grant Ownership",
+  "vaultDetails.sharedWith.members": "Members",
   "vaultDetails.sharedWith.revokeOwnership": "Revoke Ownership",
   "vaultDetails.actions.title": "Actions",
   "vaultDetails.actions.updatePermissions": "Update Permissions",

--- a/frontend/src/i18n/en-US.json
+++ b/frontend/src/i18n/en-US.json
@@ -28,6 +28,7 @@
   "common.show": "Show",
   "common.unexpectedError": "Unexpected Error: {0}",
   "common.update": "Update",
+  "common.xMembers": "{0} Members",
 
   "admin.title": "Admin",
   "admin.serverInfo.title": "Server Info",
@@ -263,7 +264,6 @@
   "vaultDetails.sharedWith.title": "Shared with",
   "vaultDetails.sharedWith.badge.owner": "Owner",
   "vaultDetails.sharedWith.grantOwnership": "Grant Ownership",
-  "vaultDetails.sharedWith.members": "Members",
   "vaultDetails.sharedWith.revokeOwnership": "Revoke Ownership",
   "vaultDetails.actions.title": "Actions",
   "vaultDetails.actions.updatePermissions": "Update Permissions",


### PR DESCRIPTION
This PR addresses https://github.com/cryptomator/hub/issues/173 by displaying the number of members for shared groups in the VaultDetail view.

The member count appears as italicized gray text (e.g., 3 Members) next to group names.

This information is visible both in the search results and the "Shared with" list, helping distinguish groups from individual users.

<img width="423" alt="Search output" src="https://github.com/user-attachments/assets/cb977f02-982d-4253-b73e-da2e58e1ae1b" />
<img width="426" alt="Search selected" src="https://github.com/user-attachments/assets/29428c23-d45f-4847-bf8c-efc497326324" />
<img width="427" alt="Shared with list" src="https://github.com/user-attachments/assets/1f0aae6f-0a26-413d-87a0-487ecaa94755" />

