### PR TITLE
Disabled users should not require a license seat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - User and group management (#376)
 - Emergency Access: Allow a council to restore access to a orphaned vault (#390)
 - Show pictures of the groups in the Vaults member list (#375)
+- Disable users to exclude them from license seat count (#427)
 
 ### Changed
 

--- a/backend/src/main/java/org/cryptomator/hub/api/AuthorityResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/AuthorityResource.java
@@ -10,6 +10,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import org.cryptomator.hub.entities.Authority;
+import org.cryptomator.hub.entities.User;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.jboss.resteasy.reactive.NoCache;
@@ -31,7 +32,7 @@ public class AuthorityResource {
 	@Operation(summary = "search authority by name")
 	@Transactional
 	public List<AuthorityDto> search(@QueryParam("query") @NotBlank String query, @QueryParam("withMemberSize") boolean withMemberSize) {
-		return authorityRepo.byName(query).map(authority -> AuthorityDto.fromEntity(authority, withMemberSize)).toList();
+		return authorityRepo.byName(query).filter(a -> !(a instanceof User u) || u.isEnabled()).map(authority -> AuthorityDto.fromEntity(authority, withMemberSize)).toList();
 	}
 
 	@GET

--- a/backend/src/main/java/org/cryptomator/hub/api/UserDto.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/UserDto.java
@@ -21,6 +21,7 @@ public final class UserDto extends AuthorityDto {
 	private final String lastName;
 	private final String language;
 	private final Set<String> realmRoles;
+	private final boolean enabled;
 	private final Set<DeviceResource.DeviceDto> devices;
 	private final String ecdhPublicKey;
 	private final String ecdsaPublicKey;
@@ -37,6 +38,7 @@ public final class UserDto extends AuthorityDto {
 			@JsonProperty("lastName") String lastName,
 			@JsonProperty("language") String language,
 			@JsonProperty("realmRoles") @NotNull Set<String> realmRoles,
+			@JsonProperty("enabled") boolean enabled,
 			@JsonProperty("devices") Set<DeviceResource.DeviceDto> devices,
 			// Accept either "ecdhPublicKey" or the legacy "publicKey" on input
 			@Nullable @JsonProperty("ecdhPublicKey") @OnlyBase64Chars String ecdhPublicKey,
@@ -52,6 +54,7 @@ public final class UserDto extends AuthorityDto {
 		this.lastName = lastName;
 		this.language = language;
 		this.realmRoles = realmRoles;
+		this.enabled = enabled;
 		this.devices = devices;
 		this.ecdhPublicKey = ecdhPublicKey != null ? ecdhPublicKey : publicKey;
 		this.ecdsaPublicKey = ecdsaPublicKey;
@@ -68,12 +71,13 @@ public final class UserDto extends AuthorityDto {
 			String lastName,
 			String language,
 			Set<String> realmRoles,
+			boolean enabled,
 			Set<DeviceResource.DeviceDto> devices,
 			String ecdhPublicKey,
 			String ecdsaPublicKey,
 			String privateKeys,
 			String setupCode) {
-		this(id, name, pictureUrl, email, firstName, lastName, language, realmRoles, devices, ecdhPublicKey, ecdhPublicKey, ecdsaPublicKey, privateKeys, privateKeys, setupCode);
+		this(id, name, pictureUrl, email, firstName, lastName, language, realmRoles, enabled, devices, ecdhPublicKey, ecdhPublicKey, ecdsaPublicKey, privateKeys, privateKeys, setupCode);
 	}
 
 	@JsonProperty("email")
@@ -99,6 +103,11 @@ public final class UserDto extends AuthorityDto {
 	@JsonProperty("realmRoles")
 	public Set<String> getRealmRoles() {
 		return realmRoles;
+	}
+
+	@JsonProperty("enabled")
+	public boolean isEnabled() {
+		return enabled;
 	}
 
 	@JsonProperty("devices")
@@ -158,6 +167,7 @@ public final class UserDto extends AuthorityDto {
 				user.getLastName(),
 				user.getLanguage(),
 				Set.of(user.getRealmRoles()),
+				user.isEnabled(),
 				Set.of(),
 				user.getEcdhPublicKey(),
 				user.getEcdsaPublicKey(),

--- a/backend/src/main/java/org/cryptomator/hub/api/UsersResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/UsersResource.java
@@ -431,8 +431,8 @@ public class UsersResource {
 	@Transactional
 	@Operation(summary = "enable or disable a user")
 	@APIResponse(responseCode = "204", description = "user updated")
-	public Response setUserEnabled(@PathParam("id") String userId, @Valid @NotNull SetUserEnabledDto dto) {
-		keycloakAdminService.setUserEnabled(userId, dto.enabled());
+	public Response setUserEnabled(@PathParam("id") String userId, boolean enabled) {
+		keycloakAdminService.setUserEnabled(userId, enabled);
 		return Response.noContent().build();
 	}
 
@@ -468,11 +468,6 @@ public class UsersResource {
 			@JsonProperty("password") String password,
 			@JsonProperty("pictureUrl") @Size(max = 255) String pictureUrl,
 			@JsonProperty("realmRoles") @NotNull Set<RealmRole> realmRoles
-	) {
-	}
-
-	public record SetUserEnabledDto(
-			@JsonProperty("enabled") boolean enabled
 	) {
 	}
 

--- a/backend/src/main/java/org/cryptomator/hub/api/UsersResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/UsersResource.java
@@ -190,7 +190,7 @@ public class UsersResource {
 		} else {
 			deviceDtos = Set.of();
 		}
-		return new UserDto(user.getId(), user.getName(), user.getPictureUrl(), user.getEmail(), user.getFirstName(), user.getLastName(), user.getLanguage(), Set.of(user.getRealmRoles()), deviceDtos, user.getEcdhPublicKey(), user.getEcdsaPublicKey(), user.getPrivateKeys(), user.getSetupCode());
+		return new UserDto(user.getId(), user.getName(), user.getPictureUrl(), user.getEmail(), user.getFirstName(), user.getLastName(), user.getLanguage(), Set.of(user.getRealmRoles()), user.isEnabled(), deviceDtos, user.getEcdhPublicKey(), user.getEcdsaPublicKey(), user.getPrivateKeys(), user.getSetupCode());
 	}
 
 	/**
@@ -214,7 +214,7 @@ public class UsersResource {
 			var event = events.get(d.getId());
 			return DeviceResource.DeviceDto.fromEntity(d, event);
 		}).collect(Collectors.toSet());
-		return new UserDto(user.getId(), user.getName(), user.getPictureUrl(), user.getEmail(), user.getFirstName(), user.getLastName(), user.getLanguage(), Set.of(user.getRealmRoles()), deviceDtos, user.getEcdhPublicKey(), user.getEcdsaPublicKey(), user.getPrivateKeys(), user.getSetupCode());
+		return new UserDto(user.getId(), user.getName(), user.getPictureUrl(), user.getEmail(), user.getFirstName(), user.getLastName(), user.getLanguage(), Set.of(user.getRealmRoles()), user.isEnabled(), deviceDtos, user.getEcdhPublicKey(), user.getEcdsaPublicKey(), user.getPrivateKeys(), user.getSetupCode());
 	}
 
 	@POST

--- a/backend/src/main/java/org/cryptomator/hub/api/UsersResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/UsersResource.java
@@ -424,6 +424,18 @@ public class UsersResource {
 		return UserDto.justPublicInfo(user);
 	}
 
+	@PUT
+	@Path("/{id}/enabled")
+	@RolesAllowed("admin")
+	@Consumes(MediaType.APPLICATION_JSON)
+	@Transactional
+	@Operation(summary = "enable or disable a user")
+	@APIResponse(responseCode = "204", description = "user updated")
+	public Response setUserEnabled(@PathParam("id") String userId, @Valid @NotNull SetUserEnabledDto dto) {
+		keycloakAdminService.setUserEnabled(userId, dto.enabled());
+		return Response.noContent().build();
+	}
+
 	@DELETE
 	@Path("/{id}")
 	@RolesAllowed("admin")
@@ -456,6 +468,11 @@ public class UsersResource {
 			@JsonProperty("password") String password,
 			@JsonProperty("pictureUrl") @Size(max = 255) String pictureUrl,
 			@JsonProperty("realmRoles") @NotNull Set<RealmRole> realmRoles
+	) {
+	}
+
+	public record SetUserEnabledDto(
+			@JsonProperty("enabled") boolean enabled
 	) {
 	}
 

--- a/backend/src/main/java/org/cryptomator/hub/api/UsersResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/UsersResource.java
@@ -427,7 +427,7 @@ public class UsersResource {
 	@PUT
 	@Path("/{id}/enabled")
 	@RolesAllowed("admin")
-	@Consumes(MediaType.APPLICATION_JSON)
+	@Consumes(MediaType.TEXT_PLAIN)
 	@Transactional
 	@Operation(summary = "enable or disable a user")
 	@APIResponse(responseCode = "204", description = "user updated")

--- a/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
@@ -184,7 +184,7 @@ public class VaultResource {
 	@APIResponse(responseCode = "200")
 	@APIResponse(responseCode = "403", description = "not a vault owner")
 	public List<MemberDto> getDirectMembers(@PathParam("vaultId") UUID vaultId) {
-		return vaultAccessRepo.forVault(vaultId).map(access -> switch (access.getAuthority()) {
+		return vaultAccessRepo.forVault(vaultId).filter(access -> !(access.getAuthority() instanceof User u) || u.isEnabled()).map(access -> switch (access.getAuthority()) {
 			case User u -> MemberDto.fromEntity(u, access.getRole());
 			case Group g -> MemberDto.fromEntity(g, access.getRole());
 			default -> throw new IllegalStateException();

--- a/backend/src/main/java/org/cryptomator/hub/entities/EffectiveVaultAccess.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/EffectiveVaultAccess.java
@@ -31,28 +31,28 @@ import java.util.stream.Stream;
 		FROM User u
 		INNER JOIN EffectiveVaultAccess eva ON u.id = eva.id.authorityId
 		INNER JOIN Vault v ON eva.id.vaultId = v.id
-		WHERE u.id = :userId AND NOT v.archived
+		WHERE u.id = :userId AND NOT v.archived AND u.enabled
 		""")
 @NamedQuery(name = "EffectiveVaultAccess.countSeatsOccupiedByUsers", query = """
 		SELECT COUNT(DISTINCT u.id)
 		FROM User u
 		INNER JOIN EffectiveVaultAccess eva ON u.id = eva.id.authorityId
 		INNER JOIN Vault v ON eva.id.vaultId = v.id
-		WHERE u.id IN :userIds AND NOT v.archived
+		WHERE u.id IN :userIds AND NOT v.archived AND u.enabled
 		""")
 @NamedQuery(name = "EffectiveVaultAccess.usersSeatedOnOtherVaults", query = """
 		SELECT DISTINCT u.id
 		FROM User u
 		INNER JOIN EffectiveVaultAccess eva ON u.id = eva.id.authorityId
 		INNER JOIN Vault v ON eva.id.vaultId = v.id
-		WHERE NOT v.archived AND v.id <> :vaultId
+		WHERE NOT v.archived AND v.id <> :vaultId AND u.enabled
 		""")
 @NamedQuery(name = "EffectiveVaultAccess.countSeatOccupyingUsers", query = """
 		SELECT COUNT(DISTINCT u.id)
 		FROM User u
 		INNER JOIN EffectiveVaultAccess eva ON u.id = eva.id.authorityId
 		INNER JOIN Vault v ON eva.id.vaultId = v.id
-		WHERE NOT v.archived
+		WHERE NOT v.archived AND u.enabled
 		""")
 @NamedQuery(name = "EffectiveVaultAccess.countSeatOccupyingUsersWithAccessToken", query = """
 		SELECT COUNT(DISTINCT u.id)
@@ -60,7 +60,7 @@ import java.util.stream.Stream;
 		INNER JOIN EffectiveVaultAccess eva ON u.id = eva.id.authorityId
 		INNER JOIN Vault v ON eva.id.vaultId = v.id
 		INNER JOIN AccessToken at ON eva.id.vaultId = at.id.vaultId AND eva.id.authorityId = at.id.userId
-		WHERE NOT v.archived
+		WHERE NOT v.archived AND u.enabled
 		""")
 @NamedQuery(name = "EffectiveVaultAccess.countSeatOccupyingUsersOfGroup", query = """
 		SELECT COUNT(DISTINCT u.id)
@@ -68,7 +68,7 @@ import java.util.stream.Stream;
 		INNER JOIN EffectiveVaultAccess eva ON u.id = eva.id.authorityId
 		INNER JOIN EffectiveGroupMembership egm ON u.id = egm.id.memberId
 		INNER JOIN Vault v ON eva.id.vaultId = v.id
-		WHERE egm.id.groupId = :groupId AND NOT v.archived
+		WHERE egm.id.groupId = :groupId AND NOT v.archived AND u.enabled
 		""")
 @NamedQuery(name = "EffectiveVaultAccess.findByAuthorityAndVault", query = """
 		SELECT eva

--- a/backend/src/main/java/org/cryptomator/hub/entities/User.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/User.java
@@ -34,19 +34,19 @@ import java.util.stream.Stream;
 				FROM User u
 					INNER JOIN EffectiveVaultAccess perm ON u.id = perm.id.authorityId
 					LEFT JOIN u.accessTokens token ON token.id.vaultId = :vaultId AND token.id.userId = u.id
-					WHERE perm.id.vaultId = :vaultId AND token.vault IS NULL AND u.ecdhPublicKey IS NOT NULL
+					WHERE perm.id.vaultId = :vaultId AND token.vault IS NULL AND u.ecdhPublicKey IS NOT NULL AND u.enabled
 				""")
 @NamedQuery(name = "User.getEffectiveGroupUsers", query = """
 				SELECT DISTINCT u
 				FROM User u
 				INNER JOIN EffectiveGroupMembership egm ON u.id = egm.id.memberId
-				WHERE egm.id.groupId IN :groupIds
+				WHERE egm.id.groupId IN :groupIds AND u.enabled
 		""")
 @NamedQuery(name = "User.countEffectiveGroupUsers", query = """
 				SELECT count( DISTINCT u)
 				FROM User u
 				INNER JOIN EffectiveGroupMembership egm	ON u.id = egm.id.memberId
-				WHERE egm.id.groupId = :groupId
+				WHERE egm.id.groupId = :groupId AND u.enabled
 		""")
 public class User extends Authority {
 
@@ -65,6 +65,9 @@ public class User extends Authority {
 	@Column(name = "realm_roles")
 	@Type(StringArrayType.class)
 	private String[] realmRoles = new String[0];
+
+	@Column(name = "enabled", nullable = false)
+	private boolean enabled = true;
 
 	@Column(name = "ecdh_publickey")
 	private String ecdhPublicKey;
@@ -139,6 +142,14 @@ public class User extends Authority {
 
 	public void setRealmRoles(String[] realmRoles) {
 		this.realmRoles = realmRoles;
+	}
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
 	}
 
 	public String getEcdhPublicKey() {

--- a/backend/src/main/java/org/cryptomator/hub/keycloak/KeycloakAdminService.java
+++ b/backend/src/main/java/org/cryptomator/hub/keycloak/KeycloakAdminService.java
@@ -177,6 +177,15 @@ public class KeycloakAdminService {
 		}
 	}
 
+	@Transactional
+	public void setUserEnabled(String userId, boolean enabled) {
+		UserResource userResource = realm.users().get(userId);
+		UserRepresentation user = userResource.toRepresentation();
+		user.setEnabled(enabled);
+		userResource.update(user);
+		syncUser(userId);
+	}
+
 	public boolean isUserReadOnly(String userId) {
 		try {
 			UserResource userResource = realm.users().get(userId);
@@ -204,6 +213,8 @@ public class KeycloakAdminService {
 		dbUser.setEmail(keycloakUser.getEmail());
 		dbUser.setFirstName(keycloakUser.getFirstName());
 		dbUser.setLastName(keycloakUser.getLastName());
+
+		dbUser.setEnabled(Boolean.TRUE.equals(keycloakUser.isEnabled()));
 
 		var attrs = keycloakUser.getAttributes();
 		if (attrs != null && attrs.containsKey("picture")) {

--- a/backend/src/main/java/org/cryptomator/hub/keycloak/KeycloakAdminService.java
+++ b/backend/src/main/java/org/cryptomator/hub/keycloak/KeycloakAdminService.java
@@ -214,7 +214,7 @@ public class KeycloakAdminService {
 		dbUser.setFirstName(keycloakUser.getFirstName());
 		dbUser.setLastName(keycloakUser.getLastName());
 
-		dbUser.setEnabled(Boolean.TRUE.equals(keycloakUser.isEnabled()));
+		dbUser.setEnabled(keycloakUser.isEnabled());
 
 		var attrs = keycloakUser.getAttributes();
 		if (attrs != null && attrs.containsKey("picture")) {

--- a/backend/src/main/java/org/cryptomator/hub/keycloak/KeycloakAuthorityProvider.java
+++ b/backend/src/main/java/org/cryptomator/hub/keycloak/KeycloakAuthorityProvider.java
@@ -67,7 +67,7 @@ public class KeycloakAuthorityProvider {
 				userRepresentation.getFirstName(),
 				userRepresentation.getLastName(),
 				pictureUrl,
-				Boolean.TRUE.equals(userRepresentation.isEnabled()),
+				userRepresentation.isEnabled(),
 				RealmRole.fromKcNames(userRepresentation.getRealmRoles()));
 	}
 

--- a/backend/src/main/java/org/cryptomator/hub/keycloak/KeycloakAuthorityProvider.java
+++ b/backend/src/main/java/org/cryptomator/hub/keycloak/KeycloakAuthorityProvider.java
@@ -67,6 +67,7 @@ public class KeycloakAuthorityProvider {
 				userRepresentation.getFirstName(),
 				userRepresentation.getLastName(),
 				pictureUrl,
+				Boolean.TRUE.equals(userRepresentation.isEnabled()),
 				RealmRole.fromKcNames(userRepresentation.getRealmRoles()));
 	}
 

--- a/backend/src/main/java/org/cryptomator/hub/keycloak/KeycloakAuthorityPuller.java
+++ b/backend/src/main/java/org/cryptomator/hub/keycloak/KeycloakAuthorityPuller.java
@@ -79,6 +79,7 @@ public class KeycloakAuthorityPuller {
 			databaseUser.setFirstName(keycloakUser.firstName());
 			databaseUser.setLastName(keycloakUser.lastName());
 			databaseUser.setPictureUrl(keycloakUser.pictureUrl());
+			databaseUser.setEnabled(keycloakUser.enabled());
 			databaseUser.setRealmRoles(keycloakUser.roles().stream().map(RealmRole::kcName).toArray(String[]::new));
 			return databaseUser;
 		}).collect(Collectors.toMap(User::getId, Function.identity()));
@@ -106,6 +107,7 @@ public class KeycloakAuthorityPuller {
 			databaseUser.setFirstName(keycloakUser.firstName());
 			databaseUser.setLastName(keycloakUser.lastName());
 			databaseUser.setPictureUrl(keycloakUser.pictureUrl());
+			databaseUser.setEnabled(keycloakUser.enabled());
 			databaseUser.setRealmRoles(keycloakUser.roles().stream().map(RealmRole::kcName).toArray(String[]::new));
 		}
 	}

--- a/backend/src/main/java/org/cryptomator/hub/keycloak/KeycloakUserDto.java
+++ b/backend/src/main/java/org/cryptomator/hub/keycloak/KeycloakUserDto.java
@@ -2,5 +2,5 @@ package org.cryptomator.hub.keycloak;
 
 import java.util.Set;
 
-public record KeycloakUserDto(String id, String name, String email, String firstName, String lastName, String pictureUrl, Set<RealmRole> roles) {
+public record KeycloakUserDto(String id, String name, String email, String firstName, String lastName, String pictureUrl, boolean enabled, Set<RealmRole> roles) {
 }

--- a/backend/src/main/resources/org/cryptomator/hub/flyway/V25__User_Enabled.sql
+++ b/backend/src/main/resources/org/cryptomator/hub/flyway/V25__User_Enabled.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user_details" ADD COLUMN "enabled" BOOLEAN NOT NULL DEFAULT TRUE;

--- a/backend/src/test/java/org/cryptomator/hub/api/UsersResourceIT.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/UsersResourceIT.java
@@ -608,12 +608,7 @@ class UsersResourceIT {
 		void testSetUserEnabledSuccess() {
 			Mockito.doNothing().when(keycloakAdminService).setUserEnabled("user1", false);
 
-			var body = """
-					{
-						"enabled": false
-					}
-					""";
-			given().contentType(ContentType.JSON).body(body)
+			given().contentType(ContentType.JSON).body("false")
 					.when().put("/users/user1/enabled")
 					.then().statusCode(204);
 

--- a/backend/src/test/java/org/cryptomator/hub/api/UsersResourceIT.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/UsersResourceIT.java
@@ -608,7 +608,7 @@ class UsersResourceIT {
 		void testSetUserEnabledSuccess() {
 			Mockito.doNothing().when(keycloakAdminService).setUserEnabled("user1", false);
 
-			given().contentType(ContentType.JSON).body("false")
+			given().contentType(ContentType.TEXT).body("false")
 					.when().put("/users/user1/enabled")
 					.then().statusCode(204);
 

--- a/backend/src/test/java/org/cryptomator/hub/api/UsersResourceIT.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/UsersResourceIT.java
@@ -604,6 +604,23 @@ class UsersResourceIT {
 		}
 
 		@Test
+		@DisplayName("PUT /users/{id}/enabled returns 204 when disabled successfully")
+		void testSetUserEnabledSuccess() {
+			Mockito.doNothing().when(keycloakAdminService).setUserEnabled("user1", false);
+
+			var body = """
+					{
+						"enabled": false
+					}
+					""";
+			given().contentType(ContentType.JSON).body(body)
+					.when().put("/users/user1/enabled")
+					.then().statusCode(204);
+
+			Mockito.verify(keycloakAdminService).setUserEnabled("user1", false);
+		}
+
+		@Test
 		@DisplayName("DELETE /users/{id} returns 204 when deleted successfully")
 		void testDeleteUserSuccess() {
 			Mockito.doNothing().when(keycloakAdminService).deleteUser("mockedUserId");

--- a/backend/src/test/java/org/cryptomator/hub/keycloak/KeycloakAuthorityProviderTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/keycloak/KeycloakAuthorityProviderTest.java
@@ -51,11 +51,13 @@ class KeycloakAuthorityProviderTest {
 		Mockito.when(user1.getId()).thenReturn("id3000");
 		Mockito.when(user1.getUsername()).thenReturn("username3000");
 		Mockito.when(user1.getEmail()).thenReturn("email3000");
+		Mockito.when(user1.isEnabled()).thenReturn(true);
 		Mockito.when(user1.getAttributes()).thenReturn(Map.of("picture", List.of("picture3000")));
 
 		Mockito.when(user2.getId()).thenReturn("id3001");
 		Mockito.when(user2.getUsername()).thenReturn("username3001");
 		Mockito.when(user2.getEmail()).thenReturn("email3001");
+		Mockito.when(user2.isEnabled()).thenReturn(false);
 
 		keycloakRemoteUserProvider = new KeycloakAuthorityProvider();
 	}
@@ -76,11 +78,13 @@ class KeycloakAuthorityProviderTest {
 		Assertions.assertEquals("username3000", resultUser1.name());
 		Assertions.assertEquals("email3000", resultUser1.email());
 		Assertions.assertEquals("picture3000", resultUser1.pictureUrl());
+		Assertions.assertTrue(resultUser1.enabled());
 
 		Assertions.assertEquals("id3001", resultUser2.id());
 		Assertions.assertEquals("username3001", resultUser2.name());
 		Assertions.assertEquals("email3001", resultUser2.email());
 		Assertions.assertNull(resultUser2.pictureUrl());
+		Assertions.assertFalse(resultUser2.enabled());
 	}
 
 	@Test
@@ -114,11 +118,13 @@ class KeycloakAuthorityProviderTest {
 		Assertions.assertEquals("username3000", resultUser1.name());
 		Assertions.assertEquals("email3000", resultUser1.email());
 		Assertions.assertEquals("picture3000", resultUser1.pictureUrl());
+		Assertions.assertTrue(resultUser1.enabled());
 
 		Assertions.assertEquals("id3001", resultUser2.id());
 		Assertions.assertEquals("username3001", resultUser2.name());
 		Assertions.assertEquals("email3001", resultUser2.email());
 		Assertions.assertNull(resultUser2.pictureUrl());
+		Assertions.assertFalse(resultUser2.enabled());
 
 		Assertions.assertEquals("cryptomatorHubCliUserId", resultUser3.id());
 		Assertions.assertEquals("cryptomatorHubCliUserUsername", resultUser3.name());
@@ -184,11 +190,13 @@ class KeycloakAuthorityProviderTest {
 			Assertions.assertEquals("username3000", member1Group2.name());
 			Assertions.assertEquals("email3000", member1Group2.email());
 			Assertions.assertEquals("picture3000", member1Group2.pictureUrl());
+			Assertions.assertTrue(member1Group2.enabled());
 
 			Assertions.assertEquals("id3001", member2Group2.id());
 			Assertions.assertEquals("username3001", member2Group2.name());
 			Assertions.assertEquals("email3001", member2Group2.email());
 			Assertions.assertNull(member2Group2.pictureUrl());
+			Assertions.assertFalse(member2Group2.enabled());
 		}
 	}
 

--- a/backend/src/test/java/org/cryptomator/hub/keycloak/KeycloakAuthorityPullerTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/keycloak/KeycloakAuthorityPullerTest.java
@@ -88,7 +88,7 @@ class KeycloakAuthorityPullerTest {
 			Mockito.when(databaseUsers.keySet()).thenReturn(databaseUserIds);
 
 			for (var userId : addedUserIds) {
-				var keycloakUser = new KeycloakUserDto(userId, "name " + userId, "email " + userId, "first " + userId, "last " + userId, "pic " + userId, Set.of());
+				var keycloakUser = new KeycloakUserDto(userId, "name " + userId, "email " + userId, "first " + userId, "last " + userId, "pic " + userId, true, Set.of());
 				Mockito.when(keycloakUsers.get(userId)).thenReturn(keycloakUser);
 			}
 
@@ -105,7 +105,8 @@ class KeycloakAuthorityPullerTest {
 								Matchers.hasProperty("email", Matchers.equalTo("email " + userId)),
 								Matchers.hasProperty("firstName", Matchers.equalTo("first " + userId)),
 								Matchers.hasProperty("lastName", Matchers.equalTo("last " + userId)),
-								Matchers.hasProperty("pictureUrl", Matchers.equalTo("pic " + userId))
+								Matchers.hasProperty("pictureUrl", Matchers.equalTo("pic " + userId)),
+								Matchers.hasProperty("enabled", Matchers.equalTo(true))
 						)
 				));
 			}
@@ -170,7 +171,7 @@ class KeycloakAuthorityPullerTest {
 			Mockito.when(databaseUsers.keySet()).thenReturn(databaseUserIds);
 
 			for (var userId : updatedUserIds) {
-				var keycloakUser = new KeycloakUserDto(userId, "name " + userId, "email " + userId, "first " + userId, "last " + userId, "pic " + userId, Set.of());
+				var keycloakUser = new KeycloakUserDto(userId, "name " + userId, "email " + userId, "first " + userId, "last " + userId, "pic " + userId, true, Set.of());
 				Mockito.when(keycloakUsers.get(userId)).thenReturn(keycloakUser);
 
 				var databaseUser = Mockito.mock(User.class);
@@ -187,6 +188,7 @@ class KeycloakAuthorityPullerTest {
 				Mockito.verify(databaseUser).setFirstName("first " + userId);
 				Mockito.verify(databaseUser).setLastName("last " + userId);
 				Mockito.verify(databaseUser).setPictureUrl("pic " + userId);
+				Mockito.verify(databaseUser).setEnabled(true);
 			}
 			Mockito.verify(userRepo, Mockito.never()).persist(any(User.class));
 		}
@@ -209,7 +211,7 @@ class KeycloakAuthorityPullerTest {
 		void testAddGroups(@ConvertWith(StringArrayConverter.class) String[] keycloakGroupIdString, @ConvertWith(StringArrayConverter.class) String[] databaseGroupIdString, @ConvertWith(StringArrayConverter.class) String[] addedGroupIdString) {
 			Map<String, KeycloakUserDto> kcUsers = new HashMap<>();
 			for (var gid : keycloakGroupIdString) {
-				kcUsers.put(gid, new KeycloakUserDto(gid, "username", "email", "first", "last", "pic", Set.of()));
+				kcUsers.put(gid, new KeycloakUserDto(gid, "username", "email", "first", "last", "pic", true, Set.of()));
 			}
 
 			Map<String, KeycloakGroupDto> keycloakGroups = new HashMap<>();
@@ -313,8 +315,8 @@ class KeycloakAuthorityPullerTest {
 			Mockito.when(kcDto.name()).thenReturn(String.format("name %s", groupId));
 			Mockito.when(kcDto.pictureUrl()).thenReturn(String.format("pic %s", groupId));
 			Mockito.when(kcDto.members()).thenReturn(Set.of(
-					new KeycloakUserDto("U_user", "n", "e", "f", "l", "p", Set.of()),
-					new KeycloakUserDto("U_otherKC", "n", "e", "f", "l", "p", Set.of())
+					new KeycloakUserDto("U_user", "n", "e", "f", "l", "p", true, Set.of()),
+					new KeycloakUserDto("U_otherKC", "n", "e", "f", "l", "p", true, Set.of())
 			));
 
 			var dbGroup = Mockito.mock(Group.class);

--- a/frontend/src/common/backend.ts
+++ b/frontend/src/common/backend.ts
@@ -527,7 +527,7 @@ class UserService {
   }
 
   public async setUserEnabled(userId: string, enabled: boolean): Promise<void> {
-    await axiosAuth.put(`/users/${userId}/enabled`, { enabled });
+    await axiosAuth.put(`/users/${userId}/enabled`, enabled);
   }
 
   public async updateUser(userId: string, dto: UpdateUserDto, addFallbackPictures: boolean = true): Promise<UserDto> {

--- a/frontend/src/common/backend.ts
+++ b/frontend/src/common/backend.ts
@@ -526,6 +526,10 @@ class UserService {
     }
   }
 
+  public async setUserEnabled(userId: string, enabled: boolean): Promise<void> {
+    await axiosAuth.put(`/users/${userId}/enabled`, { enabled });
+  }
+
   public async updateUser(userId: string, dto: UpdateUserDto, addFallbackPictures: boolean = true): Promise<UserDto> {
     const user = await axiosAuth.put<UserDto>(`/users/${userId}`, dto).then(response => response.data).catch((error) => rethrowAndConvertIfExpected(error, 404));
     return addFallbackPictures ? fillInMissingPicture(user) : user;

--- a/frontend/src/common/backend.ts
+++ b/frontend/src/common/backend.ts
@@ -91,6 +91,7 @@ export type UserDto = {
   firstName?: string;
   lastName?: string;
   realmRoles: RealmRole[];
+  enabled: boolean;
   language?: string;
   devices: DeviceDto[];
   accessibleVaults: VaultDtoWithRole[];

--- a/frontend/src/common/backend.ts
+++ b/frontend/src/common/backend.ts
@@ -527,7 +527,7 @@ class UserService {
   }
 
   public async setUserEnabled(userId: string, enabled: boolean): Promise<void> {
-    await axiosAuth.put(`/users/${userId}/enabled`, enabled);
+    await axiosAuth.put(`/users/${userId}/enabled`, enabled, { headers: { 'Content-Type': 'text/plain' } });
   }
 
   public async updateUser(userId: string, dto: UpdateUserDto, addFallbackPictures: boolean = true): Promise<UserDto> {

--- a/frontend/src/components/authority/UserDeleteDialog.vue
+++ b/frontend/src/components/authority/UserDeleteDialog.vue
@@ -59,15 +59,7 @@ import { Dialog, DialogOverlay, DialogPanel, DialogTitle, TransitionChild, Trans
 import { ExclamationTriangleIcon } from '@heroicons/vue/24/outline';
 import { ref, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
-import backend from '../../common/backend';
-
-interface User {
-  id: string;
-  name: string;
-  pictureUrl?: string;
-  firstName?: string;
-  lastName?: string;
-}
+import backend, { UserDto } from '../../common/backend';
 
 const { t } = useI18n({ useScope: 'global' });
 
@@ -75,8 +67,8 @@ const open = ref(false);
 const onDeleteUserError = ref<Error | null>(null);
 
 const props = defineProps<{
-    user: User
-  }>();
+  user: UserDto;
+}>();
 
 const fullName = computed(() => {
   const first = props.user.firstName ?? '';
@@ -85,9 +77,9 @@ const fullName = computed(() => {
 });
 
 const emit = defineEmits<{
-    close: []
-    delete: [updatedUser: User]
-  }>();
+  close: [];
+  delete: [deletedUser: UserDto];
+}>();
 
 defineExpose({
   show
@@ -110,5 +102,4 @@ async function deleteUser() {
     onDeleteUserError.value = error instanceof Error ? error : new Error('Unknown Error');
   }
 }
-
 </script>

--- a/frontend/src/components/authority/UserDetail.vue
+++ b/frontend/src/components/authority/UserDetail.vue
@@ -26,6 +26,16 @@
           <transition enter-active-class="transition ease-out duration-100" enter-from-class="transform opacity-0 translate-y-1 scale-95" enter-to-class="transform opacity-100 translate-y-0 scale-100" leave-active-class="transition ease-in duration-75" leave-from-class="transform opacity-100 translate-y-0 scale-100" leave-to-class="transform opacity-0 translate-y-1 scale-95">
             <MenuItems class="absolute right-0 mt-2 z-10 w-48 origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black/5 focus:outline-hidden">
               <div class="py-1">
+                <MenuItem v-if="user.enabled" v-slot="{ active }">
+                  <div :class="[ active ? 'bg-gray-100 text-red-900' : 'text-red-700', 'cursor-pointer block px-4 py-2 text-sm']" @click="showDisableUserDialog()">
+                    {{ t('user.detail.disable') }}
+                  </div>
+                </MenuItem>
+                <MenuItem v-else v-slot="{ active }">
+                  <div :class="[ active ? 'bg-gray-100 text-gray-900' : 'text-gray-700', 'cursor-pointer block px-4 py-2 text-sm']" @click="enableUser()">
+                    {{ t('user.detail.enable') }}
+                  </div>
+                </MenuItem>
                 <MenuItem v-slot="{ active }">
                   <div :class="[ active ? 'bg-gray-100 text-red-900' : 'text-red-700', 'cursor-pointer block px-4 py-2 text-sm']" @click="showDeleteUserDialog()">
                     {{ t('common.remove') }}
@@ -66,6 +76,7 @@
   </div>
 
   <!-- Dialogs -->
+  <UserDisableDialog v-if="disablingUser" ref="disableUserDialog" :user="disablingUser" @close="disablingUser = undefined" @disable="onUserDisabled"/>
   <UserDeleteDialog v-if="deletingUser" ref="deleteUserDialog" :user="deletingUser" @close="deletingUser = undefined" @delete="onUserDeleted"/>
 </template>
 
@@ -78,6 +89,7 @@ import { useRouter } from 'vue-router';
 import backend, { GroupDto, isSelectableRealmRole, UserDto, UserDtoWithDetails } from '../../common/backend';
 import BreadcrumbNav from '../BreadcrumbNav.vue';
 import UserDeleteDialog from './UserDeleteDialog.vue';
+import UserDisableDialog from './UserDisableDialog.vue';
 import UserDeviceList from './UserDeviceList.vue';
 import UserGroupsList from './UserGroupsList.vue';
 import UserInfo from './UserInfo.vue';
@@ -89,6 +101,8 @@ const router = useRouter();
 
 const deleteUserDialog = ref<typeof UserDeleteDialog>();
 const deletingUser = ref<UserDto>();
+const disableUserDialog = ref<typeof UserDisableDialog>();
+const disablingUser = ref<UserDto>();
 
 const showDeleteUserDialog = () => {
   deletingUser.value = user.value;
@@ -97,6 +111,24 @@ const showDeleteUserDialog = () => {
 
 const onUserDeleted = () => {
   router.push('/app/users');
+};
+
+const showDisableUserDialog = () => {
+  disablingUser.value = user.value;
+  nextTick(() => disableUserDialog.value?.show());
+};
+
+const onUserDisabled = async () => {
+  user.value = await backend.users.getUser(props.id);
+};
+
+const enableUser = async () => {
+  try {
+    await backend.users.setUserEnabled(props.id, true);
+    user.value = await backend.users.getUser(props.id);
+  } catch (error) {
+    console.error('Enabling user failed.', error);
+  }
 };
 
 const user = ref<UserDtoWithDetails>({

--- a/frontend/src/components/authority/UserDetail.vue
+++ b/frontend/src/components/authority/UserDetail.vue
@@ -110,6 +110,7 @@ const user = ref<UserDtoWithDetails>({
   language: undefined,
   accessibleVaults: [],
   realmRoles: [],
+  enabled: true,
   groups: [],
   devices: [],
   legacyDevices: [],

--- a/frontend/src/components/authority/UserDisableDialog.vue
+++ b/frontend/src/components/authority/UserDisableDialog.vue
@@ -59,15 +59,7 @@ import { Dialog, DialogOverlay, DialogPanel, DialogTitle, TransitionChild, Trans
 import { ExclamationTriangleIcon } from '@heroicons/vue/24/outline';
 import { ref, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
-import backend from '../../common/backend';
-
-interface User {
-  id: string;
-  name: string;
-  pictureUrl?: string;
-  firstName?: string;
-  lastName?: string;
-}
+import backend, { UserDto } from '../../common/backend';
 
 const { t } = useI18n({ useScope: 'global' });
 
@@ -75,8 +67,8 @@ const open = ref(false);
 const onDisableUserError = ref<Error | null>(null);
 
 const props = defineProps<{
-    user: User
-  }>();
+  user: UserDto;
+}>();
 
 const fullName = computed(() => {
   const first = props.user.firstName ?? '';
@@ -85,9 +77,9 @@ const fullName = computed(() => {
 });
 
 const emit = defineEmits<{
-    close: []
-    disable: [updatedUser: User]
-  }>();
+  close: [];
+  disable: [disabledUser: UserDto];
+}>();
 
 defineExpose({
   show
@@ -110,5 +102,4 @@ async function disableUser() {
     onDisableUserError.value = error instanceof Error ? error : new Error('Unknown Error');
   }
 }
-
 </script>

--- a/frontend/src/components/authority/UserDisableDialog.vue
+++ b/frontend/src/components/authority/UserDisableDialog.vue
@@ -1,0 +1,114 @@
+<template>
+  <TransitionRoot as="template" :show="open" @after-leave="$emit('close')">
+    <Dialog as="div" class="fixed z-10 inset-0 overflow-y-auto" @close="open = false">
+      <TransitionChild as="template" enter="ease-out duration-300" enter-from="opacity-0" enter-to="opacity-100" leave="ease-in duration-200" leave-from="opacity-100" leave-to="opacity-0">
+        <DialogOverlay class="fixed inset-0 bg-gray-500/75 transition-opacity" />
+      </TransitionChild>
+
+      <div class="fixed inset-0 z-10 overflow-y-auto">
+        <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+          <TransitionChild as="template" enter="ease-out duration-300" enter-from="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95" enter-to="opacity-100 translate-y-0 sm:scale-100" leave="ease-in duration-200" leave-from="opacity-100 translate-y-0 sm:scale-100" leave-to="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95">
+            <DialogPanel class="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
+              <form novalidate @submit.prevent="disableUser" >
+                <div class="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+                  <div class="sm:flex sm:items-start">
+                    <div class="mx-auto shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-red-100 sm:mx-0 sm:h-10 sm:w-10">
+                      <ExclamationTriangleIcon class="h-6 w-6 text-red-600" aria-hidden="true" />
+                    </div>
+                    <div class="mt-3 grow text-center sm:mt-0 sm:ml-4 sm:text-left">
+                      <DialogTitle as="h3" class="text-lg leading-6 font-medium text-gray-900">
+                        {{ t('disableUserDialog.title') }}
+                      </DialogTitle>
+                      <div class="mt-2">
+                        <p class="text-sm text-gray-500">
+                          {{ t('disableUserDialog.description') }}
+                        </p>
+                      </div>
+                      <div class="mt-4 hidden sm:flex items-center gap-2">
+                        <img :src="user.pictureUrl" class="w-8 h-8 rounded-full border" />
+                        <div class="flex flex-col">
+                          <span class="font-medium text-sm">{{ user.name }}</span>
+                          <span v-if="fullName" class="text-xs text-gray-500">{{ fullName }}</span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+                  <button type="submit" class="w-full inline-flex justify-center rounded-md border border-transparent shadow-xs px-4 py-2 bg-red-600 text-base font-medium text-white hover:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500 sm:ml-3 sm:w-auto sm:text-sm" >
+                    {{ t('disableUserDialog.confirm') }}
+                  </button>
+                  <button type="button" class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-xs px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-primary sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm" @click="open = false">
+                    {{ t('common.cancel') }}
+                  </button>
+                </div>
+                <p v-if="onDisableUserError != null" class="text-sm text-red-900 px-4 sm:px-6 text-right bg-red-50">
+                  {{ t('common.unexpectedError', [onDisableUserError.message]) }}
+                </p>
+              </form>
+            </DialogPanel>
+          </TransitionChild>
+        </div>
+      </div>
+    </Dialog>
+  </TransitionRoot>
+</template>
+
+<script setup lang="ts">
+import { Dialog, DialogOverlay, DialogPanel, DialogTitle, TransitionChild, TransitionRoot } from '@headlessui/vue';
+import { ExclamationTriangleIcon } from '@heroicons/vue/24/outline';
+import { ref, computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import backend from '../../common/backend';
+
+interface User {
+  id: string;
+  name: string;
+  pictureUrl?: string;
+  firstName?: string;
+  lastName?: string;
+}
+
+const { t } = useI18n({ useScope: 'global' });
+
+const open = ref(false);
+const onDisableUserError = ref<Error | null>(null);
+
+const props = defineProps<{
+    user: User
+  }>();
+
+const fullName = computed(() => {
+  const first = props.user.firstName ?? '';
+  const last = props.user.lastName ?? '';
+  return `${first} ${last}`.trim();
+});
+
+const emit = defineEmits<{
+    close: []
+    disable: [updatedUser: User]
+  }>();
+
+defineExpose({
+  show
+});
+
+function show() {
+  open.value = true;
+}
+
+async function disableUser() {
+  onDisableUserError.value = null;
+
+  try {
+    await backend.users.setUserEnabled(props.user.id, false);
+
+    emit('disable', props.user);
+    open.value = false;
+  } catch (error) {
+    console.error('Disabling user failed.', error);
+    onDisableUserError.value = error instanceof Error ? error : new Error('Unknown Error');
+  }
+}
+
+</script>

--- a/frontend/src/components/authority/UserInfo.vue
+++ b/frontend/src/components/authority/UserInfo.vue
@@ -14,6 +14,7 @@
         <p v-if="user.firstName || user.lastName" class="text-sm text-gray-500 mt-1">
           {{ user.name }}
         </p>
+        <span v-if="!user.enabled" class="inline-flex items-center rounded-md bg-gray-100 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10 mt-2">{{ t('user.detail.disabled') }}</span>
       </div>
       <dl class="divide-y divide-gray-100">
         <div class="py-3 flex justify-between">

--- a/frontend/src/components/authority/UserList.vue
+++ b/frontend/src/components/authority/UserList.vue
@@ -24,7 +24,10 @@
             <div class="flex items-center min-w-0 flex-1" :title="user.name">
               <img :src="user.pictureUrl" :alt="t('userList.profileImage')" class="w-10 h-10 rounded-full object-cover border border-gray-300 flex-shrink-0" />
               <div class="ml-3 min-w-0 flex-1">
-                <p class="text-sm font-medium text-gray-900 truncate leading-tight">{{ user.name }}</p>
+                <div class="flex items-center gap-2">
+                  <p class="text-sm font-medium text-gray-900 truncate leading-tight">{{ user.name }}</p>
+                  <span v-if="!user.enabled" class="inline-flex items-center rounded-md bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10 shrink-0">{{ t('userList.disabled') }}</span>
+                </div>
                 <p class="text-xs text-gray-500 truncate">{{ user.firstName || user.lastName ? `${user.firstName ?? ''} ${user.lastName ?? ''}`.trim() : user.email }}</p>
               </div>
             </div>
@@ -79,7 +82,10 @@
                     <div class="flex items-center gap-3 max-w-sm">
                       <img :src="user.pictureUrl" :alt="t('userList.profileImage')" class="w-10 h-10 rounded-full object-cover border border-gray-300"/>
                       <div class="flex flex-col min-w-0 flex-1">
-                        <button type="button" class="truncate block hover:underline cursor-pointer text-left" :title="user.name" @click="router.push(`users/${user.id}`)">{{ user.name }}</button>
+                        <div class="flex items-center gap-2">
+                          <button type="button" class="truncate block hover:underline cursor-pointer text-left" :title="user.name" @click="router.push(`users/${user.id}`)">{{ user.name }}</button>
+                          <span v-if="!user.enabled" class="inline-flex items-center rounded-md bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10 shrink-0">{{ t('userList.disabled') }}</span>
+                        </div>
                         <span class="text-xs text-gray-500 truncate" :title="user.firstName || user.lastName ? `${user.firstName ?? ''} ${user.lastName ?? ''}`.trim() : user.email ?? undefined">{{ user.firstName || user.lastName ? `${user.firstName ?? ''} ${user.lastName ?? ''}`.trim() : user.email }}</span>
                       </div>
                     </div>

--- a/frontend/src/i18n/en-US.json
+++ b/frontend/src/i18n/en-US.json
@@ -196,6 +196,10 @@
   "deleteGroupDialog.description": "Are you sure you want to permanently delete this group? It will be removed from all associated vaults. This action cannot be undone.",
   "deleteGroupDialog.confirm": "Yes, delete group",
 
+  "disableUserDialog.title": "Disable User",
+  "disableUserDialog.description": "This user will no longer be able to log in and will be excluded from the seat count. You can re-enable the user at any time.",
+  "disableUserDialog.confirm": "Disable User",
+
   "deleteUserDialog.title": "Delete User Account",
   "deleteUserDialog.description": "Are you sure you want to permanently delete this user? All associated vaults and devices will be removed. This action cannot be undone.",
   "deleteUserDialog.confirm": "Yes, delete user",
@@ -456,9 +460,11 @@
 
   "users.title": "Users",
   "user.detail.createdOn": "Created on",
+  "user.detail.disable": "Disable",
   "user.detail.disabled": "Disabled",
   "user.detail.devices": "Devices",
   "user.detail.edit": "Edit",
+  "user.detail.enable": "Enable",
   "user.detail.email": "Email",
   "user.detail.groups": "Groups",
   "user.detail.groups.join": "Join",

--- a/frontend/src/i18n/en-US.json
+++ b/frontend/src/i18n/en-US.json
@@ -456,6 +456,7 @@
 
   "users.title": "Users",
   "user.detail.createdOn": "Created on",
+  "user.detail.disabled": "Disabled",
   "user.detail.devices": "Devices",
   "user.detail.edit": "Edit",
   "user.detail.email": "Email",
@@ -510,6 +511,7 @@
   "userList.user.created": "Created on",
   "userList.profileImage": "Profile Image",
   "userList.create.button": "Create User",
+  "userList.disabled": "Disabled",
 
   "userProfile.title": "Profile",
   "userProfile.actions.manageAccount": "Manage Account",

--- a/frontend/test/common/emergencyaccess.spec.ts
+++ b/frontend/test/common/emergencyaccess.spec.ts
@@ -110,6 +110,7 @@ async function createUserDto(id: string, publicKey: CryptoKey): Promise<Activate
     name: `User ${id}`,
     email: '',
     realmRoles: [],
+    enabled: true,
     devices: [],
     accessibleVaults: [],
     ecdhPublicKey: base64.encode(keyBytes),


### PR DESCRIPTION
Fixes #427

Syncs the `enabled` property from Keycloak's `UserRepresentation` into Hub's user entity. Disabled users are excluded from license seat calculations and hidden from non-admin views (authority search, vault member lists, access grant lists, group member queries). Admins can still see disabled users in the user management page, where they're marked with a "Disabled" badge. Admins can also enable or disable users directly from the user detail page.

Changes:
- New Flyway migration V25 adding `enabled` column to `user_details`
- Keycloak syncer pulls and updates the `enabled` flag on every sync cycle
- All seat-counting queries in `EffectiveVaultAccess` filter on `u.enabled`
- Authority search and vault member endpoints filter out disabled users
- `UserDto` exposes the `enabled` field to the frontend
- Admin user list and user detail pages show a "Disabled" badge
- New `PUT /users/{id}/enabled` admin endpoint to toggle a user's enabled state in Keycloak
- User detail page ellipsis menu shows "Disable" (with confirmation dialog) or "Enable" action