### PR TITLE
Feature: Add Archived state to VaultAccess handling in UnlockSuccess

### DIFF
--- a/frontend/src/components/UnlockSuccess.vue
+++ b/frontend/src/components/UnlockSuccess.vue
@@ -41,6 +41,16 @@
         </router-link>
       </div>
 
+      <!-- ARCHIVED -->
+      <div v-else-if="vaultAccess == VaultAccess.Archived" class="text-sm text-gray-500">
+        <h1 class="text-2xl leading-6 font-medium text-gray-900">
+          {{ t('unlock.noAccessVaultArchived.title') }}
+        </h1>
+        <p class="mt-2">
+          {{ t('unlock.noAccessVaultArchived.description') }}
+        </p>
+      </div>
+
       <!-- NO VAULT ACCESS -->
       <div v-else-if="vaultAccess == VaultAccess.Denied" class="text-sm text-gray-500">
         <h1 class="text-2xl leading-6 font-medium text-gray-900">
@@ -52,7 +62,7 @@
       </div>
 
       <!-- SUCCESS -->
-      <div v-else class="text-sm text-gray-500">
+      <div v-else-if="vaultAccess == VaultAccess.Allowed" class="text-sm text-gray-500">
         <h1 class="text-2xl leading-6 font-medium text-gray-900">
           {{ t('unlockSuccess.title') }}
         </h1>
@@ -98,9 +108,10 @@ const deviceState : ComputedRef<DeviceState> = computed(() => {
 });
 
 const vaultAccess : ComputedRef<VaultAccess> = computed(() => {
-  return accessibleVaults.value?.find(v => v.id === props.vaultId)
-    ? VaultAccess.Allowed
-    : VaultAccess.Denied;
+  const vault = accessibleVaults.value?.find(v => v.id === props.vaultId);
+  if (!vault) return VaultAccess.Denied;
+  if (vault.archived) return VaultAccess.Archived;
+  return VaultAccess.Allowed;
 });
 
 enum AccountState {
@@ -115,6 +126,7 @@ enum DeviceState {
 
 enum VaultAccess {
   Allowed,
+  Archived,
   Denied
 }
 

--- a/frontend/src/i18n/en-US.json
+++ b/frontend/src/i18n/en-US.json
@@ -268,6 +268,9 @@
   "userProfile.actions.changeLanguage.entry.browser": "Browser Language",
   "userProfile.keycloakVersion.notAvailable": "version not available",
 
+  "unlock.noAccessVaultArchived.title": "Vault is archived",
+  "unlock.noAccessVaultArchived.description": "This vault has been archived and is no longer accessible. Please contact the vault owner.",
+
   "unlockSuccess.title": "Vault unlocked successfully",
   "unlockSuccess.description": "You may now close this browser tab and return to Cryptomator.",
   "unlockSuccess.accountSetup.title": "Setup Required",


### PR DESCRIPTION
This PR extends the VaultAccess logic in UnlockSuccess.vue by introducing a new Archived state.

- VaultAccess.Archived is reached when a vault is archived and the current user is still a member of that vault.
- If the vault is archived and the user is not a member, the existing Denied screen is shown unchanged.
- When VaultAccess is in the Archived state, a new Archived screen is displayed to clearly communicate the vault’s status to the user.

This change addresses the behaviour mentioned in #300 and makes the handling of archived vaults more explicit and user-friendly.
<img width="1512" height="786" alt="localhost_3000_app_unlock-success_vault_archived" src="https://github.com/user-attachments/assets/43e8e2ef-3a95-405b-9def-9e704195aad8" />
