### PR TITLE
Show legacy devices in user profile and legacy device name in audit log

### DIFF
--- a/backend/src/main/java/org/cryptomator/hub/api/DeviceResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/DeviceResource.java
@@ -60,8 +60,14 @@ public class DeviceResource {
 	User.Repository userRepo;
 	@Inject
 	Device.Repository deviceRepo;
+	/**
+	 * @deprecated to be removed in <a href="https://github.com/cryptomator/hub/issues/333">#333</a>
+	 */
 	@Inject
 	LegacyAccessToken.Repository legacyAccessTokenRepo;
+	/**
+	 * @deprecated to be removed in <a href="https://github.com/cryptomator/hub/issues/333">#333</a>
+	 */
 	@Inject
 	LegacyDevice.Repository legacyDeviceRepo;
 

--- a/backend/src/main/java/org/cryptomator/hub/api/DeviceResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/DeviceResource.java
@@ -79,7 +79,10 @@ public class DeviceResource {
 		return deviceRepo.findAllInList(deviceIds).map(DeviceDto::fromEntity).toList();
 	}
 
-	@Deprecated
+	/**
+	 * @deprecated to be removed in <a href="https://github.com/cryptomator/hub/issues/333">#333</a>
+	 */
+	@Deprecated(since = "1.3.0", forRemoval = true)
 	@GET
 	@Path("/legacy-devices")
 	@RolesAllowed("admin")
@@ -147,7 +150,10 @@ public class DeviceResource {
 		}
 	}
 
-	@Deprecated
+	/**
+	 * @deprecated to be removed in <a href="https://github.com/cryptomator/hub/issues/333">#333</a>
+	 */
+	@Deprecated(since = "1.3.0", forRemoval = true)
 	@GET
 	@Path("/{deviceId}/legacy-access-tokens")
 	@RolesAllowed("user")
@@ -173,7 +179,10 @@ public class DeviceResource {
 		return remove(deviceId, false);
 	}
 
-	@Deprecated
+	/**
+	 * @deprecated to be removed in <a href="https://github.com/cryptomator/hub/issues/333">#333</a>
+	 */
+	@Deprecated(since = "1.3.0", forRemoval = true)
 	@DELETE
 	@Path("/{deviceId}/legacy-device")
 	@RolesAllowed("user")
@@ -226,7 +235,10 @@ public class DeviceResource {
 			return new DeviceDto(entity.getId(), entity.getName(), entity.getType(), entity.getPublickey(), entity.getUserPrivateKeys(), entity.getOwner().getId(), entity.getCreationTime().truncatedTo(ChronoUnit.MILLIS), null, null, false);
 		}
 
-		@Deprecated
+		/**
+		 * @deprecated to be removed in <a href="https://github.com/cryptomator/hub/issues/333">#333</a>
+		 */
+		@Deprecated(since = "1.3.0", forRemoval = true)
 		public static DeviceDto fromEntity(LegacyDevice entity) {
 			return new DeviceDto(entity.getId(), entity.getName(), entity.getType(), entity.getPublickey(), null, entity.getOwner().getId(), entity.getCreationTime().truncatedTo(ChronoUnit.MILLIS), null, null, true);
 		}
@@ -237,7 +249,10 @@ public class DeviceResource {
 			return new DeviceResource.DeviceDto(d.getId(), d.getName(), d.getType(), d.getPublickey(), d.getUserPrivateKeys(), d.getOwner().getId(), d.getCreationTime().truncatedTo(ChronoUnit.MILLIS), lastIpAddress, lastAccessTime, false);
 		}
 
