### PR TITLE
Fix ProcessAbortDialog rendering outside its parent Dialog

### DIFF
--- a/frontend/src/components/emergencyaccess/EmergencyAccessDialog.vue
+++ b/frontend/src/components/emergencyaccess/EmergencyAccessDialog.vue
@@ -295,16 +295,15 @@
           </DialogPanel>
         </TransitionChild>
       </div>
+      <ProcessAbortDialog
+        v-if="props.recoveryProcess"
+        ref="abortDialog"
+        :recovery-process-id="props.recoveryProcess.id"
+        @confirmed="handleRecoveryAborted"
+        @close="onAbortClosed"
+      />
     </Dialog>
   </TransitionRoot>
-
-  <ProcessAbortDialog
-    v-if="props.recoveryProcess"
-    ref="abortDialog"
-    :recovery-process-id="props.recoveryProcess.id"
-    @confirmed="handleRecoveryAborted"
-    @close="onAbortClosed"
-  />
 </template>
 
 <script setup lang="ts">

--- a/frontend/src/components/emergencyaccess/ProcessAbortDialog.vue
+++ b/frontend/src/components/emergencyaccess/ProcessAbortDialog.vue
@@ -5,10 +5,9 @@
         <DialogOverlay class="fixed inset-0 bg-gray-500/75 transition-opacity" />
       </TransitionChild>
 
-      <div class="fixed inset-0 z-50 overflow-y-auto">
-        <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
-          <TransitionChild as="template" enter="ease-out duration-300" enter-from="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95" enter-to="opacity-100 translate-y-0 sm:scale-100" leave="ease-in duration-200" leave-from="opacity-100 translate-y-0 sm:scale-100" leave-to="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95">
-            <DialogPanel class="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-100 sm:max-w-lg">
+      <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+        <TransitionChild as="template" enter="ease-out duration-300" enter-from="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95" enter-to="opacity-100 translate-y-0 sm:scale-100" leave="ease-in duration-200" leave-from="opacity-100 translate-y-0 sm:scale-100" leave-to="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95">
+          <DialogPanel class="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-100 sm:max-w-lg">
               <div class="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
                 <div class="sm:flex sm:items-start">
                   <div class="mx-auto shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-red-100 sm:mx-0 sm:h-10 sm:w-10">
@@ -37,9 +36,8 @@
               <p v-if="onAbortError != null" class="text-sm text-red-900 px-4 sm:px-6 text-right bg-red-50">
                 {{ t('common.unexpectedError', [onAbortError.message]) }}
               </p>
-            </DialogPanel>
-          </TransitionChild>
-        </div>
+          </DialogPanel>
+        </TransitionChild>
       </div>
     </Dialog>
   </TransitionRoot>


### PR DESCRIPTION
The `ProcessAbortDialog` was rendered outside of the parent `<Dialog>` component in `EmergencyAccessDialog`, which caused incorrect overlay stacking behaviour. 

This was especially noticeable on mobile, where the abort dialog rendered behind the parent overlay, making buttons unreachable. The dialog was moved inside the parent `<Dialog>` to ensure correct rendering and overlay handling.