### PR TITLE
Fix COUNCIL_CHANGE start condition to include key shares change

### DIFF
--- a/frontend/src/components/emergencyaccess/EmergencyAccessDialog.vue
+++ b/frontend/src/components/emergencyaccess/EmergencyAccessDialog.vue
@@ -501,8 +501,8 @@ const canStartRecovery = computed(() => {
     return !(sameOwners && sameMembers) && owners.value.length !== 0;
   } else if (processType.value === 'COUNCIL_CHANGE') {
     return (
-      newCouncilMembers.value.length >= defaultMinMembers.value
-      && isCouncilChanged.value
+      newCouncilMembers.value.length >= defaultMinMembers.value && 
+      (isCouncilChanged.value || defaultRequiredEmergencyKeyShares.value != props.vault.requiredEmergencyKeyShares)
     );
   }
 


### PR DESCRIPTION
The "Start" button for council changes was only enabled when the council members themselves changed, ignoring changes to the required number of key shares. 

This PR fixes `canStartRecovery` to also allow starting the process when `requiredEmergencyKeyShares` differs from the current vault configuration.