### PR TITLE
Fix required keys validation tooltip position in emergency access settings

### DIFF
--- a/frontend/src/components/AdminSettingsEmergencyAccess.vue
+++ b/frontend/src/components/AdminSettingsEmergencyAccess.vue
@@ -48,28 +48,29 @@
         <label for="requiredKeyShares" class="col-span-2 block text-sm font-medium text-gray-700 md:text-right md:pr-4 md:mt-2">
           {{ t('admin.emergencyAccess.requiredKeys.label') }}
         </label>
-        <div class="mt-1 md:mt-0 lg:col-span-3 md:col-span-4 relative">
-          <div class="flex items-center gap-2">
-            <div v-if="defaultRequiredEmergencyKeySharesLessThenTwoError || defaultRequiredEmergencyKeySharesToHighError instanceof FormValidationFailedError" class="absolute  -top-2 transform translate-y-full z-10">
+        <div class="mt-1 md:mt-0 lg:col-span-3 md:col-span-4">
+          <div class="relative flex-1">
+            <!-- Tooltip -->
+            <div
+              v-if="defaultRequiredEmergencyKeySharesLessThenTwoError || defaultRequiredEmergencyKeySharesToHighError instanceof FormValidationFailedError"
+              class="absolute left-1/2 -translate-x-1/2 -top-2 transform -translate-y-full z-10"
+            >
               <div class="bg-red-50 border border-red-300 text-red-900 px-2 py-1 rounded shadow-sm text-sm hyphens-auto">
                 {{ requiredKeySharesValidationText }}
+                <!-- Arrow -->
+                <div class="absolute bottom-0 left-1/2 transform translate-y-1/2 rotate-45 w-2 h-2 bg-red-50 border-r border-b border-red-300"></div>
               </div>
             </div>
-            <div class="relative flex-1">
-              <input
-                id="requiredKeyShares"
-                v-model.number="requiredShares"
-                type="number" min="2" max="255"
-                :disabled="!enableEmergencyAccess"
-                class="rounded-md border-gray-300 shadow-sm sm:text-sm focus:ring-primary focus:border-primary text-left w-full disabled:cursor-not-allowed disabled:bg-gray-200"
-                :class="{ 'border-red-300 text-red-900 focus:ring-red-500 focus:border-red-500': defaultRequiredEmergencyKeySharesError || defaultRequiredEmergencyKeySharesToHighError instanceof FormValidationFailedError}"
-                :aria-label="t('admin.emergencyAccess.requiredKeys.ariaLabel')"
-              />
-              <div v-if="defaultRequiredEmergencyKeySharesLessThenTwoError || defaultRequiredEmergencyKeySharesToHighError instanceof FormValidationFailedError" class="absolute  -top-2 transform translate-y-full z-10">
-                <div class="absolute bottom-0 left-5 transform translate-y-1/2 rotate-45 w-2 h-2 bg-red-50 border-r border-b border-red-300"></div>
-              </div>
-              <p class="mt-2 my-4 text-sm text-gray-500">{{ t('admin.emergencyAccess.requiredKeys.help') }}</p>
-            </div>
+            <input
+              id="requiredKeyShares"
+              v-model.number="requiredShares"
+              type="number" min="2" max="255"
+              :disabled="!enableEmergencyAccess"
+              class="rounded-md border-gray-300 shadow-sm sm:text-sm focus:ring-primary focus:border-primary text-left w-full disabled:cursor-not-allowed disabled:bg-gray-200"
+              :class="{ 'border-red-300 text-red-900 focus:ring-red-500 focus:border-red-500': defaultRequiredEmergencyKeySharesError || defaultRequiredEmergencyKeySharesToHighError instanceof FormValidationFailedError}"
+              :aria-label="t('admin.emergencyAccess.requiredKeys.ariaLabel')"
+            />
+            <p class="mt-2 my-4 text-sm text-gray-500">{{ t('admin.emergencyAccess.requiredKeys.help') }}</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
- Validation tooltip for the "Required Keys" input in `AdminSettingsEmergencyAccess` was rendered below the input instead of above it
- Restructured tooltip markup to match the existing pattern used by the keyholders field (`MultiUserSelectInputGroup`): `-translate-y-full` to position above, arrow inside the tooltip box pointing downward

Before:
<img width="755" height="170" alt="Bildschirmfoto 2026-04-07 um 08 57 21" src="https://github.com/user-attachments/assets/934ddf5a-a980-4081-ac24-b1ec0f046d44" />

After:
<img width="714" height="170" alt="Bildschirmfoto 2026-04-07 um 09 31 55" src="https://github.com/user-attachments/assets/10fb9aa6-f775-4d84-b5ae-630ef5642b31" />
