### PR TITLE
Merge license buttons into single "Manage Subscription" link

### DIFF
--- a/backend/src/main/java/org/cryptomator/hub/api/ConfigResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/ConfigResource.java
@@ -39,8 +39,8 @@ public class ConfigResource {
 	String internalRealmUrl;
 
 	@Inject
-	@ConfigProperty(name = "hub.ce-registration-url", defaultValue = "")
-	String ceRegistrationUrl;
+	@ConfigProperty(name = "hub.billing-url", defaultValue = "")
+	String billingUrl;
 
 	@Inject
 	OidcConfigurationMetadata oidcConfData;
@@ -57,7 +57,7 @@ public class ConfigResource {
 		var authUri = replacePrefix(oidcConfData.getAuthorizationUri(), trimTrailingSlash(internalRealmUrl), publicRealmUri);
 		var tokenUri = replacePrefix(oidcConfData.getTokenUri(), trimTrailingSlash(internalRealmUrl), publicRealmUri);
 
-		return new ConfigDto(keycloakPublicUrl, keycloakRealm, keycloakClientIdHub, keycloakClientIdCryptomator, authUri, tokenUri, Instant.now().truncatedTo(ChronoUnit.MILLIS), 4, license.getEntitlements(), ceRegistrationUrl);
+		return new ConfigDto(keycloakPublicUrl, keycloakRealm, keycloakClientIdHub, keycloakClientIdCryptomator, authUri, tokenUri, Instant.now().truncatedTo(ChronoUnit.MILLIS), 4, license.getEntitlements(), billingUrl);
 	}
 
 	//visible for testing
@@ -85,7 +85,7 @@ public class ConfigResource {
 							@JsonProperty("keycloakAuthEndpoint") String authEndpoint, @JsonProperty("keycloakTokenEndpoint") String tokenEndpoint,
 							@JsonProperty("serverTime") Instant serverTime, @JsonProperty("apiLevel") Integer apiLevel,
 							@JsonProperty("entitlements") HubLicenseEntitlements entitlements,
-							@JsonProperty("ceRegistrationUrl") String ceRegistrationUrl) {
+							@JsonProperty("billingUrl") String billingUrl) {
 	}
 
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -13,8 +13,8 @@ hub.keycloak.public-url=http://localhost:8180
 hub.keycloak.local-url=http://localhost:8180
 hub.keycloak.realm=cryptomator
 hub.managed-instance=false
-hub.ce-registration-url=https://cryptomator.org/hub/register/
-%dev.hub.ce-registration-url=https://staging.cryptomator.org/hub/register/
+hub.billing-url=https://cryptomator.org/hub/billing
+%dev.hub.billing-url=https://staging.cryptomator.org/hub/billing
 
 quarkus.rest.path=/api
 %test.quarkus.rest.path=/

--- a/frontend/src/common/config.ts
+++ b/frontend/src/common/config.ts
@@ -2,7 +2,6 @@ import AxiosStatic from 'axios';
 
 // these URLs must end on '/':
 export const baseURL = new URL(document.baseURI).pathname;
-export const absBaseURL = `${location.origin}${baseURL}`;
 export const frontendBaseURL = `${baseURL}app/`;
 export const absFrontendBaseURL = `${location.origin}${frontendBaseURL}`;
 export const backendBaseURL = `${baseURL}api/`;
@@ -34,7 +33,7 @@ export type ConfigDto = {
     androidLicense: string;
     desktopLicense: string;
   };
-  ceRegistrationUrl: string;
+  billingUrl: string;
 };
 
 class ConfigWrapper {

--- a/frontend/src/components/AdminSettings.vue
+++ b/frontend/src/components/AdminSettings.vue
@@ -323,7 +323,7 @@ const manageSubscriptionUrl = computed(() => {
     return '';
   }
   const returnUrl = `${absFrontendBaseURL}admin`;
-  return `${cfg.value.billingUrl}#hub_id=${encodeURIComponent(billing.value.hubId)}&return_url=${encodeURIComponent(returnUrl)}&old_license=${encodeURIComponent(billing.value.licenseKey)}`;
+  return `${cfg.value.billingUrl}#oldLicense=${encodeURIComponent(billing.value.licenseKey)}&returnUrl=${encodeURIComponent(returnUrl)}`;
 });
 
 async function refreshLicense() {

--- a/frontend/src/components/AdminSettings.vue
+++ b/frontend/src/components/AdminSettings.vue
@@ -139,15 +139,10 @@
 
           <div class="md:grid md:grid-cols-3 md:gap-6">
             <div class="md:col-start-2 col-span-2 flex gap-2">
-              <a :href="manageSubscriptionUrl" rel="noopener" class="button flex-1 inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-primary hover:bg-primary-d1 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-primary disabled:opacity-50 disabled:hover:bg-primary disabled:cursor-not-allowed">
+              <a :href="manageSubscriptionUrl" rel="noopener" class="button inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-primary hover:bg-primary-d1 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-primary disabled:opacity-50 disabled:hover:bg-primary disabled:cursor-not-allowed">
                 <ArrowTopRightOnSquareIcon class="-ml-1 mr-2 h-5 w-5" aria-hidden="true" />
                 {{ t('admin.licenseInfo.manageSubscription') }}
               </a>
-              <a :href="freeCeLicenseUrl" rel="noopener" class="button flex-1 inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-primary hover:bg-primary-d1 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-primary disabled:opacity-50 disabled:hover:bg-primary disabled:cursor-not-allowed">
-                <ArrowTopRightOnSquareIcon class="-ml-1 mr-2 h-5 w-5" aria-hidden="true" />
-                {{ t('admin.licenseInfo.getFreeCeLicense') }}
-              </a>
-              <span class="flex-1"></span>
             </div>
           </div>
         </form>
@@ -237,18 +232,15 @@
 import { ArrowPathIcon, ArrowRightIcon, ArrowTopRightOnSquareIcon, CheckIcon, ExclamationTriangleIcon, InformationCircleIcon, LinkIcon, XMarkIcon } from '@heroicons/vue/20/solid';
 import semver from 'semver';
 import { computed, onMounted, ref } from 'vue';
-import { useRoute } from 'vue-router';
 import { useI18n } from 'vue-i18n';
 import backend, { BillingDto, VersionDto } from '../common/backend';
-import config, { absBaseURL, absFrontendBaseURL, ConfigDto } from '../common/config';
+import config, { absFrontendBaseURL, ConfigDto } from '../common/config';
 import { FetchUpdateError, LatestVersionDto, updateChecker } from '../common/updatecheck';
 import { debounce } from '../common/util';
 import FetchError from './FetchError.vue';
 import AdminSettingsEmergencyAccess from './AdminSettingsEmergencyAccess.vue';
 
 const { t, d } = useI18n({ useScope: 'global' });
-const route = useRoute();
-
 const props = defineProps<{
   token?: string
 }>();
@@ -326,21 +318,12 @@ const billing = ref<BillingDto>();
 
 const isRegistered = computed(() => !cfg.value.entitlements.showTrialHint );
 
-const freeCeLicenseUrl = computed(() => {
-  if (!billing.value) {
-    return '';
-  }
-  const oldLicense = billing.value.licenseKey;
-  const returnUrl = new URL(route.path.replace(/^\/+/, ''), absBaseURL).href;
-  return `${cfg.value.ceRegistrationUrl}#oldLicense=${encodeURIComponent(oldLicense)}&returnUrl=${encodeURIComponent(returnUrl)}`;
-});
-
 const manageSubscriptionUrl = computed(() => {
   if (!billing.value) {
     return '';
   }
   const returnUrl = `${absFrontendBaseURL}admin`;
-  return `https://cryptomator.org/hub/billing/?hub_id=${billing.value.hubId}&return_url=${encodeURIComponent(returnUrl)}`;
+  return `${cfg.value.billingUrl}/#hub_id=${encodeURIComponent(billing.value.hubId)}&return_url=${encodeURIComponent(returnUrl)}&old_license=${encodeURIComponent(billing.value.licenseKey)}`;
 });
 
 async function refreshLicense() {

--- a/frontend/src/components/AdminSettings.vue
+++ b/frontend/src/components/AdminSettings.vue
@@ -323,7 +323,7 @@ const manageSubscriptionUrl = computed(() => {
     return '';
   }
   const returnUrl = `${absFrontendBaseURL}admin`;
-  return `${cfg.value.billingUrl}/#hub_id=${encodeURIComponent(billing.value.hubId)}&return_url=${encodeURIComponent(returnUrl)}&old_license=${encodeURIComponent(billing.value.licenseKey)}`;
+  return `${cfg.value.billingUrl}#hub_id=${encodeURIComponent(billing.value.hubId)}&return_url=${encodeURIComponent(returnUrl)}&old_license=${encodeURIComponent(billing.value.licenseKey)}`;
 });
 
 async function refreshLicense() {

--- a/frontend/src/i18n/en-US.json
+++ b/frontend/src/i18n/en-US.json
@@ -77,7 +77,6 @@
   "admin.licenseInfo.expiresAt.description.valid": "Your license is valid.",
   "admin.licenseInfo.expiresAt.description.expired": "Your license has expired.",
   "admin.licenseInfo.manageSubscription": "Manage Subscription",
-  "admin.licenseInfo.getFreeCeLicense": "Get Free CE License",
   "admin.licenseInfo.type.title": "Type",
   "admin.licenseInfo.getLicense": "Get License",
 


### PR DESCRIPTION
Replaces the separate "Manage Subscription" and "Get Free CE License" buttons in admin settings with a single "Manage Subscription" link. The billing page URL now includes parameters as a URL fragment (`#oldLicense=...&returnUrl=...`), allowing the billing page to handle both subscription management and free CE license registration in one flow. The `hubId` is decoded from the license JWT on the billing page side. The billing URL is now configurable via `hub.billing-url` (with a `%dev` staging override), replacing the removed `hub.ce-registration-url` config property.