### PR TITLE
Fix null-safe email validation for legacy users

### DIFF
--- a/frontend/src/common/backend.ts
+++ b/frontend/src/common/backend.ts
@@ -87,7 +87,7 @@ export type UserDto = {
   id: string;
   name: string;
   pictureUrl?: string;
-  email?: string | null;
+  email?: string;
   firstName?: string;
   lastName?: string;
   realmRoles: RealmRole[];

--- a/frontend/src/common/backend.ts
+++ b/frontend/src/common/backend.ts
@@ -87,7 +87,7 @@ export type UserDto = {
   id: string;
   name: string;
   pictureUrl?: string;
-  email: string;
+  email?: string | null;
   firstName?: string;
   lastName?: string;
   realmRoles: RealmRole[];

--- a/frontend/src/common/formvalidator.ts
+++ b/frontend/src/common/formvalidator.ts
@@ -103,11 +103,14 @@ export class FormValidator {
   }
 
   /**
-   * Checks if email is required (always for CREATE, only if previously set for EDIT)
+   * Checks if email is required
    */
   static isEmailRequired(isEditMode: boolean, initialEmail?: string): boolean {
-    if (!isEditMode) return true;
-    return !!initialEmail?.trim();
+    if (!isEditMode) {
+      return true; // CREATE: always required
+    }
+    // EDIT: required only if user previously had email
+    return initialEmail !== undefined && initialEmail.trim() !== '';
   }
 
   /**

--- a/frontend/src/common/formvalidator.ts
+++ b/frontend/src/common/formvalidator.ts
@@ -15,11 +15,11 @@ export class FormValidator {
     firstName?: string,
     lastName?: string,
     username: string,
-    email?: string | null,
+    email?: string,
     password: string,
     passwordConfirm: string,
     isEditMode: boolean,
-    initialEmail?: string | null,
+    initialEmail?: string,
     pictureUrl?: string,
     isValidImageUrl?: boolean
   }): ValidationResult {
@@ -97,7 +97,7 @@ export class FormValidator {
   /**
    * Validates email format
    */
-  static isValidEmail(email: string | null | undefined): boolean {
+  static isValidEmail(email?: string): boolean {
     if (!email) return false;
     return /^[^\s@]+@[^\s@]+\.[a-z]{2,}$/i.test(email.trim());
   }
@@ -105,7 +105,7 @@ export class FormValidator {
   /**
    * Checks if email is required (always for CREATE, only if previously set for EDIT)
    */
-  static isEmailRequired(isEditMode: boolean, initialEmail?: string | null): boolean {
+  static isEmailRequired(isEditMode: boolean, initialEmail?: string): boolean {
     if (!isEditMode) return true;
     return !!initialEmail?.trim();
   }

--- a/frontend/src/common/formvalidator.ts
+++ b/frontend/src/common/formvalidator.ts
@@ -15,10 +15,11 @@ export class FormValidator {
     firstName?: string,
     lastName?: string,
     username: string,
-    email: string,
+    email?: string | null,
     password: string,
     passwordConfirm: string,
     isEditMode: boolean,
+    initialEmail?: string | null,
     pictureUrl?: string,
     isValidImageUrl?: boolean
   }): ValidationResult {
@@ -30,9 +31,12 @@ export class FormValidator {
     if (!data.username.trim()) errors.username = t('userEditCreate.validation.required');
 
     // Email validation
-    if (!data.email.trim()) {
+    const emailTrimmed = data.email?.trim() ?? '';
+    const emailRequired = this.isEmailRequired(data.isEditMode, data.initialEmail);
+
+    if (emailRequired && !emailTrimmed) {
       errors.email = t('userEditCreate.validation.required');
-    } else if (!this.isValidEmail(data.email.trim())) {
+    } else if (emailTrimmed && !this.isValidEmail(emailTrimmed)) {
       errors.email = t('userEditCreate.invalidEmail');
     }
 
@@ -93,8 +97,17 @@ export class FormValidator {
   /**
    * Validates email format
    */
-  static isValidEmail(email: string): boolean {
+  static isValidEmail(email: string | null | undefined): boolean {
+    if (!email) return false;
     return /^[^\s@]+@[^\s@]+\.[a-z]{2,}$/i.test(email.trim());
+  }
+
+  /**
+   * Checks if email is required (always for CREATE, only if previously set for EDIT)
+   */
+  static isEmailRequired(isEditMode: boolean, initialEmail?: string | null): boolean {
+    if (!isEditMode) return true;
+    return !!initialEmail?.trim();
   }
 
   /**

--- a/frontend/src/common/formvalidator.ts
+++ b/frontend/src/common/formvalidator.ts
@@ -106,11 +106,13 @@ export class FormValidator {
    * Checks if email is required
    */
   static isEmailRequired(isEditMode: boolean, initialEmail?: string): boolean {
-    if (!isEditMode) {
-      return true; // CREATE: always required
+    if (isEditMode) {
+      // EDIT: required only if user previously had email
+      return initialEmail !== undefined && initialEmail.trim() !== '';
+    } else {
+      // CREATE: always required
+      return true;
     }
-    // EDIT: required only if user previously had email
-    return initialEmail !== undefined && initialEmail.trim() !== '';
   }
 
   /**

--- a/frontend/src/components/authority/UserEditCreate.vue
+++ b/frontend/src/components/authority/UserEditCreate.vue
@@ -395,7 +395,7 @@ async function onSubmit() {
   data.firstName = data.firstName?.trim();
   data.lastName = data.lastName?.trim();
   data.name = data.name.trim();
-  data.email = data.email?.trim() || undefined;
+  data.email = data.email?.trim();
   data.pictureUrl = data.pictureUrl?.trim();
 
   try {

--- a/frontend/src/components/authority/UserEditCreate.vue
+++ b/frontend/src/components/authority/UserEditCreate.vue
@@ -89,9 +89,9 @@
                 {{ t('userEditCreate.email') }}
               </label>
               <div class="mt-1 md:mt-0 md:col-span-2 lg:col-span-1">
-                <input id="email" v-model="data.email" type="email" required :class="[errors.email ? 'border-red-300 focus:border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-primary focus:border-primary', 'block w-full max-w-md shadow-sm sm:text-sm rounded-md']"/>
+                <input id="email" v-model="data.email" type="email" :required="emailRequired" :class="[errors.email ? 'border-red-300 focus:border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-primary focus:border-primary', 'block w-full max-w-md shadow-sm sm:text-sm rounded-md']"/>
                 <p v-if="errors.email" class="mt-1 text-sm text-red-600">{{ errors.email }}</p>
-                <p v-else-if="data.email && !isValidEmail(data.email?.trim())" class="mt-1 text-sm text-red-600">
+                <p v-else-if="data.email?.trim() && !isValidEmail(data.email)" class="mt-1 text-sm text-red-600">
                   {{ t('userEditCreate.invalidEmail') }}
                 </p>
               </div>
@@ -341,10 +341,11 @@ async function validateForm(): Promise<boolean> {
     password: password.value,
     passwordConfirm: passwordConfirm.value,
     isEditMode: props.mode === 'EDIT',
-    pictureUrl: data.pictureUrl,      
+    initialEmail: initialData.value.email,
+    pictureUrl: data.pictureUrl,
     isValidImageUrl: await FormValidator.validateImageUrl(data.pictureUrl)
   });
-  
+
   errors.value = result.errors;
   return result.valid;
 }
@@ -368,6 +369,7 @@ const passwordStrengthColor = computed(() => {
 });
 
 const isValidEmail = FormValidator.isValidEmail;
+const emailRequired = computed(() => FormValidator.isEmailRequired(props.mode === 'EDIT', initialData.value.email));
 
 function evaluatePasswordStrength(pw: string): 'weak' | 'medium' | 'strong' | '' {
   return FormValidator.evaluatePasswordStrength(pw);
@@ -393,7 +395,7 @@ async function onSubmit() {
   data.firstName = data.firstName?.trim();
   data.lastName = data.lastName?.trim();
   data.name = data.name.trim();
-  data.email = data.email.trim();
+  data.email = data.email?.trim() ?? '';
   data.pictureUrl = data.pictureUrl?.trim();
 
   try {

--- a/frontend/src/components/authority/UserEditCreate.vue
+++ b/frontend/src/components/authority/UserEditCreate.vue
@@ -91,7 +91,7 @@
               <div class="mt-1 md:mt-0 md:col-span-2 lg:col-span-1">
                 <input id="email" v-model="data.email" type="email" :required="emailRequired" :class="[errors.email ? 'border-red-300 focus:border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-primary focus:border-primary', 'block w-full max-w-md shadow-sm sm:text-sm rounded-md']"/>
                 <p v-if="errors.email" class="mt-1 text-sm text-red-600">{{ errors.email }}</p>
-                <p v-else-if="data.email?.trim() && !isValidEmail(data.email)" class="mt-1 text-sm text-red-600">
+                <p v-else-if="data.email?.trim() && !isValidEmail(data.email.trim())" class="mt-1 text-sm text-red-600">
                   {{ t('userEditCreate.invalidEmail') }}
                 </p>
               </div>

--- a/frontend/src/components/authority/UserEditCreate.vue
+++ b/frontend/src/components/authority/UserEditCreate.vue
@@ -395,7 +395,7 @@ async function onSubmit() {
   data.firstName = data.firstName?.trim();
   data.lastName = data.lastName?.trim();
   data.name = data.name.trim();
-  data.email = data.email?.trim() ?? '';
+  data.email = data.email?.trim() || undefined;
   data.pictureUrl = data.pictureUrl?.trim();
 
   try {

--- a/frontend/src/components/authority/UserList.vue
+++ b/frontend/src/components/authority/UserList.vue
@@ -80,7 +80,7 @@
                       <img :src="user.pictureUrl" :alt="t('userList.profileImage')" class="w-10 h-10 rounded-full object-cover border border-gray-300"/>
                       <div class="flex flex-col min-w-0 flex-1">
                         <button type="button" class="truncate block hover:underline cursor-pointer text-left" :title="user.name" @click="router.push(`users/${user.id}`)">{{ user.name }}</button>
-                        <span class="text-xs text-gray-500 truncate" :title="user.firstName || user.lastName ? `${user.firstName ?? ''} ${user.lastName ?? ''}`.trim() : user.email">{{ user.firstName || user.lastName ? `${user.firstName ?? ''} ${user.lastName ?? ''}`.trim() : user.email }}</span>
+                        <span class="text-xs text-gray-500 truncate" :title="user.firstName || user.lastName ? `${user.firstName ?? ''} ${user.lastName ?? ''}`.trim() : user.email ?? undefined">{{ user.firstName || user.lastName ? `${user.firstName ?? ''} ${user.lastName ?? ''}`.trim() : user.email }}</span>
                       </div>
                     </div>
                   </td>


### PR DESCRIPTION
  Email validation failed when editing users migrated from legacy systems with empty email. This fix makes email handling null-safe and keeps email required for new users and those with existing email, while making it optional for legacy users without one.