### PR TITLE
Add unsaved changes notice with undo to WOT settings

### DIFF
--- a/frontend/src/components/AdminSettings.vue
+++ b/frontend/src/components/AdminSettings.vue
@@ -335,10 +335,10 @@ const numberOfExceededSeats = computed(() => {
   return remainingSeats.value < 0 ? Math.abs(remainingSeats.value) : 0;
 });
 
-const initialWebOfTrustSettings = ref<{ wotMaxDepth: number; wotIdVerifyLen: number } | null>(null);
+type WotSettings = { wotMaxDepth: number; wotIdVerifyLen: number };
+const initialWebOfTrustSettings = ref<WotSettings>({ wotMaxDepth: 0, wotIdVerifyLen: 0 });
 
 const wotHasUnsavedChanges = computed(() => {
-  if (!initialWebOfTrustSettings.value) return false;
   return (
     initialWebOfTrustSettings.value.wotMaxDepth !== wotMaxDepth.value ||
     initialWebOfTrustSettings.value.wotIdVerifyLen !== wotIdVerifyLen.value
@@ -434,10 +434,8 @@ async function saveWebOfTrust() {
 }
 
 function resetWebOfTrust() {
-  if (initialWebOfTrustSettings.value) {
-    wotMaxDepth.value = initialWebOfTrustSettings.value.wotMaxDepth;
-    wotIdVerifyLen.value = initialWebOfTrustSettings.value.wotIdVerifyLen;
-  }
+  wotMaxDepth.value = initialWebOfTrustSettings.value.wotMaxDepth;
+  wotIdVerifyLen.value = initialWebOfTrustSettings.value.wotIdVerifyLen;
 }
 
 </script>

--- a/frontend/src/components/AdminSettings.vue
+++ b/frontend/src/components/AdminSettings.vue
@@ -244,14 +244,21 @@
           </div>
 
           <div class="md:grid md:grid-cols-3 md:gap-6">
-            <div class="md:col-start-2">
-              <button type="submit" :disabled="processing" class="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-primary hover:bg-primary-d1 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-primary disabled:opacity-50 disabled:hover:bg-primary disabled:cursor-not-allowed">
+            <div class="md:col-start-2 flex items-center gap-2">
+              <button type="submit" :disabled="processing || !wotHasUnsavedChanges" class="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-primary hover:bg-primary-d1 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-primary disabled:opacity-50 disabled:hover:bg-primary disabled:cursor-not-allowed">
                 <span v-if="!wotUpdated">{{ t('admin.webOfTrust.save') }}</span>
                 <span v-else>{{ t('admin.webOfTrust.saved') }}</span>
               </button>
               <p v-if="onSaveError != null && !(onSaveError instanceof FormValidationFailedError)" class="mt-2 text-sm text-red-900">
                 {{ t('common.unexpectedError', [onSaveError.message]) }}
               </p>
+              <div v-if="wotHasUnsavedChanges" class="flex items-center whitespace-nowrap gap-1 text-sm text-yellow-700">
+                <ExclamationTriangleIcon class="w-4 h-4 m-1 text-yellow-500" />
+                {{ t('common.unsavedChanges') }}&nbsp;
+                <button type="button" class="underline hover:text-yellow-900" @click="resetWebOfTrust()">
+                  {{ t('common.undo') }}
+                </button>
+              </div>
             </div>
           </div>
         </form>
@@ -328,6 +335,16 @@ const numberOfExceededSeats = computed(() => {
   return remainingSeats.value < 0 ? Math.abs(remainingSeats.value) : 0;
 });
 
+const initialWebOfTrustSettings = ref<{ wotMaxDepth: number; wotIdVerifyLen: number } | null>(null);
+
+const wotHasUnsavedChanges = computed(() => {
+  if (!initialWebOfTrustSettings.value) return false;
+  return (
+    initialWebOfTrustSettings.value.wotMaxDepth !== wotMaxDepth.value ||
+    initialWebOfTrustSettings.value.wotIdVerifyLen !== wotIdVerifyLen.value
+  );
+});
+
 onMounted(async () => {
   const cfg = config.get();
   keycloakAdminRealmURL.value = `${cfg.keycloakUrl}/admin/${cfg.keycloakRealm}/console`;
@@ -356,6 +373,10 @@ async function fetchData() {
     const settings = await backend.settings.get();
     wotMaxDepth.value = settings.wotMaxDepth;
     wotIdVerifyLen.value = settings.wotIdVerifyLen;
+    initialWebOfTrustSettings.value = {
+      wotMaxDepth: wotMaxDepth.value,
+      wotIdVerifyLen: wotIdVerifyLen.value
+    };
   } catch (error) {
     if (error instanceof FetchUpdateError) {
       errorOnFetchingUpdates.value = true;
@@ -397,6 +418,10 @@ async function saveWebOfTrust() {
       wotIdVerifyLen: wotIdVerifyLen.value,
       hubId: admin.value.hubId
     };
+    initialWebOfTrustSettings.value = {
+      wotMaxDepth: wotMaxDepth.value,
+      wotIdVerifyLen: wotIdVerifyLen.value
+    };
     await backend.settings.put(settings);
     wotUpdated.value = true;
     debouncedWotUpdated();
@@ -405,6 +430,13 @@ async function saveWebOfTrust() {
     onSaveError.value = error instanceof Error ? error : new Error('Unknown reason');
   } finally {
     processing.value = false;
+  }
+}
+
+function resetWebOfTrust() {
+  if (initialWebOfTrustSettings.value) {
+    wotMaxDepth.value = initialWebOfTrustSettings.value.wotMaxDepth;
+    wotIdVerifyLen.value = initialWebOfTrustSettings.value.wotIdVerifyLen;
   }
 }
 

--- a/frontend/src/i18n/en-US.json
+++ b/frontend/src/i18n/en-US.json
@@ -28,7 +28,9 @@
   "common.retry": "Retry",
   "common.share": "Share",
   "common.show": "Show",
+  "common.undo": "Undo",
   "common.unexpectedError": "Unexpected Error: {0}",
+  "common.unsavedChanges": "Unsaved changes.",
   "common.update": "Update",
   "common.xMembers": "{0} Members",
 


### PR DESCRIPTION
This PR improves the UX when editing the Web of Trust settings:

- Disables the "Save" button if no changes are present.
- Displays an inline message if there are unsaved changes.
- Adds an "Undo" button next to the message.
- The "Undo" button resets the form to the last saved state.

No Changes – Save Button Disabled
<img width="1856" height="934" alt="Bildschirmfoto 2025-07-16 um 15 21 21" src="https://github.com/user-attachments/assets/bf3e6cd9-7353-4b66-b80d-eec75c0a0b7c" />

Unsaved Changes – Save Button Enabled with Undo Option
<img width="1856" height="930" alt="Bildschirmfoto 2025-07-16 um 15 21 39" src="https://github.com/user-attachments/assets/2d487f19-163f-4f04-bbc7-8ffb853fcc3d" />
