### PR TITLE
Allow admins to archive and unarchive any vault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - User and group management (#376)
 - Emergency Access: Allow a council to restore access to a orphaned vault (#390)
 - Show pictures of the groups in the Vaults member list (#375)
+- Allow admins to archive and unarchive any vault (#283)
 
 ### Changed
 

--- a/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
@@ -513,9 +513,28 @@ public class VaultResource {
 	}
 
 	@PUT
+	@Path("/{vaultId}/archived")
+	@RolesAllowed("user")
+	@VaultRole(value = VaultAccess.Role.OWNER, bypassForRealmRole = true, onMissingVault = VaultRole.OnMissingVault.NOT_FOUND)
+	@Consumes(MediaType.APPLICATION_JSON)
+	@Produces(MediaType.APPLICATION_JSON)
+	@Transactional
+	@Operation(summary = "sets the archived flag of a vault")
+	@APIResponse(responseCode = "200", description = "archived flag updated")
+	@APIResponse(responseCode = "403", description = "requesting user is neither a vault owner nor has the admin role")
+	@APIResponse(responseCode = "404", description = "vault not found")
+	public VaultDto setArchived(@PathParam("vaultId") UUID vaultId, @NotNull Boolean archived) {
+		Vault vault = vaultRepo.findByIdOptional(vaultId).orElseThrow(NotFoundException::new);
+		vault.setArchived(archived);
+		vaultRepo.persistAndFlush(vault);
+		eventLogger.logVaultUpdated(jwt.getSubject(), vault.getId(), vault.getName(), vault.getDescription(), vault.isArchived());
+		return VaultDto.fromEntity(vault);
+	}
+
+	@PUT
 	@Path("/{vaultId}")
 	@RolesAllowed("user") // general authentication. VaultRole filter will check for specific access rights
-	@VaultRole(value = VaultAccess.Role.OWNER, bypassForRealmRole = true, onMissingVault = VaultRole.OnMissingVault.REQUIRE_REALM_ROLE, realmRole = RealmRole.CREATE_VAULTS, bypassForEmergencyAccess = true)
+	@VaultRole(value = VaultAccess.Role.OWNER, onMissingVault = VaultRole.OnMissingVault.REQUIRE_REALM_ROLE, realmRole = RealmRole.CREATE_VAULTS, bypassForEmergencyAccess = true)
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
 	@Transactional

--- a/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
@@ -516,7 +516,7 @@ public class VaultResource {
 	@Path("/{vaultId}/archived")
 	@RolesAllowed("user")
 	@VaultRole(value = VaultAccess.Role.OWNER, bypassForRealmRole = true, onMissingVault = VaultRole.OnMissingVault.NOT_FOUND)
-	@Consumes(MediaType.APPLICATION_JSON)
+	@Consumes(MediaType.TEXT_PLAIN)
 	@Produces(MediaType.APPLICATION_JSON)
 	@Transactional
 	@Operation(summary = "sets the archived flag of a vault")

--- a/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/VaultResource.java
@@ -501,7 +501,7 @@ public class VaultResource {
 	@GET
 	@Path("/{vaultId}")
 	@RolesAllowed("user")
-	@VaultRole(value = {VaultAccess.Role.MEMBER, VaultAccess.Role.OWNER}, bypassForRealmRole = true, realmRole = RealmRole.ADMIN, onMissingVault = VaultRole.OnMissingVault.NOT_FOUND)
+	@VaultRole(value = {VaultAccess.Role.MEMBER, VaultAccess.Role.OWNER}, bypassForRealmRole = true, onMissingVault = VaultRole.OnMissingVault.NOT_FOUND)
 	@Produces(MediaType.APPLICATION_JSON)
 	@Transactional
 	@Operation(summary = "gets a vault")
@@ -515,7 +515,7 @@ public class VaultResource {
 	@PUT
 	@Path("/{vaultId}")
 	@RolesAllowed("user") // general authentication. VaultRole filter will check for specific access rights
-	@VaultRole(value = VaultAccess.Role.OWNER, onMissingVault = VaultRole.OnMissingVault.REQUIRE_REALM_ROLE, realmRole = RealmRole.CREATE_VAULTS, bypassForEmergencyAccess = true)
+	@VaultRole(value = VaultAccess.Role.OWNER, bypassForRealmRole = true, onMissingVault = VaultRole.OnMissingVault.REQUIRE_REALM_ROLE, realmRole = RealmRole.CREATE_VAULTS, bypassForEmergencyAccess = true)
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
 	@Transactional

--- a/backend/src/main/java/org/cryptomator/hub/filters/VaultRole.java
+++ b/backend/src/main/java/org/cryptomator/hub/filters/VaultRole.java
@@ -36,16 +36,27 @@ public @interface VaultRole {
 	enum OnMissingVault {FORBIDDEN, NOT_FOUND, PASS, REQUIRE_REALM_ROLE}
 
 	/**
-	 * If set to true, skip the role check if the current user has the role {@link #realmRole()}.
+	 * If set to true, skip the role check if the current user has the role {@link #bypassRealmRole()}.
+	 * <p>
+	 * Only applies when the vault exists. For non-existing vaults, use {@link #onMissingVault()} instead.
 	 *
 	 * @return whether the given realm role allows bypassing the vault role check.
 	 */
 	boolean bypassForRealmRole() default false;
 
 	/**
+	 * Which realm role bypasses the vault role check when {@link #bypassForRealmRole()} is true.
+	 * <p>
+	 * Separate from {@link #realmRole()}, which is only used for {@link OnMissingVault#REQUIRE_REALM_ROLE}.
+	 *
+	 * @return realm role that bypasses the vault role check.
+	 */
+	RealmRole bypassRealmRole() default RealmRole.ADMIN;
+
+	/**
 	 * Which additional realm role is required to access the annotated resource.
 	 * <p>
-	 * Only relevant if {@link #bypassForRealmRole()} or {@link #onMissingVault()} is set to {@link OnMissingVault#REQUIRE_REALM_ROLE}.
+	 * Only relevant if {@link #onMissingVault()} is set to {@link OnMissingVault#REQUIRE_REALM_ROLE}.
 	 *
 	 * @return realm role required to access the annotated resource.
 	 */

--- a/backend/src/main/java/org/cryptomator/hub/filters/VaultRoleFilter.java
+++ b/backend/src/main/java/org/cryptomator/hub/filters/VaultRoleFilter.java
@@ -48,11 +48,6 @@ public class VaultRoleFilter implements ContainerRequestFilter {
 	@Override
 	public void filter(ContainerRequestContext requestContext) throws NotFoundException, ForbiddenException, NotAuthorizedException {
 		var annotation = resourceInfo.getResourceMethod().getAnnotation(VaultRole.class);
-		if (annotation.bypassForRealmRole() && requestContext.getSecurityContext().isUserInRole(annotation.realmRole().kcName())) {
-			// user has required realm role, so we skip the vault role check:
-			return;
-		}
-
 		var vaultIdStr = requestContext.getUriInfo().getPathParameters().getFirst(annotation.vaultIdParam());
 		final UUID vaultId;
 		try {
@@ -67,22 +62,25 @@ public class VaultRoleFilter implements ContainerRequestFilter {
 		}
 
 		var vault = vaultRepo.findById(vaultId);
-		if (vault != null && annotation.bypassForEmergencyAccess() && isEmergencyAccessCouncilMember(userId, vault)) {
-			// user is a member of the emergency access council, so we skip the role check:
-			return;
-		}
-
-		var forbiddenMsg = "Vault role required: " + Arrays.stream(annotation.value()).map(VaultAccess.Role::name).collect(Collectors.joining(", "));
 		if (vault != null) {
+			if (annotation.bypassForRealmRole() && requestContext.getSecurityContext().isUserInRole(annotation.bypassRealmRole().kcName())) {
+				// user has required realm role, so we skip the vault role check:
+				return;
+			}
+			if (annotation.bypassForEmergencyAccess() && isEmergencyAccessCouncilMember(userId, vault)) {
+				// user is a member of the emergency access council, so we skip the role check:
+				return;
+			}
 			// check permissions for existing vault:
 			var effectiveRoles = effectiveVaultAccessRepo.listRoles(vaultId, userId);
-			if (Arrays.stream(annotation.value()).noneMatch(effectiveRoles::contains)) {
-				throw new ForbiddenException(forbiddenMsg);
+			var requiredRoles = annotation.value();
+			if (Arrays.stream(requiredRoles).noneMatch(effectiveRoles::contains)) {
+				throw new ForbiddenException("Vault role required: " + Arrays.stream(requiredRoles).map(VaultAccess.Role::name).collect(Collectors.joining(", ")));
 			}
 		} else {
 			// how to treat non-existing vault:
 			switch (annotation.onMissingVault()) {
-				case FORBIDDEN -> throw new ForbiddenException(forbiddenMsg);
+				case FORBIDDEN -> throw new ForbiddenException("Vault role required: " + Arrays.stream(annotation.value()).map(VaultAccess.Role::name).collect(Collectors.joining(", ")));
 				case NOT_FOUND -> throw new NotFoundException("Vault not found");
 				case PASS -> {
 				}

--- a/backend/src/test/java/org/cryptomator/hub/api/VaultResourceIT.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/VaultResourceIT.java
@@ -963,6 +963,61 @@ public class VaultResourceIT {
 	}
 
 	@Nested
+	@DisplayName("As admin user2 (non-owner)")
+	@TestSecurity(user = "User Name 2", roles = {"user", "admin"})
+	@OidcSecurity(claims = {
+			@Claim(key = "sub", value = "user2")
+	})
+	@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+	class AdminArchiveVault {
+
+		@Test
+		@Order(1)
+		@DisplayName("PUT /vaults/7E57C0DE-0000-4000-8000-000100001111 returns 200 for admin archiving vault")
+		@DBRollbackAfter
+		void testAdminArchiveVault() {
+			var uuid = UUID.fromString("7E57C0DE-0000-4000-8000-000100001111");
+			var vaultDto = new VaultResource.VaultDto(uuid, "Vault 1", Instant.parse("2020-02-20T20:20:20Z"), "This is a testvault.", true, 0, Map.of(), "masterkey1", 42, "salt1", "authPubKey1", "authPrvKey1");
+
+			given().contentType(ContentType.JSON).body(vaultDto)
+					.when().put("/vaults/{vaultId}", "7E57C0DE-0000-4000-8000-000100001111")
+					.then().statusCode(200)
+					.body("id", equalToIgnoringCase("7E57C0DE-0000-4000-8000-000100001111"))
+					.body("name", equalTo("Vault 1"))
+					.body("archived", equalTo(true));
+		}
+
+		@Test
+		@Order(2)
+		@DisplayName("PUT /vaults/7E57C0DE-0000-4000-8000-00010000AAAA returns 200 for admin unarchiving vault")
+		@DBRollbackAfter
+		void testAdminUnarchiveVault() {
+			var uuid = UUID.fromString("7E57C0DE-0000-4000-8000-00010000AAAA");
+			var vaultDto = new VaultResource.VaultDto(uuid, "Vault Archived", Instant.parse("2020-02-20T20:20:20Z"), "This is a archived vault.", false, 0, Map.of(), "masterkey3", 42, "salt3", "authPubKey3", "authPrvKey3");
+
+			given().contentType(ContentType.JSON).body(vaultDto)
+					.when().put("/vaults/{vaultId}", "7E57C0DE-0000-4000-8000-00010000AAAA")
+					.then().statusCode(200)
+					.body("id", equalToIgnoringCase("7E57C0DE-0000-4000-8000-00010000AAAA"))
+					.body("name", equalTo("Vault Archived"))
+					.body("archived", equalTo(false));
+		}
+
+		@Test
+		@Order(3)
+		@DisplayName("PUT /vaults/7E57C0DE-0000-4000-8000-000100005555 returns 403 for admin creating vault without create-vaults role")
+		void testAdminCannotCreateVaultWithoutCreateVaultsRole() {
+			var uuid = UUID.fromString("7E57C0DE-0000-4000-8000-000100005555");
+			var vaultDto = new VaultResource.VaultDto(uuid, "New Vault", Instant.parse("2112-12-21T21:12:21Z"), "Should not be created", false, 0, Map.of(), "masterkey5", 42, "NaCl", "authPubKey5", "authPrvKey5");
+
+			given().contentType(ContentType.JSON).body(vaultDto)
+					.when().put("/vaults/{vaultId}", "7E57C0DE-0000-4000-8000-000100005555")
+					.then().statusCode(403);
+		}
+
+	}
+
+	@Nested
 	@DisplayName("As unauthenticated user")
 	class AsAnonymous {
 

--- a/backend/src/test/java/org/cryptomator/hub/api/VaultResourceIT.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/VaultResourceIT.java
@@ -976,7 +976,7 @@ public class VaultResourceIT {
 		@DisplayName("PUT /vaults/7E57C0DE-0000-4000-8000-000100001111/archived returns 200 for admin archiving vault")
 		@DBRollbackAfter
 		void testAdminArchiveVault() {
-			given().contentType(ContentType.JSON).body(true)
+			given().contentType(ContentType.TEXT).body("true")
 					.when().put("/vaults/{vaultId}/archived", "7E57C0DE-0000-4000-8000-000100001111")
 					.then().statusCode(200)
 					.body("id", equalToIgnoringCase("7E57C0DE-0000-4000-8000-000100001111"))
@@ -989,7 +989,7 @@ public class VaultResourceIT {
 		@DisplayName("PUT /vaults/7E57C0DE-0000-4000-8000-00010000AAAA/archived returns 200 for admin unarchiving vault")
 		@DBRollbackAfter
 		void testAdminUnarchiveVault() {
-			given().contentType(ContentType.JSON).body(false)
+			given().contentType(ContentType.TEXT).body("false")
 					.when().put("/vaults/{vaultId}/archived", "7E57C0DE-0000-4000-8000-00010000AAAA")
 					.then().statusCode(200)
 					.body("id", equalToIgnoringCase("7E57C0DE-0000-4000-8000-00010000AAAA"))

--- a/backend/src/test/java/org/cryptomator/hub/api/VaultResourceIT.java
+++ b/backend/src/test/java/org/cryptomator/hub/api/VaultResourceIT.java
@@ -973,14 +973,11 @@ public class VaultResourceIT {
 
 		@Test
 		@Order(1)
-		@DisplayName("PUT /vaults/7E57C0DE-0000-4000-8000-000100001111 returns 200 for admin archiving vault")
+		@DisplayName("PUT /vaults/7E57C0DE-0000-4000-8000-000100001111/archived returns 200 for admin archiving vault")
 		@DBRollbackAfter
 		void testAdminArchiveVault() {
-			var uuid = UUID.fromString("7E57C0DE-0000-4000-8000-000100001111");
-			var vaultDto = new VaultResource.VaultDto(uuid, "Vault 1", Instant.parse("2020-02-20T20:20:20Z"), "This is a testvault.", true, 0, Map.of(), "masterkey1", 42, "salt1", "authPubKey1", "authPrvKey1");
-
-			given().contentType(ContentType.JSON).body(vaultDto)
-					.when().put("/vaults/{vaultId}", "7E57C0DE-0000-4000-8000-000100001111")
+			given().contentType(ContentType.JSON).body(true)
+					.when().put("/vaults/{vaultId}/archived", "7E57C0DE-0000-4000-8000-000100001111")
 					.then().statusCode(200)
 					.body("id", equalToIgnoringCase("7E57C0DE-0000-4000-8000-000100001111"))
 					.body("name", equalTo("Vault 1"))
@@ -989,14 +986,11 @@ public class VaultResourceIT {
 
 		@Test
 		@Order(2)
-		@DisplayName("PUT /vaults/7E57C0DE-0000-4000-8000-00010000AAAA returns 200 for admin unarchiving vault")
+		@DisplayName("PUT /vaults/7E57C0DE-0000-4000-8000-00010000AAAA/archived returns 200 for admin unarchiving vault")
 		@DBRollbackAfter
 		void testAdminUnarchiveVault() {
-			var uuid = UUID.fromString("7E57C0DE-0000-4000-8000-00010000AAAA");
-			var vaultDto = new VaultResource.VaultDto(uuid, "Vault Archived", Instant.parse("2020-02-20T20:20:20Z"), "This is a archived vault.", false, 0, Map.of(), "masterkey3", 42, "salt3", "authPubKey3", "authPrvKey3");
-
-			given().contentType(ContentType.JSON).body(vaultDto)
-					.when().put("/vaults/{vaultId}", "7E57C0DE-0000-4000-8000-00010000AAAA")
+			given().contentType(ContentType.JSON).body(false)
+					.when().put("/vaults/{vaultId}/archived", "7E57C0DE-0000-4000-8000-00010000AAAA")
 					.then().statusCode(200)
 					.body("id", equalToIgnoringCase("7E57C0DE-0000-4000-8000-00010000AAAA"))
 					.body("name", equalTo("Vault Archived"))
@@ -1005,6 +999,18 @@ public class VaultResourceIT {
 
 		@Test
 		@Order(3)
+		@DisplayName("PUT /vaults/7E57C0DE-0000-4000-8000-000100001111 returns 403 for admin updating vault they don't own")
+		void testAdminCannotUpdateVaultTheyDontOwn() {
+			var uuid = UUID.fromString("7E57C0DE-0000-4000-8000-000100001111");
+			var vaultDto = new VaultResource.VaultDto(uuid, "Vault 1", Instant.parse("2020-02-20T20:20:20Z"), "This is a testvault.", true, 0, Map.of(), "masterkey1", 42, "salt1", "authPubKey1", "authPrvKey1");
+
+			given().contentType(ContentType.JSON).body(vaultDto)
+					.when().put("/vaults/{vaultId}", "7E57C0DE-0000-4000-8000-000100001111")
+					.then().statusCode(403);
+		}
+
+		@Test
+		@Order(4)
 		@DisplayName("PUT /vaults/7E57C0DE-0000-4000-8000-000100005555 returns 403 for admin creating vault without create-vaults role")
 		void testAdminCannotCreateVaultWithoutCreateVaultsRole() {
 			var uuid = UUID.fromString("7E57C0DE-0000-4000-8000-000100005555");
@@ -1031,7 +1037,8 @@ public class VaultResourceIT {
 				"PUT, /vaults/7E57C0DE-0000-4000-8000-000100001111/users/user1",
 				"DELETE, /vaults/7E57C0DE-0000-4000-8000-000100001111/authority/user1",
 				"GET, /vaults/7E57C0DE-0000-4000-8000-000100001111/users-requiring-access-grant",
-				"GET, /vaults/7E57C0DE-0000-4000-8000-000100001111/access-token"
+				"GET, /vaults/7E57C0DE-0000-4000-8000-000100001111/access-token",
+				"PUT, /vaults/7E57C0DE-0000-4000-8000-000100001111/archived"
 		})
 		void testGet(String method, String path) {
 			when().request(method, path)

--- a/backend/src/test/java/org/cryptomator/hub/filters/VaultRoleFilterTest.java
+++ b/backend/src/test/java/org/cryptomator/hub/filters/VaultRoleFilterTest.java
@@ -140,6 +140,35 @@ class VaultRoleFilterTest {
 		Mockito.verify(effectiveVaultAccessRepo, Mockito.never()).listRoles(Mockito.any(), Mockito.any());
 	}
 
+	@Test
+	@DisplayName("pass if admin user tries to access 7E57C0DE-0000-4000-8000-000100001111 (admin bypasses vault role check)")
+	void testFilterBypassForAdmin() throws NoSuchMethodException {
+		Mockito.doReturn(VaultRoleFilterTest.class.getMethod("byPassForRealmRole")).when(resourceInfo).getResourceMethod();
+		Mockito.doReturn(new MultivaluedHashMap<>(Map.of(VaultRole.DEFAULT_VAULT_ID_PARAM, "7E57C0DE-0000-4000-8000-000100001111"))).when(uriInfo).getPathParameters();
+		Mockito.doReturn("user2").when(jwt).getSubject();
+		Mockito.when(vaultRepo.findById(uuid("7E57C0DE-0000-4000-8000-000100001111"))).thenReturn(Mockito.mock(Vault.class));
+		Mockito.doReturn(true).when(securityContext).isUserInRole("admin");
+
+		Assertions.assertDoesNotThrow(() -> filter.filter(context));
+
+		Mockito.verify(effectiveVaultAccessRepo, Mockito.never()).listRoles(Mockito.any(), Mockito.any());
+	}
+
+	@Test
+	@DisplayName("error 403 if non-admin user tries to access 7E57C0DE-0000-4000-8000-000100001111 (bypassForRealmRole has no effect)")
+	void testFilterNoBypassForNonAdmin() throws NoSuchMethodException {
+		Mockito.doReturn(VaultRoleFilterTest.class.getMethod("byPassForRealmRole")).when(resourceInfo).getResourceMethod();
+		Mockito.doReturn(new MultivaluedHashMap<>(Map.of(VaultRole.DEFAULT_VAULT_ID_PARAM, "7E57C0DE-0000-4000-8000-000100001111"))).when(uriInfo).getPathParameters();
+		Mockito.doReturn("user2").when(jwt).getSubject();
+		Mockito.when(vaultRepo.findById(uuid("7E57C0DE-0000-4000-8000-000100001111"))).thenReturn(Mockito.mock(Vault.class));
+		Mockito.when(effectiveVaultAccessRepo.listRoles(uuid("7E57C0DE-0000-4000-8000-000100001111"), Mockito.eq("user2"))).thenReturn(Set.of());
+		Mockito.doReturn(false).when(securityContext).isUserInRole("admin");
+
+		var e = Assertions.assertThrows(ForbiddenException.class, () -> filter.filter(context));
+
+		Assertions.assertEquals("Vault role required: OWNER", e.getMessage());
+	}
+
 	@Nested
 	@DisplayName("when attempting to access archived vault")
 	class OnArchivedVault {
@@ -239,6 +268,35 @@ class VaultRoleFilterTest {
 
 		}
 
+		@Nested
+		@DisplayName("if @VaultRole(bypassForRealmRole = true, onMissingVault = REQUIRE_REALM_ROLE, realmRole = CREATE_VAULTS)")
+		class BypassRealmRoleWithRequireRealmRole {
+
+			@BeforeEach
+			void setup() throws NoSuchMethodException {
+				Mockito.doReturn(NonExistingVault.class.getMethod("bypassRealmRoleWithRequireRealmRole")).when(resourceInfo).getResourceMethod();
+			}
+
+			@Test
+			@DisplayName("error 403 if admin lacks create-vaults role (bypass does not apply for non-existing vault)")
+			void testAdminWithoutCreateVaultsRole() {
+				Mockito.doReturn(true).when(securityContext).isUserInRole("admin");
+				Mockito.doReturn(false).when(securityContext).isUserInRole("create-vaults");
+
+				Assertions.assertThrows(ForbiddenException.class, () -> filter.filter(context));
+			}
+
+			@Test
+			@DisplayName("pass if user has create-vaults role (onMissingVault checks realmRole, not bypassRealmRole)")
+			void testUserWithCreateVaultsRole() {
+				Mockito.doReturn(false).when(securityContext).isUserInRole("admin");
+				Mockito.doReturn(true).when(securityContext).isUserInRole("create-vaults");
+
+				Assertions.assertDoesNotThrow(() -> filter.filter(context));
+			}
+
+		}
+
 	}
 
 	/*
@@ -247,6 +305,10 @@ class VaultRoleFilterTest {
 
 	@VaultRole(value = {VaultAccess.Role.OWNER}, bypassForEmergencyAccess = true)
 	public void byPassRecoveryCouncilMembers() {
+	}
+
+	@VaultRole(value = {VaultAccess.Role.OWNER}, bypassForRealmRole = true)
+	public void byPassForRealmRole() {
 	}
 
 	@VaultRole({VaultAccess.Role.MEMBER})
@@ -268,6 +330,10 @@ class VaultRoleFilterTest {
 
 		@VaultRole(value = {VaultAccess.Role.OWNER}, onMissingVault = VaultRole.OnMissingVault.PASS)
 		public void pass() {
+		}
+
+		@VaultRole(value = {VaultAccess.Role.OWNER}, bypassForRealmRole = true, onMissingVault = VaultRole.OnMissingVault.REQUIRE_REALM_ROLE, realmRole = RealmRole.CREATE_VAULTS)
+		public void bypassRealmRoleWithRequireRealmRole() {
 		}
 
 		@VaultRole(value = {VaultAccess.Role.OWNER}, onMissingVault = VaultRole.OnMissingVault.REQUIRE_REALM_ROLE, realmRole = RealmRole.ADMIN)

--- a/frontend/src/common/backend.ts
+++ b/frontend/src/common/backend.ts
@@ -362,7 +362,10 @@ class VaultService {
 
   public async setArchived(vaultId: string, archived: boolean): Promise<VaultDto> {
     return axiosAuth.put<VaultDto>(`/vaults/${vaultId}/archived`, archived)
-      .then(response => response.data)
+      .then(response => {
+        response.data.creationTime = new Date(response.data.creationTime);
+        return response.data;
+      })
       .catch((error) => rethrowAndConvertIfExpected(error, 403, 404));
   }
 

--- a/frontend/src/common/backend.ts
+++ b/frontend/src/common/backend.ts
@@ -360,6 +360,12 @@ class VaultService {
     return addFallbackPictures ? users.map(fillInMissingPicture) : users;
   }
 
+  public async setArchived(vaultId: string, archived: boolean): Promise<VaultDto> {
+    return axiosAuth.put<VaultDto>(`/vaults/${vaultId}/archived`, archived)
+      .then(response => response.data)
+      .catch((error) => rethrowAndConvertIfExpected(error, 403, 404));
+  }
+
   public async createOrUpdateVault(vaultId: string, name: string, archived: boolean, requiredEmergencyKeyShares: number, emergencyKeyShares: Record<string, string>, description?: string): Promise<VaultDto> {
     const body: VaultDto = {
       id: vaultId,

--- a/frontend/src/common/backend.ts
+++ b/frontend/src/common/backend.ts
@@ -362,7 +362,7 @@ class VaultService {
   }
 
   public async setArchived(vaultId: string, archived: boolean): Promise<VaultDto> {
-    return axiosAuth.put<VaultDto>(`/vaults/${vaultId}/archived`, archived)
+    return axiosAuth.put<VaultDto>(`/vaults/${vaultId}/archived`, String(archived), { headers: { 'Content-Type': 'text/plain' } })
       .then(response => {
         response.data.creationTime = new Date(response.data.creationTime);
         return response.data;

--- a/frontend/src/components/ArchiveVaultDialog.vue
+++ b/frontend/src/components/ArchiveVaultDialog.vue
@@ -81,7 +81,7 @@ async function archiveVault() {
   onArchiveVaultError.value = undefined;
   const v = props.vault;
   try {
-    const vaultDto = await backend.vaults.createOrUpdateVault(v.id, v.name, true, v.requiredEmergencyKeyShares, v.emergencyKeyShares, v.description);
+    const vaultDto = await backend.vaults.setArchived(v.id, true);
     emit('archived', vaultDto);
     open.value = false;
   } catch (error) {

--- a/frontend/src/components/ReactivateVaultDialog.vue
+++ b/frontend/src/components/ReactivateVaultDialog.vue
@@ -81,7 +81,7 @@ async function reactivateVault() {
   onReactivateVaultError.value = undefined;
   const v = props.vault;
   try {
-    const vaultDto = await backend.vaults.createOrUpdateVault(v.id, v.name, false, v.requiredEmergencyKeyShares, v.emergencyKeyShares, v.description);
+    const vaultDto = await backend.vaults.setArchived(v.id, false);
     emit('reactivated', vaultDto);
     open.value = false;
   } catch (error) {

--- a/frontend/src/components/VaultDetails.vue
+++ b/frontend/src/components/VaultDetails.vue
@@ -130,8 +130,12 @@
           {{ t('vaultDetails.actions.editVaultMetadata') }}
         </button>
         <!-- archiveVault button -->
-        <button v-if="canToggleArchive" type="button" class="bg-red-600 py-2 px-4 border border-transparent rounded-md shadow-xs text-sm font-medium text-white  hover:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500" @click="showArchiveVaultDialog()">
+        <button v-if="canToggleArchive && !vault.archived" type="button" class="bg-red-600 py-2 px-4 border border-transparent rounded-md shadow-xs text-sm font-medium text-white  hover:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500" @click="showArchiveVaultDialog()">
           {{ t('vaultDetails.actions.archiveVault') }}
+        </button>
+        <!-- reactivateVault button -->
+        <button v-if="canToggleArchive && vault.archived" type="button" class="bg-red-600 py-2 px-4 border border-transparent rounded-md shadow-xs text-sm font-medium text-white  hover:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500" @click="showReactivateVaultDialog()">
+          {{ t('vaultDetails.actions.reactivateVault') }}
         </button>
       </div>
 

--- a/frontend/src/components/VaultDetails.vue
+++ b/frontend/src/components/VaultDetails.vue
@@ -147,6 +147,14 @@
         <button type="button" class="bg-red-600 py-2 px-4 border border-transparent rounded-md shadow-xs text-sm font-medium text-white  hover:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500" @click="showRecoverVaultDialog()">
           {{ t('vaultDetails.actions.recoverVault') }}
         </button>
+        <!-- archiveVault button -->
+        <button v-if="canToggleArchive && !vault.archived" type="button" class="bg-red-600 py-2 px-4 border border-transparent rounded-md shadow-xs text-sm font-medium text-white  hover:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500" @click="showArchiveVaultDialog()">
+          {{ t('vaultDetails.actions.archiveVault') }}
+        </button>
+        <!-- reactivateVault button -->
+        <button v-if="canToggleArchive && vault.archived" type="button" class="bg-red-600 py-2 px-4 border border-transparent rounded-md shadow-xs text-sm font-medium text-white  hover:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500" @click="showReactivateVaultDialog()">
+          {{ t('vaultDetails.actions.reactivateVault') }}
+        </button>
       </div>
 
       <!-- vault is archived -->

--- a/frontend/src/components/VaultDetails.vue
+++ b/frontend/src/components/VaultDetails.vue
@@ -130,7 +130,7 @@
           {{ t('vaultDetails.actions.editVaultMetadata') }}
         </button>
         <!-- archiveVault button -->
-        <button v-if="vaultRole == 'OWNER'" type="button" class="bg-red-600 py-2 px-4 border border-transparent rounded-md shadow-xs text-sm font-medium text-white  hover:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500" @click="showArchiveVaultDialog()">
+        <button v-if="canToggleArchive" type="button" class="bg-red-600 py-2 px-4 border border-transparent rounded-md shadow-xs text-sm font-medium text-white  hover:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500" @click="showArchiveVaultDialog()">
           {{ t('vaultDetails.actions.archiveVault') }}
         </button>
       </div>
@@ -160,7 +160,7 @@
           {{ t('vaultDetails.actions.displayRecoveryKey') }}
         </button>
         <!-- reactivateVault button -->
-        <button v-if="vaultRole == 'OWNER'" type="button" class="bg-red-600 py-2 px-4 border border-transparent rounded-md shadow-xs text-sm font-medium text-white  hover:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500" @click="showReactivateVaultDialog()">
+        <button v-if="canToggleArchive" type="button" class="bg-red-600 py-2 px-4 border border-transparent rounded-md shadow-xs text-sm font-medium text-white  hover:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500" @click="showReactivateVaultDialog()">
           {{ t('vaultDetails.actions.reactivateVault') }}
         </button>
       </div>
@@ -205,7 +205,7 @@
           <span>{{ t('vaultDetails.emergencyAccess.fixCouncil') }}</span>
         </button>
         <!-- archiveVault button -->
-        <button v-if="vaultRole == 'OWNER'" type="button" class="bg-red-600 py-2 px-4 border border-transparent rounded-md shadow-xs text-sm font-medium text-white  hover:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500" @click="showArchiveVaultDialog()">
+        <button v-if="canToggleArchive" type="button" class="bg-red-600 py-2 px-4 border border-transparent rounded-md shadow-xs text-sm font-medium text-white  hover:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500" @click="showArchiveVaultDialog()">
           {{ t('vaultDetails.actions.archiveVault') }}
         </button>
       </div>
@@ -253,12 +253,15 @@ const { t, d } = useI18n({ useScope: 'global' });
 const props = defineProps<{
   vaultId: string,
   vaultRole: VaultRole | 'NONE',
+  isAdmin: boolean,
 }>();
 
 const emit = defineEmits<{
   vaultUpdated: [updatedVault: VaultDto]
   licenseStatusUpdated: [license: LicenseUserInfoDto]
 }>();
+
+const canToggleArchive = computed(() => props.vaultRole === 'OWNER' || props.isAdmin);
 
 const onFetchError = ref<Error>();
 const allowRetryFetch = computed(() => onFetchError.value && !(onFetchError.value instanceof NotFoundError));  //fetch requests either list something, or query from th vault. In the latter, a 404 indicates the vault does not exists anymore.

--- a/frontend/src/components/VaultDetails.vue
+++ b/frontend/src/components/VaultDetails.vue
@@ -210,6 +210,15 @@
         </button>
       </div>
     </div>
+
+    <div v-if="isAdmin && vaultRole !== 'OWNER' && !vaultRecoveryRequired" class="mt-2 flex flex-col gap-2">
+      <button v-if="!vault.archived" type="button" class="bg-red-600 py-2 px-4 border border-transparent rounded-md shadow-xs text-sm font-medium text-white  hover:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500" @click="showArchiveVaultDialog()">
+        {{ t('vaultDetails.actions.archiveVault') }}
+      </button>
+      <button v-if="vault.archived" type="button" class="bg-red-600 py-2 px-4 border border-transparent rounded-md shadow-xs text-sm font-medium text-white  hover:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500" @click="showReactivateVaultDialog()">
+        {{ t('vaultDetails.actions.reactivateVault') }}
+      </button>
+    </div>
   </div>
 
   <ClaimVaultOwnershipDialog v-if="claimingVaultOwnership && vault" ref="claimVaultOwnershipDialog" :vault="vault" @action="provedOwnership" @close="claimingVaultOwnership = false" />

--- a/frontend/src/components/VaultDetails.vue
+++ b/frontend/src/components/VaultDetails.vue
@@ -210,15 +210,6 @@
         </button>
       </div>
     </div>
-
-    <div v-if="isAdmin && vaultRole !== 'OWNER' && !vaultRecoveryRequired" class="mt-2 flex flex-col gap-2">
-      <button v-if="!vault.archived" type="button" class="bg-red-600 py-2 px-4 border border-transparent rounded-md shadow-xs text-sm font-medium text-white  hover:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500" @click="showArchiveVaultDialog()">
-        {{ t('vaultDetails.actions.archiveVault') }}
-      </button>
-      <button v-if="vault.archived" type="button" class="bg-red-600 py-2 px-4 border border-transparent rounded-md shadow-xs text-sm font-medium text-white  hover:bg-red-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-red-500" @click="showReactivateVaultDialog()">
-        {{ t('vaultDetails.actions.reactivateVault') }}
-      </button>
-    </div>
   </div>
 
   <ClaimVaultOwnershipDialog v-if="claimingVaultOwnership && vault" ref="claimVaultOwnershipDialog" :vault="vault" @action="provedOwnership" @close="claimingVaultOwnership = false" />

--- a/frontend/src/components/VaultList.vue
+++ b/frontend/src/components/VaultList.vue
@@ -126,7 +126,7 @@
   </div>
 
   <SlideOver v-if="selectedVault" ref="vaultDetailsSlideOver" :title="selectedVault.name" @close="selectedVault = undefined">
-    <VaultDetails :vault-id="selectedVault.id" :vault-role="roleOfSelectedVault" @vault-updated="v => onSelectedVaultUpdate(v)" @license-status-updated="l => licenseUpdated(l)"></VaultDetails>
+    <VaultDetails :vault-id="selectedVault.id" :vault-role="roleOfSelectedVault" :is-admin="isAdmin" @vault-updated="v => onSelectedVaultUpdate(v)" @license-status-updated="l => licenseUpdated(l)"></VaultDetails>
   </SlideOver>
 </template>
 


### PR DESCRIPTION
Fixes #283.

Admins can view all vaults but previously couldn't archive or unarchive vaults they don't own. The `@VaultRole` annotation's `realmRole` field was shared between the bypass check and the `onMissingVault` check, making it impossible to add admin bypass to the `createOrUpdate` endpoint without breaking vault creation permissions.

This PR introduces a `bypassRealmRole` field on the `@VaultRole` annotation to separate the two concerns. The bypass check is also moved into the vault-exists block so it only applies to existing vaults. Vault creation still requires the `create-vaults` role as before.

Instead of adding admin bypass to the general `createOrUpdate` endpoint (which would let admins modify vault name, description, and emergency key shares), a dedicated `PUT /{vaultId}/archived` endpoint handles archive toggling with its own admin bypass. The `createOrUpdate` endpoint remains restricted to vault owners.

On the frontend, archive and reactivate buttons are now visible to admin users who aren't vault owners. The buttons also appear in the vault recovery section, so admins who are vault owners but have lost their account key can still archive or reactivate. The `setArchived` response normalizes `creationTime` to a `Date` object so the vault detail view renders correctly after toggling.