### PR TITLE
Fix license refresh

### DIFF
--- a/backend/src/main/java/org/cryptomator/hub/license/LicenseHolder.java
+++ b/backend/src/main/java/org/cryptomator/hub/license/LicenseHolder.java
@@ -108,7 +108,7 @@ public class LicenseHolder {
 	 */
 	@Scheduled(cron = "0 0 1 * * ?", timeZone = "UTC", concurrentExecution = Scheduled.ConcurrentExecution.SKIP)
 	void refreshLicense() throws InterruptedException {
-		if (license != null) {
+		if (get() != null) {
 			randomMinuteSleeper.sleep(); // add random sleep between [0,59]min to reduce infrastructure load
 			var refreshUrlClaim = get().getClaim("refreshUrl");
 			if (refreshUrlClaim != null) {


### PR DESCRIPTION
`skipExecutionIf` runs in its own thread, so there is no access to the actual beans in this case. This leads to a `jakarta.enterprise.context.ContextNotActiveException` (runtime exception), while calling (again) `init` in the `LicenseHolder` which crashes the thread and leads to `licenseHolder.license` is always null in this `Scheduled.SkipPredicate` environment.

This reverts the changes made in https://github.com/cryptomator/hub/pull/266 concerning the handling of license refreshes, so that the process is executed again at 1 am UTC (±1 hour).