-		@Deprecated
+		/**
+		 * @deprecated to be removed in <a href="https://github.com/cryptomator/hub/issues/333">#333</a>
+		 */
+		@Deprecated(since = "1.3.0", forRemoval = true)
 		public static DeviceDto fromEntity(LegacyDevice d, @Nullable VaultKeyRetrievedEvent event) {
 			var lastIpAddress = (event != null) ? event.getIpAddress() : null;
 			var lastAccessTime = (event != null) ? event.getTimestamp() : null;

--- a/backend/src/main/java/org/cryptomator/hub/api/DeviceResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/DeviceResource.java
@@ -228,7 +228,7 @@ public class DeviceResource {
 
 		@Deprecated
 		public static DeviceDto fromEntity(LegacyDevice entity) {
-			return new DeviceDto(entity.getId(), entity.getName(), entity.getType(), null, null, entity.getOwner().getId(), entity.getCreationTime().truncatedTo(ChronoUnit.MILLIS), null, null, true);
+			return new DeviceDto(entity.getId(), entity.getName(), entity.getType(), entity.getPublickey(), null, entity.getOwner().getId(), entity.getCreationTime().truncatedTo(ChronoUnit.MILLIS), null, null, true);
 		}
 
 		public static DeviceDto fromEntity(Device d, @Nullable VaultKeyRetrievedEvent event) {
@@ -241,7 +241,7 @@ public class DeviceResource {
 		public static DeviceDto fromEntity(LegacyDevice d, @Nullable VaultKeyRetrievedEvent event) {
 			var lastIpAddress = (event != null) ? event.getIpAddress() : null;
 			var lastAccessTime = (event != null) ? event.getTimestamp() : null;
-			return new DeviceResource.DeviceDto(d.getId(), d.getName(), d.getType(), null, null, d.getOwner().getId(), d.getCreationTime().truncatedTo(ChronoUnit.MILLIS), lastIpAddress, lastAccessTime, true);
+			return new DeviceResource.DeviceDto(d.getId(), d.getName(), d.getType(), d.getPublickey(), null, d.getOwner().getId(), d.getCreationTime().truncatedTo(ChronoUnit.MILLIS), lastIpAddress, lastAccessTime, true);
 		}
 
 	}

--- a/backend/src/main/java/org/cryptomator/hub/api/DeviceResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/DeviceResource.java
@@ -63,11 +63,13 @@ public class DeviceResource {
 	/**
 	 * @deprecated to be removed in <a href="https://github.com/cryptomator/hub/issues/333">#333</a>
 	 */
+	@Deprecated(since = "1.3.0", forRemoval = true)
 	@Inject
 	LegacyAccessToken.Repository legacyAccessTokenRepo;
 	/**
 	 * @deprecated to be removed in <a href="https://github.com/cryptomator/hub/issues/333">#333</a>
 	 */
+	@Deprecated(since = "1.3.0", forRemoval = true)
 	@Inject
 	LegacyDevice.Repository legacyDeviceRepo;
 

--- a/backend/src/main/java/org/cryptomator/hub/api/UsersResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/UsersResource.java
@@ -181,7 +181,10 @@ public class UsersResource {
 		return new UserDto(user.getId(), user.getName(), user.getPictureUrl(), user.getEmail(), user.getLanguage(), deviceDtos, user.getEcdhPublicKey(), user.getEcdsaPublicKey(), user.getPrivateKeys(), user.getSetupCode());
 	}
 
-	@Deprecated
+	/**
+	 * @deprecated to be removed in <a href="https://github.com/cryptomator/hub/issues/333">#333</a>
+	 */
+	@Deprecated(since = "1.3.0", forRemoval = true)
 	@GET
 	@Path("/me-with-legacy-devices-and-access")
 	@RolesAllowed("user")

--- a/backend/src/main/java/org/cryptomator/hub/api/UsersResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/UsersResource.java
@@ -30,6 +30,8 @@ import org.cryptomator.hub.entities.events.EventLogger;
 import org.cryptomator.hub.entities.events.VaultKeyRetrievedEvent;
 import org.eclipse.microprofile.jwt.JsonWebToken;
 import org.eclipse.microprofile.openapi.annotations.Operation;
+import org.eclipse.microprofile.openapi.annotations.enums.ParameterIn;
+import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.jboss.resteasy.reactive.NoCache;
 
@@ -42,7 +44,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @Path("/users")
 @Produces(MediaType.TEXT_PLAIN)
@@ -162,32 +163,44 @@ public class UsersResource {
 	@NoCache
 	@Transactional
 	@Operation(summary = "get the logged-in user")
+	@Parameter(name = "withLastAccess", in = ParameterIn.QUERY, description = "adds last access values to the devices (if present)")
 	@APIResponse(responseCode = "200", description = "returns the current user")
 	@APIResponse(responseCode = "404", description = "no user matching the subject of the JWT passed as Bearer Token")
-	public UserDto getMe(@QueryParam("withDevices") boolean withDevices, @QueryParam("withLastAccessAndLegacyDevices") boolean withLastAccessAndLegacyDevices) {
+	public UserDto getMe(@QueryParam("withDevices") boolean withDevices, @QueryParam("withLastAccess") boolean withLastAccess) {
 		User user = userRepo.findById(jwt.getSubject());
 		Set<DeviceResource.DeviceDto> deviceDtos = new HashSet<>();
-		if (withLastAccessAndLegacyDevices) {
-			deviceDtos = getLegacyDevicesWithAccess(user);
+		if (withLastAccess) {
+			var devices = user.devices.stream().collect(Collectors.toMap(Device::getId, Function.identity()));
+			var events = auditEventRepo.findLastVaultKeyRetrieve(devices.keySet()).collect(Collectors.toMap(VaultKeyRetrievedEvent::getDeviceId, Function.identity()));
+			deviceDtos = devices.values().stream().map(d -> {
+				var event = events.get(d.getId());
+				return DeviceResource.DeviceDto.fromEntity(d, event);
+			}).collect(Collectors.toSet());
 		} else if (withDevices) {
 			deviceDtos = user.getDevices().stream().map(DeviceResource.DeviceDto::fromEntity).collect(Collectors.toSet());
 		}
 		return new UserDto(user.getId(), user.getName(), user.getPictureUrl(), user.getEmail(), user.getLanguage(), deviceDtos, user.getEcdhPublicKey(), user.getEcdsaPublicKey(), user.getPrivateKeys(), user.getSetupCode());
 	}
 
-	private Set<DeviceResource.DeviceDto> getLegacyDevicesWithAccess(User user) {
-		Set<DeviceResource.DeviceDto> deviceDtos = new HashSet<>();
-		var devices = user.getDevices().stream().collect(Collectors.toMap(Device::getId, Function.identity()));
-		var legacyDevices = user.getLegacyDevices().stream().collect(Collectors.toMap(LegacyDevice::getId, Function.identity()));
-		var allDeviceIds = Stream.concat(devices.keySet().stream(), legacyDevices.keySet().stream()).collect(Collectors.toSet());
-		var events = auditEventRepo.findLastVaultKeyRetrieve(allDeviceIds).collect(Collectors.toMap(VaultKeyRetrievedEvent::getDeviceId, Function.identity()));
-		deviceDtos.addAll(devices.values().stream()
-				.map(device -> DeviceResource.DeviceDto.fromEntity(device, events.get(device.getId())))
-				.collect(Collectors.toSet()));
-		deviceDtos.addAll(legacyDevices.values().stream()
-				.map(legacyDevice -> DeviceResource.DeviceDto.fromEntity(legacyDevice, events.get(legacyDevice.getId())))
-				.collect(Collectors.toSet()));
-		return deviceDtos;
+	@Deprecated
+	@GET
+	@Path("/me-with-legacy-devices-and-access")
+	@RolesAllowed("user")
+	@Produces(MediaType.APPLICATION_JSON)
+	@NoCache
+	@Transactional
+	@Operation(summary = "get the logged-in user")
+	@APIResponse(responseCode = "200", description = "returns the current user")
+	@APIResponse(responseCode = "404", description = "no user matching the subject of the JWT passed as Bearer Token")
+	public UserDto getMeWithLegacyDevicesAndAccess() {
+		User user = userRepo.findById(jwt.getSubject());
+		var legacyDevices = user.legacyDevices.stream().collect(Collectors.toMap(LegacyDevice::getId, Function.identity()));
+		var events = auditEventRepo.findLastVaultKeyRetrieve(legacyDevices.keySet()).collect(Collectors.toMap(VaultKeyRetrievedEvent::getDeviceId, Function.identity()));
+		var deviceDtos = legacyDevices.values().stream().map(d -> {
+			var event = events.get(d.getId());
+			return DeviceResource.DeviceDto.fromEntity(d, event);
+		}).collect(Collectors.toSet());
+		return new UserDto(user.getId(), user.getName(), user.getPictureUrl(), user.getEmail(), user.getLanguage(), deviceDtos, user.getEcdhPublicKey(), user.getEcdsaPublicKey(), user.getPrivateKeys(), user.getSetupCode());
 	}
 
 	@POST

--- a/backend/src/main/java/org/cryptomator/hub/api/UsersResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/UsersResource.java
@@ -36,7 +36,6 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.jboss.resteasy.reactive.NoCache;
 
 import java.net.URI;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -57,8 +56,6 @@ public class UsersResource {
 	User.Repository userRepo;
 	@Inject
 	Device.Repository deviceRepo;
-	@Inject
-	LegacyDevice.Repository legacyDeviceRepo;
 	@Inject
 	Vault.Repository vaultRepo;
 	@Inject
@@ -168,7 +165,7 @@ public class UsersResource {
 	@APIResponse(responseCode = "404", description = "no user matching the subject of the JWT passed as Bearer Token")
 	public UserDto getMe(@QueryParam("withDevices") boolean withDevices, @QueryParam("withLastAccess") boolean withLastAccess) {
 		User user = userRepo.findById(jwt.getSubject());
-		Set<DeviceResource.DeviceDto> deviceDtos = new HashSet<>();
+		Set<DeviceResource.DeviceDto> deviceDtos;
 		if (withLastAccess) {
 			var devices = user.devices.stream().collect(Collectors.toMap(Device::getId, Function.identity()));
 			var events = auditEventRepo.findLastVaultKeyRetrieve(devices.keySet()).collect(Collectors.toMap(VaultKeyRetrievedEvent::getDeviceId, Function.identity()));
@@ -178,6 +175,8 @@ public class UsersResource {
 			}).collect(Collectors.toSet());
 		} else if (withDevices) {
 			deviceDtos = user.getDevices().stream().map(DeviceResource.DeviceDto::fromEntity).collect(Collectors.toSet());
+		} else {
+			deviceDtos = Set.of();
 		}
 		return new UserDto(user.getId(), user.getName(), user.getPictureUrl(), user.getEmail(), user.getLanguage(), deviceDtos, user.getEcdhPublicKey(), user.getEcdsaPublicKey(), user.getPrivateKeys(), user.getSetupCode());
 	}

--- a/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
@@ -81,8 +81,11 @@ public class VaultResource {
 	User.Repository userRepo;
 	@Inject
 	EffectiveVaultAccess.Repository effectiveVaultAccessRepo;
+	/**
+	 * @deprecated to be removed in <a href="https://github.com/cryptomator/hub/issues/333">#333</a>
+	 */
 	@Inject
-	@Deprecated
+	@Deprecated(since = "1.3.0", forRemoval = true)
 	LegacyAccessToken.Repository legacyAccessTokenRepo;
 	@Inject
 	Vault.Repository vaultRepo;
@@ -259,7 +262,10 @@ public class VaultResource {
 		return userRepo.findRequiringAccessGrant(vaultId).map(UserDto::justPublicInfo).toList();
 	}
 
-	@Deprecated(forRemoval = true)
+	/**
+	 * @deprecated to be removed in <a href="https://github.com/cryptomator/hub/issues/333">#333</a>
+	 */
+	@Deprecated(since = "1.3.0", forRemoval = true)
 	@GET
 	@Path("/{vaultId}/keys/{deviceId}")
 	@RolesAllowed("user")

--- a/backend/src/main/java/org/cryptomator/hub/entities/LegacyAccessToken.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/LegacyAccessToken.java
@@ -15,6 +15,10 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Stream;
 
+/**
+ * @deprecated to be removed in <a href="https://github.com/cryptomator/hub/issues/333">#333</a>
+ */
+@Deprecated(since = "1.3.0", forRemoval = true)
 @Entity
 @Table(name = "access_token_legacy")
 @NamedQuery(name = "LegacyAccessToken.get", query = """
@@ -31,10 +35,6 @@ import java.util.stream.Stream;
 		INNER JOIN EffectiveVaultAccess perm ON token.id.vaultId = perm.id.vaultId AND device.owner.id = perm.id.authorityId
 		WHERE token.id.deviceId = :deviceId AND device.owner.id = :userId
 		""")
-/**
- * @deprecated to be removed in <a href="https://github.com/cryptomator/hub/issues/333">#333</a>
- */
-@Deprecated(since = "1.3.0", forRemoval = true)
 public class LegacyAccessToken {
 
 	@EmbeddedId

--- a/backend/src/main/java/org/cryptomator/hub/entities/LegacyAccessToken.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/LegacyAccessToken.java
@@ -21,15 +21,15 @@ import java.util.stream.Stream;
 		SELECT token
 		FROM LegacyAccessToken token
 		INNER JOIN LegacyDevice device ON device.id = token.id.deviceId
-		INNER JOIN EffectiveVaultAccess perm ON token.id.vaultId = perm.id.vaultId AND device.ownerId = perm.id.authorityId
-		WHERE token.id.vaultId = :vaultId AND token.id.deviceId = :deviceId AND device.ownerId = :userId
+		INNER JOIN EffectiveVaultAccess perm ON token.id.vaultId = perm.id.vaultId AND device.owner.id = perm.id.authorityId
+		WHERE token.id.vaultId = :vaultId AND token.id.deviceId = :deviceId AND device.owner.id = :userId
 		""")
 @NamedQuery(name = "LegacyAccessToken.getByDevice", query = """
 		SELECT token
 		FROM LegacyAccessToken token
 		INNER JOIN LegacyDevice device ON device.id = token.id.deviceId
-		INNER JOIN EffectiveVaultAccess perm ON token.id.vaultId = perm.id.vaultId AND device.ownerId = perm.id.authorityId
-		WHERE token.id.deviceId = :deviceId AND device.ownerId = :userId
+		INNER JOIN EffectiveVaultAccess perm ON token.id.vaultId = perm.id.vaultId AND device.owner.id = perm.id.authorityId
+		WHERE token.id.deviceId = :deviceId AND device.owner.id = :userId
 		""")
 @Deprecated
 public class LegacyAccessToken {

--- a/backend/src/main/java/org/cryptomator/hub/entities/LegacyAccessToken.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/LegacyAccessToken.java
@@ -25,15 +25,15 @@ import java.util.stream.Stream;
 		SELECT token
 		FROM LegacyAccessToken token
 		INNER JOIN LegacyDevice device ON device.id = token.id.deviceId
-		INNER JOIN EffectiveVaultAccess perm ON token.id.vaultId = perm.id.vaultId AND device.owner.id = perm.id.authorityId
-		WHERE token.id.vaultId = :vaultId AND token.id.deviceId = :deviceId AND device.owner.id = :userId
+		INNER JOIN EffectiveVaultAccess perm ON token.id.vaultId = perm.id.vaultId AND device.ownerId = perm.id.authorityId
+		WHERE token.id.vaultId = :vaultId AND token.id.deviceId = :deviceId AND device.ownerId = :userId
 		""")
 @NamedQuery(name = "LegacyAccessToken.getByDevice", query = """
 		SELECT token
 		FROM LegacyAccessToken token
 		INNER JOIN LegacyDevice device ON device.id = token.id.deviceId
-		INNER JOIN EffectiveVaultAccess perm ON token.id.vaultId = perm.id.vaultId AND device.owner.id = perm.id.authorityId
-		WHERE token.id.deviceId = :deviceId AND device.owner.id = :userId
+		INNER JOIN EffectiveVaultAccess perm ON token.id.vaultId = perm.id.vaultId AND device.ownerId = perm.id.authorityId
+		WHERE token.id.deviceId = :deviceId AND device.ownerId = :userId
 		""")
 public class LegacyAccessToken {
 

--- a/backend/src/main/java/org/cryptomator/hub/entities/LegacyAccessToken.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/LegacyAccessToken.java
@@ -31,7 +31,10 @@ import java.util.stream.Stream;
 		INNER JOIN EffectiveVaultAccess perm ON token.id.vaultId = perm.id.vaultId AND device.owner.id = perm.id.authorityId
 		WHERE token.id.deviceId = :deviceId AND device.owner.id = :userId
 		""")
-@Deprecated
+/**
+ * @deprecated to be removed in <a href="https://github.com/cryptomator/hub/issues/333">#333</a>
+ */
+@Deprecated(since = "1.3.0", forRemoval = true)
 public class LegacyAccessToken {
 
 	@EmbeddedId
@@ -134,8 +137,11 @@ public class LegacyAccessToken {
 		}
 	}
 
+	/**
+	 * @deprecated to be removed in <a href="https://github.com/cryptomator/hub/issues/333">#333</a>
+	 */
+	@Deprecated(since = "1.3.0", forRemoval = true)
 	@ApplicationScoped
-	@Deprecated
 	public static class Repository implements PanacheRepositoryBase<LegacyAccessToken, AccessId> {
 
 		public LegacyAccessToken unlock(UUID vaultId, String deviceId, String userId) {

--- a/backend/src/main/java/org/cryptomator/hub/entities/LegacyDevice.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/LegacyDevice.java
@@ -15,9 +15,16 @@ import jakarta.persistence.NamedQuery;
 import jakarta.persistence.Table;
 
 import java.time.Instant;
+import java.util.List;
+import java.util.stream.Stream;
 
+@NamedQuery(name = "LegacyDevice.allInList",
+		query = """
+				SELECT d
+				FROM LegacyDevice d
+				WHERE d.id IN :ids
+				""")
 @NamedQuery(name = "LegacyDevice.deleteByOwner", query = "DELETE FROM LegacyDevice d WHERE d.owner.id = :userId")
-
 @Deprecated
 @Entity
 @Table(name = "device_legacy")
@@ -70,6 +77,10 @@ public class LegacyDevice {
 	@ApplicationScoped
 	@Deprecated
 	public static class Repository implements PanacheRepositoryBase<LegacyDevice, String> {
+
+		public Stream<LegacyDevice> findAllInList(List<String> ids) {
+			return find("#LegacyDevice.allInList", Parameters.with("ids", ids)).stream();
+		}
 
 		public void deleteByOwner(String userId) {
 			delete("#LegacyDevice.deleteByOwner", Parameters.with("userId", userId));

--- a/backend/src/main/java/org/cryptomator/hub/entities/LegacyDevice.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/LegacyDevice.java
@@ -18,6 +18,10 @@ import java.time.Instant;
 import java.util.List;
 import java.util.stream.Stream;
 
+/**
+ * @deprecated to be removed in <a href="https://github.com/cryptomator/hub/issues/333">#333</a>
+ */
+@Deprecated(since = "1.3.0", forRemoval = true)
 @NamedQuery(name = "LegacyDevice.allInList",
 		query = """
 				SELECT d
@@ -25,7 +29,6 @@ import java.util.stream.Stream;
 				WHERE d.id IN :ids
 				""")
 @NamedQuery(name = "LegacyDevice.deleteByOwner", query = "DELETE FROM LegacyDevice d WHERE d.owner.id = :userId")
-@Deprecated
 @Entity
 @Table(name = "device_legacy")
 public class LegacyDevice {
@@ -81,8 +84,11 @@ public class LegacyDevice {
 
 	// Further attributes omitted, as they are no longer used. The above ones are exceptions, as they are referenced via JPQL for joining and required for the device list.
 
+	/**
+	 * @deprecated to be removed in <a href="https://github.com/cryptomator/hub/issues/333">#333</a>
+	 */
+	@Deprecated(since = "1.3.0", forRemoval = true)
 	@ApplicationScoped
-	@Deprecated
 	public static class Repository implements PanacheRepositoryBase<LegacyDevice, String> {
 
 		public Stream<LegacyDevice> findAllInList(List<String> ids) {

--- a/backend/src/main/java/org/cryptomator/hub/entities/LegacyDevice.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/LegacyDevice.java
@@ -45,6 +45,9 @@ public class LegacyDevice {
 	@Enumerated(EnumType.STRING)
 	private Device.Type type;
 
+	@Column(name = "publickey", nullable = false)
+	private String publickey;
+
 	@Column(name = "creation_time", nullable = false)
 	private Instant creationTime;
 
@@ -70,6 +73,10 @@ public class LegacyDevice {
 
 	public Device.Type getType() {
 		return type;
+	}
+
+	public String getPublickey() {
+		return publickey;
 	}
 
 	// Further attributes omitted, as they are no longer used. The above ones are exceptions, as they are referenced via JPQL for joining and required for the device list.

--- a/backend/src/main/java/org/cryptomator/hub/entities/LegacyDevice.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/LegacyDevice.java
@@ -1,11 +1,22 @@
 package org.cryptomator.hub.entities;
 
 import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import io.quarkus.panache.common.Parameters;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.NamedQuery;
 import jakarta.persistence.Table;
+
+import java.time.Instant;
+
+@NamedQuery(name = "LegacyDevice.deleteByOwner", query = "DELETE FROM LegacyDevice d WHERE d.owner.id = :userId")
 
 @Deprecated
 @Entity
@@ -16,8 +27,19 @@ public class LegacyDevice {
 	@Column(name = "id", nullable = false)
 	private String id;
 
-	@Column(name = "owner_id", nullable = false)
-	private String ownerId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "owner_id", updatable = false, nullable = false)
+	private User owner;
+
+	@Column(name = "name", nullable = false)
+	private String name;
+
+	@Column(name = "type", nullable = false)
+	@Enumerated(EnumType.STRING)
+	private Device.Type type;
+
+	@Column(name = "creation_time", nullable = false)
+	private Instant creationTime;
 
 	public String getId() {
 		return id;
@@ -27,18 +49,30 @@ public class LegacyDevice {
 		this.id = id;
 	}
 
-	public String getOwnerId() {
-		return ownerId;
+	public User getOwner() {
+		return owner;
 	}
 
-	public void setOwnerId(String ownerId) {
-		this.ownerId = ownerId;
+	public String getName() {
+		return name;
 	}
 
-	// Further attributes omitted, as they are no longer used. The above ones are exceptions, as they are referenced via JPQL for joining.
+	public Instant getCreationTime() {
+		return creationTime;
+	}
+
+	public Device.Type getType() {
+		return type;
+	}
+
+	// Further attributes omitted, as they are no longer used. The above ones are exceptions, as they are referenced via JPQL for joining and required for the device list.
 
 	@ApplicationScoped
 	@Deprecated
 	public static class Repository implements PanacheRepositoryBase<LegacyDevice, String> {
+
+		public void deleteByOwner(String userId) {
+			delete("#LegacyDevice.deleteByOwner", Parameters.with("userId", userId));
+		}
 	}
 }

--- a/backend/src/main/java/org/cryptomator/hub/entities/LegacyDevice.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/LegacyDevice.java
@@ -28,7 +28,7 @@ import java.util.stream.Stream;
 				FROM LegacyDevice d
 				WHERE d.id IN :ids
 				""")
-@NamedQuery(name = "LegacyDevice.deleteByOwner", query = "DELETE FROM LegacyDevice d WHERE d.owner.id = :userId")
+@NamedQuery(name = "LegacyDevice.deleteByOwner", query = "DELETE FROM LegacyDevice d WHERE d.ownerId = :userId")
 @Entity
 @Table(name = "device_legacy")
 public class LegacyDevice {
@@ -40,6 +40,9 @@ public class LegacyDevice {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "owner_id", updatable = false, nullable = false)
 	private User owner;
+
+	@Column(name = "owner_id", insertable = false, updatable = false, nullable = false)
+	private String ownerId;
 
 	@Column(name = "name", nullable = false)
 	private String name;

--- a/backend/src/main/java/org/cryptomator/hub/entities/User.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/User.java
@@ -136,11 +136,20 @@ public class User extends Authority {
 		this.devices = devices;
 	}
 
+	@Deprecated
+	public Set<LegacyDevice> getLegacyDevices() {
+		return legacyDevices;
+	}
+
 	@OneToMany(mappedBy = "user", fetch = FetchType.LAZY)
 	public Set<AccessToken> accessTokens = new HashSet<>();
 
 	@OneToMany(mappedBy = "owner", orphanRemoval = true, fetch = FetchType.LAZY)
 	public Set<Device> devices = new HashSet<>();
+
+	@Deprecated
+	@OneToMany(mappedBy = "owner", orphanRemoval = true, fetch = FetchType.LAZY)
+	public Set<LegacyDevice> legacyDevices = new HashSet<>();
 
 	@Override
 	public boolean equals(Object o) {

--- a/backend/src/main/java/org/cryptomator/hub/entities/User.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/User.java
@@ -136,7 +136,10 @@ public class User extends Authority {
 		this.devices = devices;
 	}
 
-	@Deprecated
+	/**
+	 * @deprecated to be removed in <a href="https://github.com/cryptomator/hub/issues/333">#333</a>
+	 */
+	@Deprecated(since = "1.3.0", forRemoval = true)
 	public Set<LegacyDevice> getLegacyDevices() {
 		return legacyDevices;
 	}
@@ -147,7 +150,10 @@ public class User extends Authority {
 	@OneToMany(mappedBy = "owner", orphanRemoval = true, fetch = FetchType.LAZY)
 	public Set<Device> devices = new HashSet<>();
 
-	@Deprecated
+	/**
+	 * @deprecated to be removed in <a href="https://github.com/cryptomator/hub/issues/333">#333</a>
+	 */
+	@Deprecated(since = "1.3.0", forRemoval = true)
 	@OneToMany(mappedBy = "owner", orphanRemoval = true, fetch = FetchType.LAZY)
 	public Set<LegacyDevice> legacyDevices = new HashSet<>();
 

--- a/backend/src/test/java/org/cryptomator/hub/api/DeviceResourceIT.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/DeviceResourceIT.java
@@ -235,15 +235,15 @@ public class DeviceResourceIT {
 
 		@Test
 		@Order(7)
-		@DisplayName("DELETE /devices/device999 with legacy flag and non legacy device returns 404")
+		@DisplayName("DELETE /devices/device999/legacy-device as legacy device returns 404")
 		public void testDeleteExistingDeviceAsLegacyDevice() {
-			when().delete("/devices/{deviceId}?legacyDevice=true", "device999") //
+			when().delete("/devices/{deviceId}/legacy-device", "device999") //
 					.then().statusCode(404);
 		}
 
 		@Test
 		@Order(7)
-		@DisplayName("DELETE /devices/device15000 without legacy flag and legacy device returns 404")
+		@DisplayName("DELETE /devices/device15000 as non legacy device returns 404")
 		public void testDeleteExistingLegacyDeviceAsDevice() throws SQLException {
 			try (var c = dataSource.getConnection(); var s = c.createStatement()) {
 				s.execute("""
@@ -288,7 +288,7 @@ public class DeviceResourceIT {
 						""");
 			}
 
-			when().delete("/devices/{deviceId}?legacyDevice=true", "device15000") //
+			when().delete("/devices/{deviceId}/legacy-device", "device15000") //
 					.then().statusCode(204);
 
 			try (var c = dataSource.getConnection(); var s = c.createStatement()) {
@@ -361,15 +361,12 @@ public class DeviceResourceIT {
 		}
 
 		@Test
-		@DisplayName("GET /devices?ids=device2&ids=device3&ids=legacyDevice1&withLegacyDevices=true returns 200 with body containing device2, device3 and legacyDevice1")
-		public void testGetSomeWithLegacyDevices() {
+		@DisplayName("GET /devices/legacy-devices?ids=legacyDevice1&ids=device2&ids=device3 returns 200 with body containing device2, device3 and legacyDevice1")
+		public void testGetSomeLegacyDevices() {
 			given().param("ids", "device2", "device3", "legacyDevice1")
-					.param("withLegacyDevices", true)
-					.when().get("/devices")
+					.when().get("/devices/legacy-devices")
 					.then().statusCode(200)
-					.body("id", containsInAnyOrder("device2", "device3", "legacyDevice1"))
-					.body("find { it.id == 'device2' }.legacyDevice", is(false))
-					.body("find { it.id == 'device3' }.legacyDevice", is(false))
+					.body("id", containsInAnyOrder("legacyDevice1"))
 					.body("find { it.id == 'legacyDevice1' }.legacyDevice", is(true));
 		}
 

--- a/backend/src/test/java/org/cryptomator/hub/api/DeviceResourceIT.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/DeviceResourceIT.java
@@ -350,12 +350,27 @@ public class DeviceResourceIT {
 		}
 
 		@Test
-		@DisplayName("GET /devices?ids=device2&ids=device3 returns 200 with body containing device2 and device3")
+		@DisplayName("GET /devices?ids=device2&ids=device3&ids=legacyDevice1 returns 200 with body containing device2 and device3")
 		public void testGetSome() {
-			given().param("ids", "device2", "device3")
+			given().param("ids", "device2", "device3", "legacyDevice1")
 					.when().get("/devices")
 					.then().statusCode(200)
-					.body("id", containsInAnyOrder("device2", "device3"));
+					.body("id", containsInAnyOrder("device2", "device3"))
+					.body("find { it.id == 'device2' }.legacyDevice", is(false))
+					.body("find { it.id == 'device3' }.legacyDevice", is(false));
+		}
+
+		@Test
+		@DisplayName("GET /devices?ids=device2&ids=device3&ids=legacyDevice1&withLegacyDevices=true returns 200 with body containing device2, device3 and legacyDevice1")
+		public void testGetSomeWithLegacyDevices() {
+			given().param("ids", "device2", "device3", "legacyDevice1")
+					.param("withLegacyDevices", true)
+					.when().get("/devices")
+					.then().statusCode(200)
+					.body("id", containsInAnyOrder("device2", "device3", "legacyDevice1"))
+					.body("find { it.id == 'device2' }.legacyDevice", is(false))
+					.body("find { it.id == 'device3' }.legacyDevice", is(false))
+					.body("find { it.id == 'legacyDevice1' }.legacyDevice", is(true));
 		}
 
 		@Test

--- a/backend/src/test/java/org/cryptomator/hub/api/UsersResourceIT.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/UsersResourceIT.java
@@ -105,7 +105,7 @@ public class UsersResourceIT {
 		}
 
 		@Test
-		@DisplayName("GET /users/me?withLastAccessAndLegacyDevices=true returns 200")
+		@DisplayName("GET /users/me-with-legacy-devices-and-access returns 200")
 		public void testGetMe3() throws SQLException {
 			try (var c = dataSource.getConnection(); var s = c.createStatement()) {
 				s.execute("""
@@ -116,12 +116,9 @@ public class UsersResourceIT {
 						""");
 			}
 
-			when().get("/users/me?withLastAccessAndLegacyDevices=true")
+			when().get("/users/me-with-legacy-devices-and-access")
 					.then().statusCode(200)
 					.body("id", is("user1"))
-					.body("devices.find { it.id == 'device1' }.lastAccessTime", equalTo("2020-02-20T20:20:24.242Z"))
-					.body("devices.find { it.id == 'device1' }.lastIpAddress", equalTo("1.2.3.4"))
-					.body("devices.find { it.id == 'device1' }.legacyDevice", equalTo(false))
 					.body("devices.find { it.id == 'legacyDevice1' }.lastAccessTime", equalTo("2020-02-20T20:20:24.242Z"))
 					.body("devices.find { it.id == 'legacyDevice1' }.lastIpAddress", equalTo("1.2.3.4"))
 					.body("devices.find { it.id == 'legacyDevice1' }.legacyDevice", equalTo(true));

--- a/frontend/src/common/auditlog.ts
+++ b/frontend/src/common/auditlog.ts
@@ -155,7 +155,7 @@ export class AuditLogEntityCache {
 
   private debouncedResolvePendingVaults = debounce(async () => await this.resolvePendingEntities<VaultDto>(this.vaults, backend.vaults.listSome), 100);
   private debouncedResolvePendingAuthorities = debounce(async () => await this.resolvePendingEntities<AuthorityDto>(this.authorities, backend.authorities.listSome), 100);
-  private debouncedResolvePendingDevices = debounce(async () => await this.resolvePendingEntities<DeviceDto>(this.devices, backend.devices.listSome), 100);
+  private debouncedResolvePendingDevices = debounce(async () => await this.resolvePendingEntities<DeviceDto>(this.devices, (deviceIds: string[]) => backend.devices.listSome(deviceIds, true)), 100);
 
   private async resolvePendingEntities<T extends { id: string }>(entities: Map<string, Deferred<T>>, listSome: (ids: string[]) => Promise<T[]>): Promise<void> {
     const pendingEntities = Array.from(entities.entries()).filter(([, v]) => v.status === 'pending');

--- a/frontend/src/common/auditlog.ts
+++ b/frontend/src/common/auditlog.ts
@@ -155,7 +155,19 @@ export class AuditLogEntityCache {
 
   private debouncedResolvePendingVaults = debounce(async () => await this.resolvePendingEntities<VaultDto>(this.vaults, backend.vaults.listSome), 100);
   private debouncedResolvePendingAuthorities = debounce(async () => await this.resolvePendingEntities<AuthorityDto>(this.authorities, backend.authorities.listSome), 100);
-  private debouncedResolvePendingDevices = debounce(async () => await this.resolvePendingEntities<DeviceDto>(this.devices, (deviceIds: string[]) => backend.devices.listSome(deviceIds, true)), 100);
+  private debouncedResolvePendingDevices = debounce(async () => {
+    await this.resolvePendingEntities<DeviceDto>(
+      this.devices,
+      (deviceIds: string[]) =>
+        Promise.all([
+          backend.devices.listSome(deviceIds).catch(() => []),
+          backend.devices.listSomeLegacyDevices(deviceIds).catch(() => [])
+        ]).then(([devices, legacyDevices]) => [
+          ...devices,
+          ...legacyDevices
+        ])
+    );
+  }, 100);
 
   private async resolvePendingEntities<T extends { id: string }>(entities: Map<string, Deferred<T>>, listSome: (ids: string[]) => Promise<T[]>): Promise<void> {
     const pendingEntities = Array.from(entities.entries()).filter(([, v]) => v.status === 'pending');

--- a/frontend/src/common/backend.ts
+++ b/frontend/src/common/backend.ts
@@ -236,7 +236,7 @@ class DeviceService {
     return axiosAuth.get<DeviceDto[]>(`/devices?${query}`).then(response => response.data);
   }
 
-  /** @deprecated use `listSome` instead */
+  /** @deprecated since version 1.3.0, to be removed in https://github.com/cryptomator/hub/issues/333 */
   public async listSomeLegacyDevices(deviceIds: string[]): Promise<DeviceDto[]> {
     const query = `ids=${deviceIds.join('&ids=')}`;
     return axiosAuth.get<DeviceDto[]>(`/devices/legacy-devices?${query}`).then(response => response.data);
@@ -247,7 +247,7 @@ class DeviceService {
       .catch((error) => rethrowAndConvertIfExpected(error, 404));
   }
 
-  /** @deprecated use `removeDevice` instead */
+  /** @deprecated since version 1.3.0, to be removed in https://github.com/cryptomator/hub/issues/333 */
   public async removeLegacyDevice(deviceId: string): Promise<AxiosResponse<unknown>> {
     return axiosAuth.delete(`/devices/${deviceId}/legacy-device`)
       .catch((error) => rethrowAndConvertIfExpected(error, 404));
@@ -267,7 +267,7 @@ class UserService {
     return axiosAuth.get<UserDto>(`/users/me?withDevices=${withDevices}&withLastAccess=${withLastAccess}`).then(response => AuthorityService.fillInMissingPicture(response.data));
   }
 
-  /** @deprecated use `me` instead */
+  /** @deprecated since version 1.3.0, to be removed in https://github.com/cryptomator/hub/issues/333 */
   public async meWithLegacyDevicesAndAccess(): Promise<UserDto> {
     return axiosAuth.get<UserDto>('/users/me-with-legacy-devices-and-access').then(response => AuthorityService.fillInMissingPicture(response.data));
   }

--- a/frontend/src/common/backend.ts
+++ b/frontend/src/common/backend.ts
@@ -231,8 +231,8 @@ class VaultService {
 }
 
 class DeviceService {
-  public async listSome(deviceIds: string[]): Promise<DeviceDto[]> {
-    const query = `ids=${deviceIds.join('&ids=')}`;
+  public async listSome(deviceIds: string[], withLegacyDevices: boolean = false): Promise<DeviceDto[]> {
+    const query = `ids=${deviceIds.join('&ids=')}&withLegacyDevices=${withLegacyDevices}`;
     return axiosAuth.get<DeviceDto[]>(`/devices?${query}`).then(response => response.data);
   }
 

--- a/frontend/src/common/backend.ts
+++ b/frontend/src/common/backend.ts
@@ -57,6 +57,7 @@ export type DeviceDto = {
   creationTime: Date;
   lastIpAddress?: string;
   lastAccessTime?: Date;
+  legacyDevice?: boolean;
 };
 
 export type VaultRole = 'MEMBER' | 'OWNER';
@@ -235,8 +236,9 @@ class DeviceService {
     return axiosAuth.get<DeviceDto[]>(`/devices?${query}`).then(response => response.data);
   }
 
-  public async removeDevice(deviceId: string): Promise<AxiosResponse<unknown>> {
-    return axiosAuth.delete(`/devices/${deviceId}`)
+  public async removeDevice(device: DeviceDto): Promise<AxiosResponse<unknown>> {
+    const query = device.legacyDevice == false ? '' : '?legacyDevice=true';
+    return axiosAuth.delete(`/devices/${device.id}${query}`)
       .catch((error) => rethrowAndConvertIfExpected(error, 404));
   }
 
@@ -251,7 +253,7 @@ class UserService {
   }
 
   public async me(withDevices: boolean = false, withLastAccess: boolean = false): Promise<UserDto> {
-    return axiosAuth.get<UserDto>(`/users/me?withDevices=${withDevices}&withLastAccess=${withLastAccess}`).then(response => AuthorityService.fillInMissingPicture(response.data));
+    return axiosAuth.get<UserDto>(`/users/me?withDevices=${withDevices}&withLastAccessAndLegacyDevices=${withLastAccess}`).then(response => AuthorityService.fillInMissingPicture(response.data));
   }
 
   public async resetMe(): Promise<void> {

--- a/frontend/src/common/backend.ts
+++ b/frontend/src/common/backend.ts
@@ -231,14 +231,25 @@ class VaultService {
 }
 
 class DeviceService {
-  public async listSome(deviceIds: string[], withLegacyDevices: boolean = false): Promise<DeviceDto[]> {
-    const query = `ids=${deviceIds.join('&ids=')}&withLegacyDevices=${withLegacyDevices}`;
+  public async listSome(deviceIds: string[]): Promise<DeviceDto[]> {
+    const query = `ids=${deviceIds.join('&ids=')}`;
     return axiosAuth.get<DeviceDto[]>(`/devices?${query}`).then(response => response.data);
   }
 
-  public async removeDevice(device: DeviceDto): Promise<AxiosResponse<unknown>> {
-    const query = device.legacyDevice == false ? '' : '?legacyDevice=true';
-    return axiosAuth.delete(`/devices/${device.id}${query}`)
+  /** @deprecated use `listSome` instead */
+  public async listSomeLegacyDevices(deviceIds: string[]): Promise<DeviceDto[]> {
+    const query = `ids=${deviceIds.join('&ids=')}`;
+    return axiosAuth.get<DeviceDto[]>(`/devices/legacy-devices?${query}`).then(response => response.data);
+  }
+
+  public async removeDevice(deviceId: string): Promise<AxiosResponse<unknown>> {
+    return axiosAuth.delete(`/devices/${deviceId}`)
+      .catch((error) => rethrowAndConvertIfExpected(error, 404));
+  }
+
+  /** @deprecated use `removeDevice` instead */
+  public async removeLegacyDevice(deviceId: string): Promise<AxiosResponse<unknown>> {
+    return axiosAuth.delete(`/devices/${deviceId}/legacy-device`)
       .catch((error) => rethrowAndConvertIfExpected(error, 404));
   }
 
@@ -253,7 +264,12 @@ class UserService {
   }
 
   public async me(withDevices: boolean = false, withLastAccess: boolean = false): Promise<UserDto> {
-    return axiosAuth.get<UserDto>(`/users/me?withDevices=${withDevices}&withLastAccessAndLegacyDevices=${withLastAccess}`).then(response => AuthorityService.fillInMissingPicture(response.data));
+    return axiosAuth.get<UserDto>(`/users/me?withDevices=${withDevices}&withLastAccess=${withLastAccess}`).then(response => AuthorityService.fillInMissingPicture(response.data));
+  }
+
+  /** @deprecated use `me` instead */
+  public async meWithLegacyDevicesAndAccess(): Promise<UserDto> {
+    return axiosAuth.get<UserDto>('/users/me-with-legacy-devices-and-access').then(response => AuthorityService.fillInMissingPicture(response.data));
   }
 
   public async resetMe(): Promise<void> {

--- a/frontend/src/common/userdata.ts
+++ b/frontend/src/common/userdata.ts
@@ -8,6 +8,9 @@ class UserData {
   #meWithLastAccess?: Promise<UserDto>;
   #browserKeys?: Promise<BrowserKeys | undefined>;
 
+  /** @deprecated use `meWithLastAccess` instead */
+  #meWithLegacyDevicesAndLastAccess?: Promise<UserDto>;
+
   /**
    * Gets the user DTO representing the currently logged in user.
    */
@@ -24,6 +27,14 @@ class UserData {
       this.#me = this.#meWithLastAccess;
     }
     return this.#meWithLastAccess;
+  }
+
+  /** @deprecated use `meWithLastAccess` instead */
+  public get meWithLegacyDevicesAndLastAccess(): Promise<UserDto> {
+    if (!this.#meWithLegacyDevicesAndLastAccess) {
+      this.#meWithLegacyDevicesAndLastAccess = backend.users.meWithLegacyDevicesAndAccess();
+    }
+    return this.#meWithLegacyDevicesAndLastAccess;
   }
 
   /**

--- a/frontend/src/common/userdata.ts
+++ b/frontend/src/common/userdata.ts
@@ -8,7 +8,7 @@ class UserData {
   #meWithLastAccess?: Promise<UserDto>;
   #browserKeys?: Promise<BrowserKeys | undefined>;
 
-  /** @deprecated use `meWithLastAccess` instead */
+  /** @deprecated since version 1.3.0, to be removed in https://github.com/cryptomator/hub/issues/333 */
   #meWithLegacyDevicesAndLastAccess?: Promise<UserDto>;
 
   /**
@@ -29,7 +29,7 @@ class UserData {
     return this.#meWithLastAccess;
   }
 
-  /** @deprecated use `meWithLastAccess` instead */
+  /** @deprecated since version 1.3.0, to be removed in https://github.com/cryptomator/hub/issues/333 */
   public get meWithLegacyDevicesAndLastAccess(): Promise<UserDto> {
     if (!this.#meWithLegacyDevicesAndLastAccess) {
       this.#meWithLegacyDevicesAndLastAccess = backend.users.meWithLegacyDevicesAndAccess();

--- a/frontend/src/components/AuditLog.vue
+++ b/frontend/src/components/AuditLog.vue
@@ -314,7 +314,6 @@ const eventTypeOptions = Object.fromEntries(
     VAULT_UPDATE: t('auditLog.details.vault.update')
   }).sort(([,valueA], [,valueB]) => valueA.localeCompare(valueB))
 );
-const allEventTypes = Object.keys(eventTypeOptions);
 const selectedEventTypes = ref<string[]>([]);
 
 const currentPage = ref(0);

--- a/frontend/src/components/DeviceList.vue
+++ b/frontend/src/components/DeviceList.vue
@@ -56,6 +56,7 @@
                     <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
                       <div class="flex items-center gap-3">
                         <div>{{ device.name }}</div>
+                        <div v-if="device.legacyDevice == true" class="inline-flex items-center rounded-md bg-yellow-50 px-2 py-1 text-xs font-medium text-yellow-700 ring-1 ring-inset ring-yellow-600/20">Legacy</div>
                         <div v-if="device.id == myDevice?.id" class="inline-flex items-center rounded-md bg-green-50 px-2 py-1 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-600/20">{{ t('deviceList.thisDevice') }}</div>
                       </div>
                     </td>
@@ -135,7 +136,7 @@ async function fetchData() {
 async function removeDevice(device: DeviceDto) {
   delete onRemoveDeviceError.value[device.id];
   try {
-    await backend.devices.removeDevice(device.id);
+    await backend.devices.removeDevice(device);
     userdata.reload();
   } catch (error) {
     console.error('Removing device failed.', error);

--- a/frontend/src/components/LegacyDeviceList.vue
+++ b/frontend/src/components/LegacyDeviceList.vue
@@ -8,29 +8,37 @@
     </div>
   </div>
 
-  <div v-if="me?.devices">
-    <h2 id="deviceListTitle" class="text-base font-semibold leading-6 text-gray-900">
-      {{ t('deviceList.title') }}
+  <div v-if="me?.devices && me.devices.length > 0">
+    <h2 id="legacyDeviceListTitle" class="text-base font-semibold leading-6 text-gray-900">
+      {{ t('legacyDeviceList.title') }}
     </h2>
+
+    <p class="mt-1 text-sm text-gray-500">
+      {{ t('legacyDeviceList.description') }}
+      <a href="https://docs.cryptomator.org/en/latest/security/hub/#web-of-trust" target="_blank" class="inline-flex items-center text-primary underline hover:text-primary-darker">
+        Learn more
+        <ArrowRightIcon class="ml-1 h-4 w-4" aria-hidden="true" />
+      </a>
+    </p>
 
     <div class="mt-4 flex flex-col">
       <div class="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
         <div class="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
           <div class="shadow-sm overflow-hidden border-b border-gray-200 sm:rounded-lg">
-            <table class="min-w-full divide-y divide-gray-200" aria-describedby="deviceListTitle">
+            <table class="min-w-full divide-y divide-gray-200" aria-describedby="legacyDeviceListTitle">
               <thead class="bg-gray-50">
                 <tr>
                   <th scope="col" class="w-12 px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"></th>
                   <th scope="col" class="px-2 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider flex-grow">
-                    {{ t('deviceList.deviceName') }}
+                    {{ t('legacyDeviceList.deviceName') }}
                   </th>
                   <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">
-                    {{ t('deviceList.added') }}
+                    {{ t('legacyDeviceList.added') }}
                   </th>
                   <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">
                     <span class="inline-flex items-center gap-1">
-                      {{ t('deviceList.lastAccess') }}
-                      <div class="relative group" :title="t('deviceList.lastAccess.toolTip')">
+                      {{ t('legacyDeviceList.lastAccess') }}
+                      <div class="relative group" :title="t('legacyDeviceList.lastAccess.toolTip')">
                         <QuestionMarkCircleIcon class="h-4 w-4 text-gray-400"/>
                       </div>
                     </span>
@@ -45,21 +53,14 @@
                   <tr>
                     <td class="py-4 text-sm text-gray-500">
                       <div class="grid place-items-center h-12 aspect-square">
-                        <span v-if="device.type == 'BROWSER'" :title="'Browser'">
-                          <WindowIcon class="size-5" aria-hidden="true" />
-                        </span>
-                        <span v-else-if="device.type == 'DESKTOP'" :title="'Desktop'">
+                        <span v-if="device.type == 'DESKTOP'" :title="'Desktop'">
                           <ComputerDesktopIcon class="size-5" aria-hidden="true" />
-                        </span>
-                        <span v-else-if="device.type == 'MOBILE'" :title="'Mobile'">
-                          <DevicePhoneMobileIcon class="size-5" aria-hidden="true" />
                         </span>
                       </div>
                     </td>
                     <td class="px-2 py-4 whitespace-nowrap text-sm font-medium text-gray-900 flex-grow">
                       <div class="flex items-center gap-3">
                         <div>{{ device.name }}</div>
-                        <div v-if="device.id == myDevice?.id" class="inline-flex items-center rounded-md bg-green-50 px-2 py-1 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-600/20">{{ t('deviceList.thisDevice') }}</div>
                       </div>
                     </td>
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
@@ -74,7 +75,7 @@
                       </div>
                     </td>
                     <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                      <a v-if="device.id != myDevice?.id" tabindex="0" class="text-red-600 hover:text-red-900" @click="removeDevice(device)">{{ t('common.remove') }}</a>
+                      <a tabindex="0" class="text-red-600 hover:text-red-900" @click="removeDevice(device)">{{ t('common.remove') }}</a>
                     </td>
                   </tr>
                   <!-- TODO: good styling -->
@@ -94,7 +95,7 @@
 </template>
 
 <script setup lang="ts">
-import { ComputerDesktopIcon, DevicePhoneMobileIcon, QuestionMarkCircleIcon, WindowIcon } from '@heroicons/vue/24/solid';
+import { ArrowRightIcon, ComputerDesktopIcon, QuestionMarkCircleIcon } from '@heroicons/vue/24/solid';
 import { computed, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import backend, { DeviceDto, NotFoundError, UserDto } from '../common/backend';
@@ -104,7 +105,6 @@ import FetchError from './FetchError.vue';
 const { t, d } = useI18n({ useScope: 'global' });
 
 const me = ref<UserDto>();
-const myDevice = ref<DeviceDto>();
 const onFetchError = ref<Error | null>();
 const onRemoveDeviceError = ref< {[id: string]: Error} >({});
 
@@ -115,10 +115,9 @@ onMounted(async () => {
 async function fetchData() {
   onFetchError.value = null;
   try {
-    me.value = await userdata.meWithLastAccess;
-    myDevice.value = await userdata.browser;
+    me.value = await userdata.meWithLegacyDevicesAndLastAccess;
   } catch (error) {
-    console.error('Retrieving device list failed.', error);
+    console.error('Retrieving legacy device list failed.', error);
     onFetchError.value = error instanceof Error ? error : new Error('Unknown Error');
   }
 }
@@ -126,10 +125,10 @@ async function fetchData() {
 async function removeDevice(device: DeviceDto) {
   delete onRemoveDeviceError.value[device.id];
   try {
-    await backend.devices.removeDevice(device.id);
+    await backend.devices.removeLegacyDevice(device.id);
     userdata.reload();
   } catch (error) {
-    console.error('Removing device failed.', error);
+    console.error('Removing legacy device failed.', error);
     if (error instanceof NotFoundError) {
       // if device is already missing in backend → ignore and proceed to then()
     } else {

--- a/frontend/src/components/LegacyDeviceList.vue
+++ b/frontend/src/components/LegacyDeviceList.vue
@@ -16,7 +16,7 @@
     <p class="mt-1 text-sm text-gray-500">
       {{ t('legacyDeviceList.description') }}
       <a href="https://docs.cryptomator.org/hub/your-account/#legacy-devices" target="_blank" class="inline-flex items-center text-primary underline hover:text-primary-darker">
-        Learn more
+        {{ t('legacyDeviceList.description.information') }}
         <ArrowRightIcon class="ml-1 h-4 w-4" aria-hidden="true" />
       </a>
     </p>

--- a/frontend/src/components/LegacyDeviceList.vue
+++ b/frontend/src/components/LegacyDeviceList.vue
@@ -15,7 +15,7 @@
 
     <p class="mt-1 text-sm text-gray-500">
       {{ t('legacyDeviceList.description') }}
-      <a href="https://docs.cryptomator.org/en/latest/security/hub/#web-of-trust" target="_blank" class="inline-flex items-center text-primary underline hover:text-primary-darker">
+      <a href="https://docs.cryptomator.org/hub/your-account/#legacy-devices" target="_blank" class="inline-flex items-center text-primary underline hover:text-primary-darker">
         Learn more
         <ArrowRightIcon class="ml-1 h-4 w-4" aria-hidden="true" />
       </a>

--- a/frontend/src/components/UserProfile.vue
+++ b/frontend/src/components/UserProfile.vue
@@ -54,6 +54,7 @@
       <div class="grid grid-cols-1 gap-8 lg:col-span-3">
         <ManageSetupCode />
         <DeviceList />
+        <LegacyDeviceList />
         <UserkeyFingerprint :user="me"/>
       </div>
     </div>
@@ -72,6 +73,7 @@ import userdata from '../common/userdata';
 import { Locale } from '../i18n';
 import DeviceList from './DeviceList.vue';
 import FetchError from './FetchError.vue';
+import LegacyDeviceList from './LegacyDeviceList.vue';
 import ManageSetupCode from './ManageSetupCode.vue';
 import UserkeyFingerprint from './UserkeyFingerprint.vue';
 

--- a/frontend/src/i18n/en-US.json
+++ b/frontend/src/i18n/en-US.json
@@ -146,7 +146,6 @@
   "deviceList.added": "Added",
   "deviceList.thisDevice": "This Device",
   "deviceList.ipAddress": "IP Address",
-  "deviceList.ipAddress.toolTip": "May not be set for legacy reasons.",
   "deviceList.lastAccess": "Last Vault Access",
   "deviceList.lastAccess.toolTip": "May not be set for legacy reasons.",
 
@@ -201,6 +200,16 @@
   "licenseAlert.licenseExpired.admin.description": "Your Cryptomator Hub license has expired. Renew it in the {0} in order to manage and unlock your vaults again.",
   "licenseAlert.licenseExpired.user.description": "Your Cryptomator Hub license has expired. Please inform a Hub administrator to renew the license.",
   "licenseAlert.button": "Admin Section",
+
+  "legacyDeviceList.title": "Legacy Devices",
+  "legacyDeviceList.description": "These devices were created with an older version of Hub and will not be able to unlock vaults in a future update. If you no longer need them, please remove them. If you are still using them, please update Cryptomator Desktop and your devices will be migrated to actively supported devices.",
+  "legacyDeviceList.deviceName": "Device Name",
+  "legacyDeviceList.type": "Type",
+  "legacyDeviceList.added": "Added",
+  "legacyDeviceList.thisDevice": "This Device",
+  "legacyDeviceList.ipAddress": "IP Address",
+  "legacyDeviceList.lastAccess": "Last Vault Access",
+  "legacyDeviceList.lastAccess.toolTip": "May not be set for legacy reasons.",
 
   "manageAccountKey.title": "Account Key",
   "manageAccountKey.description": "Your Account Key is required to login from other apps or browsers.",

--- a/frontend/src/i18n/en-US.json
+++ b/frontend/src/i18n/en-US.json
@@ -60,7 +60,7 @@
 
   "admin.webOfTrust.title": "Web of Trust",
   "admin.webOfTrust.description": "Configure the Web of Trust settings to manage how trust is established between users in the system. These settings affect the verification of user identities and key signatures.",
-  "admin.webOfTrust.information":"Learn more.",
+  "admin.webOfTrust.information": "Learn more.",
   "admin.webOfTrust.wotMaxDepth.error": "Maximum WoT Depth must be between 0 and 9.",
   "admin.webOfTrust.wotMaxDepth.title": "Maximum WoT Depth",
   "admin.webOfTrust.wotMaxDepth.description": "Maximum distance between two users, so an indirect acquaintanceship is still considered trustworthy (assuming intermediate identities have been verified).",
@@ -203,6 +203,7 @@
 
   "legacyDeviceList.title": "Legacy Devices",
   "legacyDeviceList.description": "These devices were created with an older version of Hub and will not be able to unlock vaults in a future update. If you no longer need them, please remove them. If you are still using them, please update Cryptomator Desktop and your devices will be migrated to actively supported devices.",
+  "legacyDeviceList.description.information": "Learn more.",
   "legacyDeviceList.deviceName": "Device Name",
   "legacyDeviceList.type": "Type",
   "legacyDeviceList.added": "Added",
@@ -210,6 +211,7 @@
   "legacyDeviceList.ipAddress": "IP Address",
   "legacyDeviceList.lastAccess": "Last Vault Access",
   "legacyDeviceList.lastAccess.toolTip": "May not be set for legacy reasons.",
+
 
   "manageAccountKey.title": "Account Key",
   "manageAccountKey.description": "Your Account Key is required to login from other apps or browsers.",

--- a/frontend/src/i18n/en-US.json
+++ b/frontend/src/i18n/en-US.json
@@ -202,7 +202,7 @@
   "licenseAlert.button": "Admin Section",
 
   "legacyDeviceList.title": "Legacy Devices",
-  "legacyDeviceList.description": "These devices were created with an older version of Hub and will not be able to unlock vaults in a future update. If you no longer need them, please remove them. If you are still using them, please update Cryptomator Desktop and your devices will be migrated to actively supported devices.",
+  "legacyDeviceList.description": "These devices were created with an older version of Hub and need to be updated to unlock vaults in future versions. If you no longer need them, please remove them. Otherwise, please update Cryptomator on that device. Your next unlock will trigger the update automatically.",
   "legacyDeviceList.description.information": "Learn more.",
   "legacyDeviceList.deviceName": "Device Name",
   "legacyDeviceList.type": "Type",


### PR DESCRIPTION
Still to do:
- [x] "Legacy" is currently hard coded in the frontend, how do we want do display it?
- [x] `withLastAccessAndLegacyDevices` is a quiet ugly name, find a better one
- [x] Fix audit log as well (we need to query devices but also legacy devices regarding e.g. `audit_event_vault_key_retrieve`)


![image](https://github.com/user-attachments/assets/25377471-ceb1-4510-9049-ee5b985dda5f)
![image](https://github.com/user-attachments/assets/5de21456-8699-425b-b18a-b92cbcf82706)
