### PR TITLE
Show pictures of the groups in the Vaults member list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/cryptomator/hub/compare/1.4.6...HEAD)
 
+### Added
+
+- Show pictures of the groups in the Vaults member list.
+
 ### Changed
 
 - Updated Keycloak to 26.4.7

--- a/backend/src/main/java/org/cryptomator/hub/api/GroupDto.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/GroupDto.java
@@ -8,8 +8,8 @@ public final class GroupDto extends AuthorityDto {
 	@JsonProperty("memberSize")
 	public final Integer memberSize;
 
-	GroupDto(@JsonProperty("id") String id, @JsonProperty("name") String name, @JsonProperty("memberSize") Integer memberSize) {
-		super(id, Type.GROUP, name, null);
+	GroupDto(@JsonProperty("id") String id, @JsonProperty("name") String name, @JsonProperty("pictureUrl") String pictureUrl, @JsonProperty("memberSize") Integer memberSize) {
+		super(id, Type.GROUP, name, pictureUrl);
 		this.memberSize = memberSize;
 	}
 
@@ -19,6 +19,6 @@ public final class GroupDto extends AuthorityDto {
 
 	public static GroupDto fromEntity(Group group, boolean withMemberSize) {
 		Integer memberSize = withMemberSize ? group.getMemberSize() : null;
-		return new GroupDto(group.getId(), group.getName(), memberSize);
+		return new GroupDto(group.getId(), group.getName(), group.getPictureUrl(), memberSize);
 	}
 }

--- a/backend/src/main/java/org/cryptomator/hub/api/MemberDto.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/MemberDto.java
@@ -29,7 +29,7 @@ public final class MemberDto extends AuthorityDto {
 	}
 
 	public static MemberDto fromEntity(Group group, VaultAccess.Role role) {
-		return new MemberDto(group.getId(), Type.GROUP, group.getName(), null, null, null, role, group.getMemberSize());
+		return new MemberDto(group.getId(), Type.GROUP, group.getName(), group.getPictureUrl(), null, null, role, group.getMemberSize());
 	}
 
 }

--- a/backend/src/main/java/org/cryptomator/hub/entities/Authority.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/Authority.java
@@ -41,6 +41,9 @@ public class Authority {
 	@Column(name = "name", nullable = false)
 	private String name;
 
+	@Column(name = "picture_url")
+	private String pictureUrl;
+
 	public String getId() {
 		return id;
 	}
@@ -57,6 +60,15 @@ public class Authority {
 		this.name = name;
 	}
 
+	public String getPictureUrl() {
+		return pictureUrl;
+	}
+
+	public void setPictureUrl(String pictureUrl) {
+		this.pictureUrl = pictureUrl;
+	}
+
+
 	@Override
 	public String toString() {
 		return "Authority{" +
@@ -71,12 +83,13 @@ public class Authority {
 		if (o == null || getClass() != o.getClass()) return false;
 		Authority authority = (Authority) o;
 		return Objects.equals(id, authority.id)
+				&& Objects.equals(pictureUrl, authority.pictureUrl)
 				&& Objects.equals(name, authority.name);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(id, name);
+		return Objects.hash(id, name, pictureUrl);
 	}
 
 	@ApplicationScoped

--- a/backend/src/main/java/org/cryptomator/hub/entities/Authority.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/Authority.java
@@ -68,7 +68,6 @@ public class Authority {
 		this.pictureUrl = pictureUrl;
 	}
 
-
 	@Override
 	public String toString() {
 		return "Authority{" +

--- a/backend/src/main/java/org/cryptomator/hub/entities/User.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/User.java
@@ -43,9 +43,6 @@ import java.util.stream.Stream;
 		""")
 public class User extends Authority {
 
-	@Column(name = "picture_url")
-	private String pictureUrl;
-
 	@Column(name = "email")
 	private String email;
 
@@ -63,14 +60,6 @@ public class User extends Authority {
 
 	@Column(name = "setupcode")
 	private String setupCode;
-
-	public String getPictureUrl() {
-		return pictureUrl;
-	}
-
-	public void setPictureUrl(String pictureUrl) {
-		this.pictureUrl = pictureUrl;
-	}
 
 	public String getEmail() {
 		return email;
@@ -163,13 +152,12 @@ public class User extends Authority {
 		if (o == null || getClass() != o.getClass()) return false;
 		User that = (User) o;
 		return super.equals(that) //
-				&& Objects.equals(pictureUrl, that.pictureUrl) //
 				&& Objects.equals(email, that.email);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(super.getId(), pictureUrl, email);
+		return Objects.hash(super.getId(), email);
 	}
 
 	@ApplicationScoped

--- a/backend/src/main/java/org/cryptomator/hub/entities/User.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/User.java
@@ -157,7 +157,7 @@ public class User extends Authority {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(super.getId(), email, super.getPictureUrl());
+		return Objects.hash(super.hashCode(), email);
 	}
 
 	@ApplicationScoped

--- a/backend/src/main/java/org/cryptomator/hub/entities/User.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/User.java
@@ -157,7 +157,7 @@ public class User extends Authority {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(super.getId(), email);
+		return Objects.hash(super.getId(), email, super.getPictureUrl());
 	}
 
 	@ApplicationScoped

--- a/backend/src/main/java/org/cryptomator/hub/keycloak/KeycloakAuthorityProvider.java
+++ b/backend/src/main/java/org/cryptomator/hub/keycloak/KeycloakAuthorityProvider.java
@@ -79,9 +79,10 @@ public class KeycloakAuthorityProvider {
 	//visible for testing
 	List<KeycloakGroupDto> groups(RealmResource realm) {
 		return deepCollectGroups(realm).stream().map(group -> {
+			var pictureUrl = parsePictureUrl(group.getAttributes());
 			// TODO add sub groups and the members of the sub group to it too using `group.getSubGroups()` recursively
 			var members = deepCollectMembers(realm, group.getId());
-			return new KeycloakGroupDto(group.getId(), group.getName(), members);
+			return new KeycloakGroupDto(group.getId(), group.getName(), pictureUrl, members);
 		}).toList();
 	}
 
@@ -92,7 +93,7 @@ public class KeycloakAuthorityProvider {
 		List<GroupRepresentation> currentRequestedGroups;
 
 		do {
-			currentRequestedGroups = group.groups(groups.size(), MAX_COUNT_PER_REQUEST);
+			currentRequestedGroups = group.groups(null, groups.size(), MAX_COUNT_PER_REQUEST, false);
 			groups.addAll(currentRequestedGroups);
 		} while (currentRequestedGroups.size() == MAX_COUNT_PER_REQUEST);
 

--- a/backend/src/main/java/org/cryptomator/hub/keycloak/KeycloakAuthorityPuller.java
+++ b/backend/src/main/java/org/cryptomator/hub/keycloak/KeycloakAuthorityPuller.java
@@ -86,6 +86,7 @@ public class KeycloakAuthorityPuller {
 			var databaseGroup = new Group();
 			databaseGroup.setId(keycloakGroup.id());
 			databaseGroup.setName(keycloakGroup.name());
+			databaseGroup.setPictureUrl(keycloakGroup.pictureUrl());
 			Set<Authority> members = new HashSet<>();
 			for (var keycloakMember : keycloakGroup.members()) {
 				var databaseUser = databaseUsers.get(keycloakMember.id());
@@ -119,6 +120,7 @@ public class KeycloakAuthorityPuller {
 			var wantIds = keycloakGroup.members().stream().map(KeycloakUserDto::id).collect(Collectors.toSet());
 			var haveIds = databaseGroup.getMembers().stream().map(Authority::getId).collect(Collectors.toSet());
 			databaseGroup.setName(keycloakGroup.name());
+			databaseGroup.setPictureUrl(keycloakGroup.pictureUrl());
 			for (var addId : diff(wantIds, haveIds)) {
 				var databaseUser = databaseUsers.get(addId);
 				if (databaseUser == null) {

--- a/backend/src/main/java/org/cryptomator/hub/keycloak/KeycloakGroupDto.java
+++ b/backend/src/main/java/org/cryptomator/hub/keycloak/KeycloakGroupDto.java
@@ -2,4 +2,4 @@ package org.cryptomator.hub.keycloak;
 
 import java.util.Set;
 
-public record KeycloakGroupDto(String id, String name, Set<KeycloakUserDto> members) { }
+public record KeycloakGroupDto(String id, String name, String pictureUrl, Set<KeycloakUserDto> members) { }

--- a/backend/src/main/resources/cryptomator-realm.json
+++ b/backend/src/main/resources/cryptomator-realm.json
@@ -198,7 +198,11 @@
       "name": "groupies",
       "path": "/groupies",
       "subGroups": [],
-      "attributes": {},
+      "attributes": {
+        "picture": [
+          "https://cryptomator.org/img/logo.svg"
+        ]
+      },
       "realmRoles": [],
       "clientRoles": {}
     }

--- a/backend/src/main/resources/org/cryptomator/hub/flyway/V21__Move_Picture_URL_to_Authority.sql
+++ b/backend/src/main/resources/org/cryptomator/hub/flyway/V21__Move_Picture_URL_to_Authority.sql
@@ -1,0 +1,3 @@
+-- noinspection SqlNoDataSourceInspectionForFile
+ALTER TABLE "user_details" DROP COLUMN "picture_url";
+ALTER TABLE "authority" ADD "picture_url" VARCHAR;

--- a/backend/src/test/java/org/cryptomator/hub/keycloak/KeycloakAuthorityPullerTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/keycloak/KeycloakAuthorityPullerTest.java
@@ -189,7 +189,7 @@ class KeycloakAuthorityPullerTest {
 
 			Map<String, KeycloakGroupDto> keycloakGroups = new HashMap<>();
 			for (var gid : keycloakGroupIdString) {
-				var dto = new KeycloakGroupDto(gid, "Name " + gid, Set.of(kcUsers.get(gid)));
+				var dto = new KeycloakGroupDto(gid, "Name " + gid, "pic " + gid, Set.of(kcUsers.get(gid)));
 				keycloakGroups.put(gid, dto);
 			}
 
@@ -212,6 +212,9 @@ class KeycloakAuthorityPullerTest {
 			for (var newGid : addedGroupIdString) {
 				Mockito.verify(groupRepo).persist(argThat((Group created) -> {
 					if (!created.getId().equals(newGid)) {
+						return false;
+					}
+					if (!created.getPictureUrl().equals("pic " + newGid)) {
 						return false;
 					}
 					var members = created.getMembers();
@@ -282,6 +285,7 @@ class KeycloakAuthorityPullerTest {
 		for (var groupId : updatedGroupIds) {
 			var kcDto = Mockito.mock(KeycloakGroupDto.class);
 			Mockito.when(kcDto.name()).thenReturn(String.format("name %s", groupId));
+			Mockito.when(kcDto.pictureUrl()).thenReturn(String.format("pic %s", groupId));
 			Mockito.when(kcDto.members()).thenReturn(Set.of(
 					new KeycloakUserDto("U_user", "n", "e", "p"),
 					new KeycloakUserDto("U_otherKC", "n", "e", "p")
@@ -306,6 +310,7 @@ class KeycloakAuthorityPullerTest {
 		for (var groupId : updatedGroupIdString) {
 			var dbGroup = databaseGroups.get(groupId);
 			Mockito.verify(dbGroup).setName(String.format("name %s", groupId));
+			Mockito.verify(dbGroup).setPictureUrl(String.format("pic %s", groupId));
 			MatcherAssert.assertThat(dbGroupMembers, Matchers.containsInAnyOrder(userMock, otherKCUser));
 		}
 	}

--- a/backend/src/test/java/org/cryptomator/hub/keycloak/KeycloakUserProviderTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/keycloak/KeycloakUserProviderTest.java
@@ -136,9 +136,11 @@ class KeycloakUserProviderTest {
 		public Groups() {
 			Mockito.when(group1.getId()).thenReturn("grpId3000");
 			Mockito.when(group1.getName()).thenReturn("grpName3000");
+			Mockito.when(group1.getAttributes()).thenReturn(Map.of("picture", List.of("grpPicture3000")));
 
 			Mockito.when(group2.getId()).thenReturn("grpId3001");
 			Mockito.when(group2.getName()).thenReturn("grpName3001");
+			Mockito.when(group2.getAttributes()).thenReturn(Map.of("picture", List.of("grpPicture3001")));
 
 			Mockito.when(realm.groups()).thenReturn(groupsResource);
 			Mockito.when(realm.groups().group("grpId3000")).thenReturn(groupResource1);
@@ -151,7 +153,7 @@ class KeycloakUserProviderTest {
 		@Test
 		@DisplayName("test groups listing contains two groups with members in group2")
 		public void testListGroups() {
-			Mockito.when(groupsResource.groups(0, KeycloakAuthorityProvider.MAX_COUNT_PER_REQUEST)).thenReturn(List.of(group1, group2));
+			Mockito.when(groupsResource.groups(null, 0, KeycloakAuthorityProvider.MAX_COUNT_PER_REQUEST, false)).thenReturn(List.of(group1, group2));
 
 			var result = keycloakRemoteUserProvider.groups(realm);
 
@@ -162,10 +164,12 @@ class KeycloakUserProviderTest {
 
 			Assertions.assertEquals("grpId3000", resultGroup1.id());
 			Assertions.assertEquals("grpName3000", resultGroup1.name());
+			Assertions.assertEquals("grpPicture3000", resultGroup1.pictureUrl());
 			Assertions.assertEquals(0, resultGroup1.members().size());
 
 			Assertions.assertEquals("grpId3001", resultGroup2.id());
 			Assertions.assertEquals("grpName3001", resultGroup2.name());
+			Assertions.assertEquals("grpPicture3001", resultGroup2.pictureUrl());
 			Assertions.assertEquals(2, resultGroup2.members().size());
 
 			var membersGroup2 = resultGroup2.members().stream().sorted(Comparator.comparing(KeycloakUserDto::id)).toList();


### PR DESCRIPTION
If `picture` "Attributes" are provided for Keycloak groups, we should display them in Hub:

<img width="2074" height="1514" alt="image" src="https://github.com/user-attachments/assets/b1f6bd82-7d39-4d93-a20c-49d60ee6b486" />
