### PR TITLE
Feature: Hide Archive/Reactivate Vault actions for admins without ownership rights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Added "Browser Language" option to language selection dropdown, enabling users to revert to browser default language (#324)
+- Hide Archive/Reactivate Vault actions for admins without ownership rights (#379)
 - Reload device lists upon device removal
 - Added pointer cursor to device remove "button" text
 - Show device only when available in audit log vault key retrieve event

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated Keycloak to 26.4.7
 
+### Fixed
+- Hide Archive/Reactivate Vault actions for admins without ownership rights (#379)
+
 ## [1.4.6](https://github.com/cryptomator/hub/compare/1.4.5...1.4.6)
 
 ### Changed
@@ -25,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Show admin section of Hub when Keycloak version is not available (#361)
-- Hide Archive/Reactivate Vault actions for admins without ownership rights (#379)
 
 ## [1.4.5](https://github.com/cryptomator/hub/compare/1.4.4...1.4.5)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Show admin section of Hub when Keycloak version is not available (#361)
+- Hide Archive/Reactivate Vault actions for admins without ownership rights (#379)
 
 ## [1.4.5](https://github.com/cryptomator/hub/compare/1.4.4...1.4.5)
 
@@ -151,7 +152,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Added "Browser Language" option to language selection dropdown, enabling users to revert to browser default language (#324)
-- Hide Archive/Reactivate Vault actions for admins without ownership rights (#379)
 - Reload device lists upon device removal
 - Added pointer cursor to device remove "button" text
 - Show device only when available in audit log vault key retrieve event

--- a/frontend/src/components/VaultDetails.vue
+++ b/frontend/src/components/VaultDetails.vue
@@ -130,7 +130,7 @@
           {{ t('vaultDetails.actions.editVaultMetadata') }}
         </button>
         <!-- archiveVault button -->
-        <button v-if="(vaultRole == 'OWNER' || isAdmin)" type="button" class="bg-red-600 py-2 px-4 border border-transparent rounded-md shadow-xs text-sm font-medium text-white  hover:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500" @click="showArchiveVaultDialog()">
+        <button v-if="vaultRole == 'OWNER'" type="button" class="bg-red-600 py-2 px-4 border border-transparent rounded-md shadow-xs text-sm font-medium text-white  hover:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500" @click="showArchiveVaultDialog()">
           {{ t('vaultDetails.actions.archiveVault') }}
         </button>
       </div>
@@ -160,7 +160,7 @@
           {{ t('vaultDetails.actions.displayRecoveryKey') }}
         </button>
         <!-- reactivateVault button -->
-        <button v-if="(vaultRole == 'OWNER' || isAdmin)" type="button" class="bg-red-600 py-2 px-4 border border-transparent rounded-md shadow-xs text-sm font-medium text-white  hover:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500" @click="showReactivateVaultDialog()">
+        <button v-if="vaultRole == 'OWNER'" type="button" class="bg-red-600 py-2 px-4 border border-transparent rounded-md shadow-xs text-sm font-medium text-white  hover:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500" @click="showReactivateVaultDialog()">
           {{ t('vaultDetails.actions.reactivateVault') }}
         </button>
       </div>
@@ -190,7 +190,7 @@
           {{ t('vaultDetails.actions.displayRecoveryKey') }}
         </button>
         <!-- archiveVault button -->
-        <button v-if="(vaultRole == 'OWNER' || isAdmin)" type="button" class="bg-red-600 py-2 px-4 border border-transparent rounded-md shadow-xs text-sm font-medium text-white  hover:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500" @click="showArchiveVaultDialog()">
+        <button v-if="vaultRole == 'OWNER'" type="button" class="bg-red-600 py-2 px-4 border border-transparent rounded-md shadow-xs text-sm font-medium text-white  hover:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500" @click="showArchiveVaultDialog()">
           {{ t('vaultDetails.actions.archiveVault') }}
         </button>
       </div>
@@ -275,7 +275,6 @@ const claimingVaultOwnership = ref(false);
 const me = ref<UserDto>();
 
 const vaultRecoveryRequired = ref<boolean>(false);
-const isAdmin = ref<boolean>();
 
 const isLegacyVault = computed(() => vault.value?.authPublicKey !== undefined);
 const licenseViolated = computed(() => license.value?.isExpired() || license.value?.isExceeded());
@@ -285,7 +284,6 @@ onMounted(fetchData);
 async function fetchData() {
   onFetchError.value = undefined;
   try {
-    isAdmin.value = (await auth).hasRole('admin');
     vault.value = await backend.vaults.get(props.vaultId);
     me.value = await userdata.me;
     license.value = await backend.license.getUserInfo();


### PR DESCRIPTION
**Superseded by https://github.com/cryptomator/hub/pull/430.**

This PR addresses the issue described in #283 by adjusting the visibility logic of the vault action buttons.

The change removes the isAdmin check from the v-if condition controlling the Archive Vault / Reactivate Vault buttons. As a result, these actions are no longer shown to admin users who do not have ownership permissions for the vault.

This is a small UI-only change that:
- Prevents admins without ownership rights from seeing actions they are not allowed to perform
- Avoids failed archive/reactivate attempts that currently result in a 403 Forbidden response from the backend