### PR TITLE
Truncate long names in detail cards and breadcrumbs

### DIFF
--- a/frontend/src/components/BreadcrumbNav.vue
+++ b/frontend/src/components/BreadcrumbNav.vue
@@ -9,7 +9,7 @@
           </RouterLink>
         </template>
         <template v-else>
-          <span class="text-gray-700 font-medium">{{ crumb.label }}</span>
+          <span class="text-gray-700 font-medium truncate max-w-48 sm:max-w-xs" :title="crumb.label">{{ crumb.label }}</span>
         </template>
         <ChevronRightIcon v-if="index < crumbs.length - 1 && !crumb.to" class="w-4 h-4 mx-1 text-gray-400"/>
       </li>

--- a/frontend/src/components/authority/GroupInfo.vue
+++ b/frontend/src/components/authority/GroupInfo.vue
@@ -3,7 +3,7 @@
     <div class="px-6 py-6">
       <div class="flex flex-col items-center justify-center h-full text-center">
         <img :src="group.pictureUrl" class="w-48 h-48 rounded-full object-cover border border-gray-300 mb-4" />
-        <h2 class="text-xl font-semibold text-gray-900">{{ group.name }}</h2>
+        <h2 class="text-xl font-semibold text-gray-900 truncate w-full" :title="group.name">{{ group.name }}</h2>
       </div>
     </div>
   </section>

--- a/frontend/src/components/authority/UserInfo.vue
+++ b/frontend/src/components/authority/UserInfo.vue
@@ -6,7 +6,7 @@
         <h2 class="text-xl font-semibold text-gray-900 truncate w-full" :title="displayName">
           {{ displayName }}
         </h2>
-        <p v-if="user.firstName || user.lastName" class="text-sm text-gray-500 mt-1 truncate w-full" :title="user.name">
+        <p v-if="displayName !== user.name" class="text-sm text-gray-500 mt-1 truncate w-full" :title="user.name">
           {{ user.name }}
         </p>
         <span v-if="!user.enabled" class="inline-flex items-center rounded-md bg-gray-100 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10 mt-2">{{ t('user.detail.disabled') }}</span>

--- a/frontend/src/components/authority/UserInfo.vue
+++ b/frontend/src/components/authority/UserInfo.vue
@@ -3,23 +3,18 @@
     <div class="px-6 py-6">
       <div class="flex flex-col items-center justify-center h-full text-center">
         <img :src="user.pictureUrl" class="w-48 h-48 rounded-full object-cover border border-gray-300 mb-4" />
-        <h2 class="text-xl font-semibold text-gray-900">
-          <template v-if="user.firstName || user.lastName">
-            {{ user.firstName }} {{ user.lastName }}
-          </template>
-          <template v-else>
-            {{ user.name }}
-          </template>
+        <h2 class="text-xl font-semibold text-gray-900 truncate w-full" :title="displayName">
+          {{ displayName }}
         </h2>
-        <p v-if="user.firstName || user.lastName" class="text-sm text-gray-500 mt-1">
+        <p v-if="user.firstName || user.lastName" class="text-sm text-gray-500 mt-1 truncate w-full" :title="user.name">
           {{ user.name }}
         </p>
         <span v-if="!user.enabled" class="inline-flex items-center rounded-md bg-gray-100 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10 mt-2">{{ t('user.detail.disabled') }}</span>
       </div>
       <dl class="divide-y divide-gray-100">
-        <div class="py-3 flex justify-between">
-          <dt class="text-sm text-gray-500">{{ t('user.detail.email') }}</dt>
-          <dd class="text-sm text-gray-900 font-medium">{{ user.email }}</dd>
+        <div class="py-3 flex justify-between min-w-0">
+          <dt class="text-sm text-gray-500 shrink-0 mr-2">{{ t('user.detail.email') }}</dt>
+          <dd class="text-sm text-gray-900 font-medium truncate min-w-0" :title="user.email">{{ user.email }}</dd>
         </div>
         <div class="py-3 flex justify-between">
           <dt class="text-sm text-gray-500">{{ t('user.detail.roles') }}</dt>
@@ -48,7 +43,13 @@ const props = defineProps<{
   user: UserDtoWithDetails;
 }>();
 
-const sortedRoles = computed(() => 
+const displayName = computed(() =>
+  props.user.firstName || props.user.lastName
+    ? `${props.user.firstName ?? ''} ${props.user.lastName ?? ''}`.trim()
+    : props.user.name
+);
+
+const sortedRoles = computed(() =>
   [...props.user.realmRoles].filter(isSelectableRealmRole).sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))
 );
 


### PR DESCRIPTION
## Summary
  - Add text truncation with hover tooltips to user/group detail cards (UserInfo, GroupInfo) and breadcrumb navigation
  - Extract `displayName` computed property in UserInfo for cleaner template logic
  - Fix email overflow in user detail card with proper flex constraints