### PR TITLE
Fix admin user management: roles, last access, and username field 

### DIFF
--- a/backend/src/main/java/org/cryptomator/hub/api/UsersResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/UsersResource.java
@@ -375,16 +375,23 @@ public class UsersResource {
 				.map(eva -> VaultResource.VaultDtoWithRole.from(eva.getVault(), eva.getRole()))
 				.toList();
 
-		// Fetch devices (modern devices)
-		Set<DeviceResource.DeviceDto> devices = user.getDevices().stream()
-				.map(DeviceResource.DeviceDto::fromEntity)
-				.collect(Collectors.toSet());
+		// Fetch devices (modern devices) with last access
+		var deviceMap = user.getDevices().stream().collect(Collectors.toMap(Device::getId, Function.identity()));
+		var deviceEvents = auditEventRepo.findLastVaultKeyRetrieve(deviceMap.keySet()).collect(Collectors.toMap(VaultKeyRetrievedEvent::getDeviceId, Function.identity()));
+		Set<DeviceResource.DeviceDto> devices = deviceMap.values().stream().map(d -> {
+			var event = deviceEvents.get(d.getId());
+			return DeviceResource.DeviceDto.fromEntity(d, event);
+		}).collect(Collectors.toSet());
 
-		// Fetch legacy devices
+		// Fetch legacy devices with last access
 		@SuppressWarnings("removal")
-		Set<DeviceResource.DeviceDto> legacyDevices = user.getLegacyDevices().stream()
-				.map(DeviceResource.DeviceDto::fromEntity)
-				.collect(Collectors.toSet());
+		var legacyDeviceMap = user.getLegacyDevices().stream().collect(Collectors.toMap(LegacyDevice::getId, Function.identity()));
+		var legacyDeviceEvents = auditEventRepo.findLastVaultKeyRetrieve(legacyDeviceMap.keySet()).collect(Collectors.toMap(VaultKeyRetrievedEvent::getDeviceId, Function.identity()));
+		@SuppressWarnings("removal")
+		Set<DeviceResource.DeviceDto> legacyDevices = legacyDeviceMap.values().stream().map(d -> {
+			var event = legacyDeviceEvents.get(d.getId());
+			return DeviceResource.DeviceDto.fromEntity(d, event);
+		}).collect(Collectors.toSet());
 
 		return UserDto.justPublicInfo(user).withDetails(
 				groups,

--- a/backend/src/main/java/org/cryptomator/hub/keycloak/KeycloakAdminService.java
+++ b/backend/src/main/java/org/cryptomator/hub/keycloak/KeycloakAdminService.java
@@ -21,6 +21,7 @@ import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.admin.client.resource.UserResource;
 import org.keycloak.representations.idm.CredentialRepresentation;
 import org.keycloak.representations.idm.GroupRepresentation;
+import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -204,6 +205,10 @@ public class KeycloakAdminService {
 		dbUser.setEmail(keycloakUser.getEmail());
 		dbUser.setFirstName(keycloakUser.getFirstName());
 		dbUser.setLastName(keycloakUser.getLastName());
+		var kcRoleNames = userResource.roles().realmLevel().listEffective().stream()
+				.map(RoleRepresentation::getName)
+				.toList();
+		dbUser.setRealmRoles(RealmRole.fromKcNames(kcRoleNames).stream().map(RealmRole::kcName).toArray(String[]::new));
 
 		var attrs = keycloakUser.getAttributes();
 		if (attrs != null && attrs.containsKey("picture")) {

--- a/frontend/src/components/authority/UserDeviceList.vue
+++ b/frontend/src/components/authority/UserDeviceList.vue
@@ -18,17 +18,17 @@
       <input :id="'deviceSearch' + id" v-model="deviceQuery" :placeholder="t('common.search.placeholder')" type="text" class="focus:ring-primary focus:border-primary block w-full shadow-xs text-sm border-gray-300 rounded-md disabled:bg-gray-200" />
     </div>
     <div>
-      <table class="w-full table-fixed divide-y divide-gray-200" :aria-describedby="'deviceListTitle' + id">
+      <table class="w-full divide-y divide-gray-200" :aria-describedby="'deviceListTitle' + id">
         <!-- Desktop Header -->
         <thead v-if="filteredDevices.length != 0" class="bg-gray-50 hidden sm:table-header-group">
           <tr>
             <th scope="col" class="px-6 py-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
               {{ t('common.device') }}
             </th>
-            <th scope="col" class="px-6 py-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+            <th scope="col" class="px-6 py-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">
               {{ t('legacyDeviceList.added') }}
             </th>
-            <th scope="col" class="px-6 py-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+            <th scope="col" class="px-6 py-4 text-left text-xs font-medium text-gray-500 uppercase tracking-wider whitespace-nowrap">
               <span class="inline-flex items-center gap-1">
                 {{ t('legacyDeviceList.lastAccess') }}
                 <div class="relative group" :title="t('legacyDeviceList.lastAccess.toolTip')">
@@ -62,11 +62,11 @@
               <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                 {{ d(device.creationTime, 'long') }}
               </td>
-              <td class="h-17 px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                <div v-if="device.lastAccessTime">
+              <td class="px-6 py-4 text-sm text-gray-500">
+                <div v-if="device.lastAccessTime" class="whitespace-nowrap">
                   {{ d(device.lastAccessTime, 'long') }}
                 </div>
-                <div v-if="device.lastIpAddress" class="text-xs text-gray-400">
+                <div v-if="device.lastIpAddress" class="whitespace-nowrap text-xs text-gray-400">
                   {{ device.lastIpAddress }}
                 </div>
               </td>

--- a/frontend/src/components/authority/UserEditCreate.vue
+++ b/frontend/src/components/authority/UserEditCreate.vue
@@ -78,7 +78,7 @@
                 {{ t('userEditCreate.username') }}
               </label>
               <div class="mt-1 md:mt-0 md:col-span-2 lg:col-span-1">
-                <input id="username" v-model="data.name" type="text" required :class="[errors.username ? 'border-red-300 focus:border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-primary focus:border-primary', 'block w-full max-w-md shadow-sm sm:text-sm rounded-md']"/>
+                <input id="username" v-model="data.name" type="text" required :disabled="props.mode === 'EDIT'" :class="[errors.username ? 'border-red-300 focus:border-red-500 focus:ring-red-500' : 'border-gray-300 focus:ring-primary focus:border-primary', 'block w-full max-w-md shadow-sm sm:text-sm rounded-md disabled:bg-gray-200 disabled:cursor-not-allowed']"/>
                 <p v-if="errors.username" class="mt-1 text-sm text-red-600">{{ errors.username }}</p>
               </div>
             </div>
@@ -256,7 +256,7 @@ const data = reactive<EditableUserData>(initialData.value);
 const userDataHasUnsavedChanges = computed(() => {
   return data.firstName !== initialData.value.firstName
     || data.lastName !== initialData.value.lastName
-    || data.name !== initialData.value.name
+    || (props.mode !== 'EDIT' && data.name !== initialData.value.name)
     || data.email !== initialData.value.email
     || JSON.stringify([...data.realmRoles].sort()) !== JSON.stringify([...initialData.value.realmRoles].sort())
     || data.pictureUrl !== initialData.value.pictureUrl


### PR DESCRIPTION
Summary                                
  - **Sync realm roles in syncUser()**: \`KeycloakAdminService.syncUser()\` was missing realm role synchronization, causing the admin UI to show no roles   
  for users. Now fetches effective realm-level roles from Keycloak and persists them.
  - **Populate last access data in admin user details**: The admin user detail view showed devices without last access timestamps and IP addresses. Now     
  queries audit events for both modern and legacy devices.                                                                                                  
  - **Disable username field in edit mode**: The username field appeared editable when editing a user, but changes were silently ignored (backend
  \`UpdateUserDto\` has no \`name\` field). The field is now disabled in edit mode.