### PR TITLE
Improve Emergency Access view loading performance  

### DIFF
--- a/backend/src/main/java/org/cryptomator/hub/api/EmergencyAccessResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/EmergencyAccessResource.java
@@ -176,8 +176,7 @@ public class EmergencyAccessResource {
 	@Transactional
 	public List<RecoveryProcessDto> findAllForRecoverableVaults() {
 		var currentUser = jwt.getSubject();
-		var vaultIds = vaultRepo.findRecoverable(currentUser).map(Vault::getId).toList();
-		return recoverProcessRepo.findByVaultIds(vaultIds).map(RecoveryProcessDto::fromEntity).toList();
+		return recoverProcessRepo.findByCouncilMemberOrProcessMember(currentUser).map(RecoveryProcessDto::fromEntity).toList();
 	}
 
 	@GET

--- a/backend/src/main/java/org/cryptomator/hub/api/EmergencyAccessResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/EmergencyAccessResource.java
@@ -25,6 +25,7 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.cryptomator.hub.entities.EmergencyRecoveryProcess;
 import org.cryptomator.hub.entities.RecoveredEmergencyKeyShares;
+import org.cryptomator.hub.entities.Vault;
 import org.cryptomator.hub.entities.events.EventLogger;
 import org.cryptomator.hub.util.RawJson;
 import org.cryptomator.hub.validation.ValidJWE;
@@ -46,6 +47,9 @@ public class EmergencyAccessResource {
 
 	@Inject
 	RecoveredEmergencyKeyShares.Repository recoveredKeySharesRepo;
+
+	@Inject
+	Vault.Repository vaultRepo;
 
 	@Inject
 	JsonWebToken jwt;
@@ -162,6 +166,18 @@ public class EmergencyAccessResource {
 
 		recoverProcessRepo.delete(process);
 		return Response.noContent().build();
+	}
+
+	@GET
+	@RolesAllowed("user")
+	@Produces(MediaType.APPLICATION_JSON)
+	@Operation(summary = "finds all recovery processes for vaults recoverable by the current user")
+	@APIResponse(responseCode = "200")
+	@Transactional
+	public List<RecoveryProcessDto> findAllForRecoverableVaults() {
+		var currentUser = jwt.getSubject();
+		var vaultIds = vaultRepo.findRecoverable(currentUser).map(Vault::getId).toList();
+		return recoverProcessRepo.findByVaultIds(vaultIds).map(RecoveryProcessDto::fromEntity).toList();
 	}
 
 	@GET

--- a/backend/src/main/java/org/cryptomator/hub/entities/EmergencyRecoveryProcess.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/EmergencyRecoveryProcess.java
@@ -36,6 +36,20 @@ import java.util.stream.Stream;
 		"""
 )
 @NamedQuery(
+		name = "EmergencyRecoveryProcess.byCouncilMemberOrProcessMember", query = """
+		SELECT p
+		FROM EmergencyRecoveryProcess p
+		WHERE KEY(p.recoveredKeyShares) = :councilMemberId
+
+		UNION
+
+		SELECT p
+		FROM EmergencyRecoveryProcess p
+		INNER JOIN Vault v ON v.id = p.vaultId
+		WHERE KEY(v.emergencyKeyShares) = :councilMemberId
+		"""
+)
+@NamedQuery(
 		name = "EmergencyRecoveryProcess.byVaultIds", query = """
 		SELECT process
 		FROM EmergencyRecoveryProcess process
@@ -151,6 +165,10 @@ public class EmergencyRecoveryProcess {
 
 		public Stream<EmergencyRecoveryProcess> findByCouncilMember(String councilMemberId) {
 			return find("#EmergencyRecoveryProcess.byCouncilMember", Parameters.with("councilMemberId", councilMemberId)).stream();
+		}
+
+		public Stream<EmergencyRecoveryProcess> findByCouncilMemberOrProcessMember(String councilMemberId) {
+			return find("#EmergencyRecoveryProcess.byCouncilMemberOrProcessMember", Parameters.with("councilMemberId", councilMemberId)).stream();
 		}
 
 		public Stream<EmergencyRecoveryProcess> findByVaultIds(java.util.Collection<UUID> vaultIds) {

--- a/backend/src/main/java/org/cryptomator/hub/entities/EmergencyRecoveryProcess.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/EmergencyRecoveryProcess.java
@@ -49,13 +49,6 @@ import java.util.stream.Stream;
 		WHERE KEY(v.emergencyKeyShares) = :councilMemberId
 		"""
 )
-@NamedQuery(
-		name = "EmergencyRecoveryProcess.byVaultIds", query = """
-		SELECT process
-		FROM EmergencyRecoveryProcess process
-		WHERE process.vaultId IN :vaultIds
-		"""
-)
 public class EmergencyRecoveryProcess {
 
 	public enum Type {
@@ -169,11 +162,6 @@ public class EmergencyRecoveryProcess {
 
 		public Stream<EmergencyRecoveryProcess> findByCouncilMemberOrProcessMember(String councilMemberId) {
 			return find("#EmergencyRecoveryProcess.byCouncilMemberOrProcessMember", Parameters.with("councilMemberId", councilMemberId)).stream();
-		}
-
-		public Stream<EmergencyRecoveryProcess> findByVaultIds(java.util.Collection<UUID> vaultIds) {
-			if (vaultIds.isEmpty()) return Stream.empty();
-			return find("#EmergencyRecoveryProcess.byVaultIds", Parameters.with("vaultIds", vaultIds)).stream();
 		}
 
 		public void deleteKeySharesForCouncilMember(String councilMemberId) {

--- a/backend/src/main/java/org/cryptomator/hub/entities/EmergencyRecoveryProcess.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/EmergencyRecoveryProcess.java
@@ -35,6 +35,13 @@ import java.util.stream.Stream;
 		WHERE KEY(process.recoveredKeyShares) = :councilMemberId
 		"""
 )
+@NamedQuery(
+		name = "EmergencyRecoveryProcess.byVaultIds", query = """
+		SELECT process
+		FROM EmergencyRecoveryProcess process
+		WHERE process.vaultId IN :vaultIds
+		"""
+)
 public class EmergencyRecoveryProcess {
 
 	public enum Type {
@@ -144,6 +151,11 @@ public class EmergencyRecoveryProcess {
 
 		public Stream<EmergencyRecoveryProcess> findByCouncilMember(String councilMemberId) {
 			return find("#EmergencyRecoveryProcess.byCouncilMember", Parameters.with("councilMemberId", councilMemberId)).stream();
+		}
+
+		public Stream<EmergencyRecoveryProcess> findByVaultIds(java.util.Collection<UUID> vaultIds) {
+			if (vaultIds.isEmpty()) return Stream.empty();
+			return find("#EmergencyRecoveryProcess.byVaultIds", Parameters.with("vaultIds", vaultIds)).stream();
 		}
 
 		public void deleteKeySharesForCouncilMember(String councilMemberId) {

--- a/frontend/src/common/backend.ts
+++ b/frontend/src/common/backend.ts
@@ -667,6 +667,10 @@ class SettingsService {
 }
 
 class EmergencyAccessService {
+  public async findAllProcesses(): Promise<RecoveryProcessDto[]> {
+    return axiosAuth.get<RecoveryProcessDto[]>('/emergency-access').then(response => response.data);
+  }
+
   public async findProcessesForVault(vaultId: string): Promise<RecoveryProcessDto[]> {
     return axiosAuth.get<RecoveryProcessDto[]>(`/emergency-access/${vaultId}`).then(response => response.data);
   }

--- a/frontend/src/components/emergencyaccess/EmergencyAccessVaultList.vue
+++ b/frontend/src/components/emergencyaccess/EmergencyAccessVaultList.vue
@@ -2,240 +2,243 @@
   <div v-if="loading" class="text-center p-8 text-gray-500 text-sm">
     {{ t('common.loading') }}
   </div>
-  <FetchError v-else-if="onFetchError" :error="onFetchError" :retry="fetchData" />
+  <div v-else-if="onFetchError == null">
+    <LicenseAlert v-if="isLicenseViolated && isAdmin != undefined && licenseStatus" :is-admin="isAdmin" :license-status="licenseStatus" />
 
-  <LicenseAlert v-if="isLicenseViolated && isAdmin != undefined && licenseStatus" :is-admin="isAdmin" :license-status="licenseStatus" />
+    <ContentBanner v-if="entitlements.emergencyAccessEnabled && entitlements.showTrialHint" type="info" :title="t('trial.enterpriseFeature.title')" class="mb-6">
+      {{ t('trial.enterpriseFeature.description') }} <!-- TODO: link to feature comparison? -->
+    </ContentBanner>
 
-  <ContentBanner v-if="entitlements.emergencyAccessEnabled && entitlements.showTrialHint" type="info" :title="t('trial.enterpriseFeature.title')" class="mb-6">
-    {{ t('trial.enterpriseFeature.description') }} <!-- TODO: link to feature comparison? -->
-  </ContentBanner>
-
-  <div v-if="!entitlements.emergencyAccessEnabled" class="flex flex-col justify-center items-center text-center">
-    <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-      <path vector-effect="non-scaling-stroke" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z" />
-    </svg>
-    <h3 class="mt-2 text-sm font-medium text-gray-900">{{ t('auditLog.paymentRequired.message') }}</h3>
-    <p class="mt-1 text-sm text-gray-500">
-      {{ t('emergencyAccess.licenseRequired.message') }}
-      <span v-if="isAdmin"> {{ t('emergencyAccess.licenseRequired.adminHint') }}</span>
-    </p>
-    <router-link to="/app/admin/settings" :hidden="!isAdmin" class="inline-flex items-center px-4 py-2 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-primary hover:bg-primary-d1 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-primary mt-6">
-      <WrenchIcon class="-ml-1 mr-2 h-5 w-5" aria-hidden="true" />
-      {{ t('auditLog.paymentRequired.openAdminSection') }}
-    </router-link>
-  </div>
-  <div v-else-if="!settings?.enableEmergencyAccess" class="mt-3 text-center">
-    <h3 class="mt-2 text-sm font-medium text-gray-900">{{ t('emergencyAccess.empty.disabled') }}</h3>
-  </div>
-  <section v-else>
-    <!-- entitlements.emergencyAccessEnabled && settings.enableEmergencyAccess -->
-    <header class="pb-5 border-b border-gray-200">
-      <div class="flex flex-col sm:flex-row sm:justify-between gap-3 w-full">
-        <h2 class="text-2xl font-bold leading-9 text-gray-900 sm:text-3xl sm:truncate">
-          {{ t('nav.emergencyAccess') }}
-        </h2>
-        <div class="flex gap-3">
-          <button class="w-full bg-primary py-2 px-4 border border-transparent rounded-md shadow-xs text-sm font-medium text-white hover:bg-primary-d1 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-primary" @click="fetchData()">
-            {{ t('common.refresh') }}
-          </button>
-        </div>
-      </div>
-      <div class="mt-3 flex flex-wrap sm:flex-nowrap gap-3 items-center whitespace-nowrap">
-        <input id="vaultSearch" v-model="query" :placeholder="t('vaultList.search.placeholder')" type="text" class="focus:ring-primary focus:border-primary block w-full shadow-xs text-sm border-gray-300 rounded-md disabled:bg-gray-200"/>
-
-        <Listbox v-model="selectedFilter" as="div">
-          <div class="relative w-auto whitespace-nowrap">
-            <ListboxButton class="min-w-60 relative w-full rounded-md border border-gray-300 bg-white py-2 pl-3 pr-10 text-left shadow-xs focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary text-sm">
-              <span class="block whitespace-nowrap">{{ filterOptions[selectedFilter] }}</span>
-              <span class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
-                <ChevronUpDownIcon class="h-5 w-5 text-gray-400" aria-hidden="true" />
-              </span>
-            </ListboxButton>
-            <transition leave-active-class="transition ease-in duration-100" leave-from-class="opacity-100" leave-to-class="opacity-0">
-              <ListboxOptions class="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 shadow-lg ring-1 ring-black/5 focus:outline-hidden text-sm">
-                <ListboxOption v-for="(name, key) in filterOptions" :key="key" v-slot="{ active, selected }" :value="key" class="relative cursor-default select-none py-2 pl-3 pr-12 ui-not-active:text-gray-900 ui-active:text-white ui-active:bg-primary">
-                  <span :class="[selected ? 'font-semibold' : 'font-normal', 'block whitespace-nowrap']">{{ name }}</span>
-                  <span v-if="selected" :class="[active ? 'text-white' : 'text-primary', 'absolute inset-y-0 right-0 flex items-center pr-4']">
-                    <CheckIcon class="h-5 w-5" aria-hidden="true" />
-                  </span>
-                </ListboxOption>
-              </ListboxOptions>
-            </transition>
-          </div>
-        </Listbox>
-      </div>
-    </header>
-
-    <div v-if="filteredVaults.length === 0" class="mt-3 text-center">
-      <h3 class="mt-2 text-sm font-medium text-gray-900">{{ t('emergencyAccess.empty.noneFound') }}</h3>
+    <div v-if="!entitlements.emergencyAccessEnabled" class="flex flex-col justify-center items-center text-center">
+      <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+        <path vector-effect="non-scaling-stroke" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z" />
+      </svg>
+      <h3 class="mt-2 text-sm font-medium text-gray-900">{{ t('auditLog.paymentRequired.message') }}</h3>
+      <p class="mt-1 text-sm text-gray-500">
+        {{ t('emergencyAccess.licenseRequired.message') }}
+        <span v-if="isAdmin"> {{ t('emergencyAccess.licenseRequired.adminHint') }}</span>
+      </p>
+      <router-link to="/app/admin/settings" :hidden="!isAdmin" class="inline-flex items-center px-4 py-2 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-primary hover:bg-primary-d1 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-primary mt-6">
+        <WrenchIcon class="-ml-1 mr-2 h-5 w-5" aria-hidden="true" />
+        {{ t('auditLog.paymentRequired.openAdminSection') }}
+      </router-link>
     </div>
-    <ul role="list" class="mt-5 divide-y divide-gray-200 bg-white shadow-sm rounded-md">
-      <li v-for="(vault, index) in filteredVaults" :key="vault.id">
-        <details
-          class="group/vault hover:bg-gray-50"
-          :class="{ 'rounded-t-md': index == 0, 'rounded-b-md': index == filteredVaults.length - 1 }"
-          @toggle="onVaultDetailsToggle(vault.id, $event)"
-        >
-          <summary
-            class="list-none px-4 py-4 sm:px-6  cursor-pointer [&::-webkit-details-marker]:hidden"
-            :class="{ 'rounded-t-md': index == 0, 'rounded-b-md': index == filteredVaults.length - 1 }"
-          >
-            <div class="flex flex-wrap gap-3 sm:flex-nowrap sm:items-center sm:justify-between">
-              <!-- Name and description -->
-              <div class="flex-1 min-w-40">
-                <div class="flex items-center gap-3 min-w-0">
-                  <p class="truncate text-sm font-medium text-primary min-w-0">
-                    {{ vault.name }}
-                  </p>
-                  <div v-if="vault.archived" class="inline-flex items-center rounded-md bg-yellow-400/10 px-2 py-1 text-xs font-medium text-yellow-500 ring-1 ring-inset ring-yellow-400/20">{{ t('vaultList.badge.archived') }}</div>
-                </div>
-                <p
-                  v-if="vault.description"
-                  class="truncate text-sm text-gray-500 mt-2 min-w-0"
-                >
-                  {{ vault.description }}
-                </p>
-              </div>
-
-              <div class="flex flex-wrap items-center gap-2 sm:justify-end" @click.stop>
-                <EmergencyBadge
-                  v-if="isBroken(vault)"
-                  type="broken"
-                  :title="t('emergencyAccess.badge.broken.title')"
-                  :message="t('emergencyAccess.badge.broken.message')"
-                />
-
-                <EmergencyBadge
-                  v-if="settings && settings.defaultMinMembers > emergencyAccessMembers(vault).length"
-                  type="insufficientCouncilMembers"
-                  :title="t('emergencyAccess.badge.insufficientCouncilMembers.title')"
-                  :message="t('emergencyAccess.badge.insufficientCouncilMembers.message', [settings.defaultMinMembers])"
-                  position="right"
-                />
-
-                <EmergencyBadge
-                  v-else-if="vault.requiredEmergencyKeyShares === emergencyAccessMembers(vault).length"
-                  type="noRedundancy"
-                  :title="t('emergencyAccess.badge.noRedundancy.title')"
-                  :message="t('emergencyAccess.badge.noRedundancy.message')"
-                />
-              </div>
-              <div class="flex items-center gap-2">
-                <span
-                  v-if="getProcesses(vault.id).length > 0"
-                  class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700"
-                >
-                  {{ getProcesses(vault.id).length }}
-                </span>
-                <ChevronDownIcon class="h-5 w-5 text-gray-400 transition-transform duration-200 group-open/vault:rotate-180" aria-hidden="true"/>
-              </div>
-            </div>
-          </summary>
-          <div class="px-4 py-4 sm:px-6 text-sm text-gray-500">
-            <div class="flex flex-col gap-4 md:flex-row">
-              <!-- EMERGENCY ACCESS COUNCIL -->
-              <section class="flex flex-1 min-w-0 flex-col">
-                <h4 class="mb-2 font-semibold text-gray-700">{{ t('emergencyAccess.vaultCouncil') }}</h4>
-                <ul class="max-h-56 overflow-auto pr-1 mb-1">
-                  <li
-                    v-for="member in getCurrentCouncilMembers(vault)"
-                    :key="member.id"
-                    class="flex items-center gap-2 h-6"
-                  >
-                    <img
-                      v-if="member.pictureUrl"
-                      :src="member.pictureUrl"
-                      class="h-4 w-4 rounded-full"
-                    />
-                    {{ member.name }}
-                  </li>
-                </ul>
-                <div class="mb-3">
-                  {{ t('emergencyAccess.requiredKeyShares') }}: {{ vault.requiredEmergencyKeyShares }}
-                </div>
-                <div class="mt-auto pt-2 flex flex-wrap items-center gap-2">
-                  <EmergencyBadge
-                    v-if="!isEmergencyKeyShareHolder(vault)"
-                    type="notCouncil"
-                    :title="t('emergencyAccess.badge.notCouncil.title')"
-                    :message="t('emergencyAccess.badge.notCouncil.message')"
-                  />
-                  <EmergencyProcessButton
-                    v-if="getProcessByType(vault, 'COUNCIL_CHANGE')"
-                    :label="getTypeLabel(vault, 'COUNCIL_CHANGE')"
-                    :approval-label="getApprovalLabel(getProcessByType(vault, 'COUNCIL_CHANGE')!)"
-                    :disabled="isBroken(vault) || !isUserInProcessWithType(vault, 'COUNCIL_CHANGE')"
-                    :has-process="true"
-                    :can-start="false"
-                    :required-key-shares="getProcessByType(vault, 'COUNCIL_CHANGE')!.requiredKeyShares"
-                    :completed-key-shares="getCompletedSegmentsForProcess(getProcessByType(vault, 'COUNCIL_CHANGE')!)"
-                    :council-members="getCouncilMembersForProcess(getProcessByType(vault, 'COUNCIL_CHANGE')!)"
-                    :recovered-member-ids="Array.from(recoveredMemberIdsForProcess(getProcessByType(vault, 'COUNCIL_CHANGE')!))"
-                    @click-main="onUnifiedButtonClick(vault, 'COUNCIL_CHANGE')"
-                  />
-                  <EmergencyProcessButton
-                    v-else
-                    :label="getTypeLabel(vault, 'COUNCIL_CHANGE')"
-                    :disabled="isBroken(vault) || !isEmergencyKeyShareHolder(vault)"
-                    :has-process="false"
-                    :can-start="true"
-                    @click-main="onUnifiedButtonClick(vault, 'COUNCIL_CHANGE')"
-                  />
-                </div>
-              </section>
-
-              <!-- VAULT MEMBERS -->
-              <section class="flex flex-1 min-w-0 flex-col">
-                <h4 class="mb-2 font-semibold text-gray-700">Vault Access</h4>
-                <div class="grid grid-cols-[max-content_minmax(0,1fr)] gap-x-3 gap-y-3 items-center mb-3">
-                  <div class="text-xs font-medium uppercase tracking-wide text-gray-500 whitespace-nowrap">{{ t('emergencyAccess.label.owners') }}:</div>
-                  <UserListGroupVisualization :authorities="getVaultMembers(vault.id).filter(member => member.vaultRole === 'OWNER')" :max="8"/>
-                    
-                  <div class="text-xs font-medium uppercase tracking-wide text-gray-500 whitespace-nowrap">{{ t('emergencyAccess.label.members') }}:</div>
-                  <UserListGroupVisualization :authorities="getVaultMembers(vault.id).filter(member => member.vaultRole === 'MEMBER')" :max="8"/>
-                </div>
-                <div class="mt-auto pt-2 flex flex-wrap items-center gap-2">
-                  <EmergencyProcessButton
-                    v-if="getProcessByType(vault, 'CHANGE_PERMISSIONS')"
-                    :label="getTypeLabel(vault, 'CHANGE_PERMISSIONS')"
-                    :approval-label="getApprovalLabel(getProcessByType(vault, 'CHANGE_PERMISSIONS')!)"
-                    :disabled="isBroken(vault) || !isUserInProcessWithType(vault, 'CHANGE_PERMISSIONS')"
-                    :has-process="true"
-                    :can-start="false"
-                    :required-key-shares="getProcessByType(vault, 'CHANGE_PERMISSIONS')!.requiredKeyShares"
-                    :completed-key-shares="getCompletedSegmentsForProcess(getProcessByType(vault, 'CHANGE_PERMISSIONS')!)"
-                    :council-members="getCouncilMembersForProcess(getProcessByType(vault, 'CHANGE_PERMISSIONS')!)"
-                    :recovered-member-ids="Array.from(recoveredMemberIdsForProcess(getProcessByType(vault, 'CHANGE_PERMISSIONS')!))"
-                    @click-main="onUnifiedButtonClick(vault, 'CHANGE_PERMISSIONS')"
-                  />
-                  <EmergencyProcessButton
-                    v-else
-                    :label="getTypeLabel(vault, 'CHANGE_PERMISSIONS')"
-                    :disabled="isBroken(vault) || !isEmergencyKeyShareHolder(vault)"
-                    :has-process="false"
-                    :can-start="true"
-                    @click-main="onUnifiedButtonClick(vault, 'CHANGE_PERMISSIONS')"
-                  />
-                </div>
-              </section>
-            </div>
+    <div v-else-if="!settings?.enableEmergencyAccess" class="mt-3 text-center">
+      <h3 class="mt-2 text-sm font-medium text-gray-900">{{ t('emergencyAccess.empty.disabled') }}</h3>
+    </div>
+    <section v-else>
+      <!-- entitlements.emergencyAccessEnabled && settings.enableEmergencyAccess -->
+      <header class="pb-5 border-b border-gray-200">
+        <div class="flex flex-col sm:flex-row sm:justify-between gap-3 w-full">
+          <h2 class="text-2xl font-bold leading-9 text-gray-900 sm:text-3xl sm:truncate">
+            {{ t('nav.emergencyAccess') }}
+          </h2>
+          <div class="flex gap-3">
+            <button class="w-full bg-primary py-2 px-4 border border-transparent rounded-md shadow-xs text-sm font-medium text-white hover:bg-primary-d1 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-primary" @click="fetchData()">
+              {{ t('common.refresh') }}
+            </button>
           </div>
-        </details>
-      </li>
-    </ul>
-  </section>
+        </div>
+        <div class="mt-3 flex flex-wrap sm:flex-nowrap gap-3 items-center whitespace-nowrap">
+          <input id="vaultSearch" v-model="query" :placeholder="t('vaultList.search.placeholder')" type="text" class="focus:ring-primary focus:border-primary block w-full shadow-xs text-sm border-gray-300 rounded-md disabled:bg-gray-200"/>
 
-  <EmergencyAccessDialog
-    v-if="recoveryApprovVault && settings"
-    ref="recoveryApprovDialog"
-    :settings="settings"
-    :vault="recoveryApprovVault"
-    :me="me!"
-    :recovery-process="selectedProcess"
-    :start-type="startType"
-    @updated="fetchData"
-    @close="recoveryApprovVault = undefined"
-  />
+          <Listbox v-model="selectedFilter" as="div">
+            <div class="relative w-auto whitespace-nowrap">
+              <ListboxButton class="min-w-60 relative w-full rounded-md border border-gray-300 bg-white py-2 pl-3 pr-10 text-left shadow-xs focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary text-sm">
+                <span class="block whitespace-nowrap">{{ filterOptions[selectedFilter] }}</span>
+                <span class="pointer-events-none absolute inset-y-0 right-0 flex items-center pr-2">
+                  <ChevronUpDownIcon class="h-5 w-5 text-gray-400" aria-hidden="true" />
+                </span>
+              </ListboxButton>
+              <transition leave-active-class="transition ease-in duration-100" leave-from-class="opacity-100" leave-to-class="opacity-0">
+                <ListboxOptions class="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 shadow-lg ring-1 ring-black/5 focus:outline-hidden text-sm">
+                  <ListboxOption v-for="(name, key) in filterOptions" :key="key" v-slot="{ active, selected }" :value="key" class="relative cursor-default select-none py-2 pl-3 pr-12 ui-not-active:text-gray-900 ui-active:text-white ui-active:bg-primary">
+                    <span :class="[selected ? 'font-semibold' : 'font-normal', 'block whitespace-nowrap']">{{ name }}</span>
+                    <span v-if="selected" :class="[active ? 'text-white' : 'text-primary', 'absolute inset-y-0 right-0 flex items-center pr-4']">
+                      <CheckIcon class="h-5 w-5" aria-hidden="true" />
+                    </span>
+                  </ListboxOption>
+                </ListboxOptions>
+              </transition>
+            </div>
+          </Listbox>
+        </div>
+      </header>
+
+      <div v-if="filteredVaults.length === 0" class="mt-3 text-center">
+        <h3 class="mt-2 text-sm font-medium text-gray-900">{{ t('emergencyAccess.empty.noneFound') }}</h3>
+      </div>
+      <ul role="list" class="mt-5 divide-y divide-gray-200 bg-white shadow-sm rounded-md">
+        <li v-for="(vault, index) in filteredVaults" :key="vault.id">
+          <details
+            class="group/vault hover:bg-gray-50"
+            :class="{ 'rounded-t-md': index == 0, 'rounded-b-md': index == filteredVaults.length - 1 }"
+            @toggle="onVaultDetailsToggle(vault.id, $event)"
+          >
+            <summary
+              class="list-none px-4 py-4 sm:px-6  cursor-pointer [&::-webkit-details-marker]:hidden"
+              :class="{ 'rounded-t-md': index == 0, 'rounded-b-md': index == filteredVaults.length - 1 }"
+            >
+              <div class="flex flex-wrap gap-3 sm:flex-nowrap sm:items-center sm:justify-between">
+                <!-- Name and description -->
+                <div class="flex-1 min-w-40">
+                  <div class="flex items-center gap-3 min-w-0">
+                    <p class="truncate text-sm font-medium text-primary min-w-0">
+                      {{ vault.name }}
+                    </p>
+                    <div v-if="vault.archived" class="inline-flex items-center rounded-md bg-yellow-400/10 px-2 py-1 text-xs font-medium text-yellow-500 ring-1 ring-inset ring-yellow-400/20">{{ t('vaultList.badge.archived') }}</div>
+                  </div>
+                  <p
+                    v-if="vault.description"
+                    class="truncate text-sm text-gray-500 mt-2 min-w-0"
+                  >
+                    {{ vault.description }}
+                  </p>
+                </div>
+
+                <div class="flex flex-wrap items-center gap-2 sm:justify-end" @click.stop>
+                  <EmergencyBadge
+                    v-if="isBroken(vault)"
+                    type="broken"
+                    :title="t('emergencyAccess.badge.broken.title')"
+                    :message="t('emergencyAccess.badge.broken.message')"
+                  />
+
+                  <EmergencyBadge
+                    v-if="settings && settings.defaultMinMembers > emergencyAccessMembers(vault).length"
+                    type="insufficientCouncilMembers"
+                    :title="t('emergencyAccess.badge.insufficientCouncilMembers.title')"
+                    :message="t('emergencyAccess.badge.insufficientCouncilMembers.message', [settings.defaultMinMembers])"
+                    position="right"
+                  />
+
+                  <EmergencyBadge
+                    v-else-if="vault.requiredEmergencyKeyShares === emergencyAccessMembers(vault).length"
+                    type="noRedundancy"
+                    :title="t('emergencyAccess.badge.noRedundancy.title')"
+                    :message="t('emergencyAccess.badge.noRedundancy.message')"
+                  />
+                </div>
+                <div class="flex items-center gap-2">
+                  <span
+                    v-if="getProcesses(vault.id).length > 0"
+                    class="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700"
+                  >
+                    {{ getProcesses(vault.id).length }}
+                  </span>
+                  <ChevronDownIcon class="h-5 w-5 text-gray-400 transition-transform duration-200 group-open/vault:rotate-180" aria-hidden="true"/>
+                </div>
+              </div>
+            </summary>
+            <div class="px-4 py-4 sm:px-6 text-sm text-gray-500">
+              <div class="flex flex-col gap-4 md:flex-row">
+                <!-- EMERGENCY ACCESS COUNCIL -->
+                <section class="flex flex-1 min-w-0 flex-col">
+                  <h4 class="mb-2 font-semibold text-gray-700">{{ t('emergencyAccess.vaultCouncil') }}</h4>
+                  <ul class="max-h-56 overflow-auto pr-1 mb-1">
+                    <li
+                      v-for="member in getCurrentCouncilMembers(vault)"
+                      :key="member.id"
+                      class="flex items-center gap-2 h-6"
+                    >
+                      <img
+                        v-if="member.pictureUrl"
+                        :src="member.pictureUrl"
+                        class="h-4 w-4 rounded-full"
+                      />
+                      {{ member.name }}
+                    </li>
+                  </ul>
+                  <div class="mb-3">
+                    {{ t('emergencyAccess.requiredKeyShares') }}: {{ vault.requiredEmergencyKeyShares }}
+                  </div>
+                  <div class="mt-auto pt-2 flex flex-wrap items-center gap-2">
+                    <EmergencyBadge
+                      v-if="!isEmergencyKeyShareHolder(vault)"
+                      type="notCouncil"
+                      :title="t('emergencyAccess.badge.notCouncil.title')"
+                      :message="t('emergencyAccess.badge.notCouncil.message')"
+                    />
+                    <EmergencyProcessButton
+                      v-if="getProcessByType(vault, 'COUNCIL_CHANGE')"
+                      :label="getTypeLabel(vault, 'COUNCIL_CHANGE')"
+                      :approval-label="getApprovalLabel(getProcessByType(vault, 'COUNCIL_CHANGE')!)"
+                      :disabled="isBroken(vault) || !isUserInProcessWithType(vault, 'COUNCIL_CHANGE')"
+                      :has-process="true"
+                      :can-start="false"
+                      :required-key-shares="getProcessByType(vault, 'COUNCIL_CHANGE')!.requiredKeyShares"
+                      :completed-key-shares="getCompletedSegmentsForProcess(getProcessByType(vault, 'COUNCIL_CHANGE')!)"
+                      :council-members="getCouncilMembersForProcess(getProcessByType(vault, 'COUNCIL_CHANGE')!)"
+                      :recovered-member-ids="Array.from(recoveredMemberIdsForProcess(getProcessByType(vault, 'COUNCIL_CHANGE')!))"
+                      @click-main="onUnifiedButtonClick(vault, 'COUNCIL_CHANGE')"
+                    />
+                    <EmergencyProcessButton
+                      v-else
+                      :label="getTypeLabel(vault, 'COUNCIL_CHANGE')"
+                      :disabled="isBroken(vault) || !isEmergencyKeyShareHolder(vault)"
+                      :has-process="false"
+                      :can-start="true"
+                      @click-main="onUnifiedButtonClick(vault, 'COUNCIL_CHANGE')"
+                    />
+                  </div>
+                </section>
+
+                <!-- VAULT MEMBERS -->
+                <section class="flex flex-1 min-w-0 flex-col">
+                  <h4 class="mb-2 font-semibold text-gray-700">Vault Access</h4>
+                  <div class="grid grid-cols-[max-content_minmax(0,1fr)] gap-x-3 gap-y-3 items-center mb-3">
+                    <div class="text-xs font-medium uppercase tracking-wide text-gray-500 whitespace-nowrap">{{ t('emergencyAccess.label.owners') }}:</div>
+                    <UserListGroupVisualization :authorities="getVaultMembers(vault.id).filter(member => member.vaultRole === 'OWNER')" :max="8"/>
+                      
+                    <div class="text-xs font-medium uppercase tracking-wide text-gray-500 whitespace-nowrap">{{ t('emergencyAccess.label.members') }}:</div>
+                    <UserListGroupVisualization :authorities="getVaultMembers(vault.id).filter(member => member.vaultRole === 'MEMBER')" :max="8"/>
+                  </div>
+                  <div class="mt-auto pt-2 flex flex-wrap items-center gap-2">
+                    <EmergencyProcessButton
+                      v-if="getProcessByType(vault, 'CHANGE_PERMISSIONS')"
+                      :label="getTypeLabel(vault, 'CHANGE_PERMISSIONS')"
+                      :approval-label="getApprovalLabel(getProcessByType(vault, 'CHANGE_PERMISSIONS')!)"
+                      :disabled="isBroken(vault) || !isUserInProcessWithType(vault, 'CHANGE_PERMISSIONS')"
+                      :has-process="true"
+                      :can-start="false"
+                      :required-key-shares="getProcessByType(vault, 'CHANGE_PERMISSIONS')!.requiredKeyShares"
+                      :completed-key-shares="getCompletedSegmentsForProcess(getProcessByType(vault, 'CHANGE_PERMISSIONS')!)"
+                      :council-members="getCouncilMembersForProcess(getProcessByType(vault, 'CHANGE_PERMISSIONS')!)"
+                      :recovered-member-ids="Array.from(recoveredMemberIdsForProcess(getProcessByType(vault, 'CHANGE_PERMISSIONS')!))"
+                      @click-main="onUnifiedButtonClick(vault, 'CHANGE_PERMISSIONS')"
+                    />
+                    <EmergencyProcessButton
+                      v-else
+                      :label="getTypeLabel(vault, 'CHANGE_PERMISSIONS')"
+                      :disabled="isBroken(vault) || !isEmergencyKeyShareHolder(vault)"
+                      :has-process="false"
+                      :can-start="true"
+                      @click-main="onUnifiedButtonClick(vault, 'CHANGE_PERMISSIONS')"
+                    />
+                  </div>
+                </section>
+              </div>
+            </div>
+          </details>
+        </li>
+      </ul>
+    </section>
+
+    <EmergencyAccessDialog
+      v-if="recoveryApprovVault && settings"
+      ref="recoveryApprovDialog"
+      :settings="settings"
+      :vault="recoveryApprovVault"
+      :me="me!"
+      :recovery-process="selectedProcess"
+      :start-type="startType"
+      @updated="fetchData"
+      @close="recoveryApprovVault = undefined"
+    />
+  </div>  
+  <div v-else>
+    <FetchError :error="onFetchError" :retry="fetchData" />
+  </div>
 </template>
 
 <script setup lang="ts">

--- a/frontend/src/components/emergencyaccess/EmergencyAccessVaultList.vue
+++ b/frontend/src/components/emergencyaccess/EmergencyAccessVaultList.vue
@@ -98,11 +98,10 @@
 
                 <div class="flex flex-wrap items-center gap-2 sm:justify-end" @click.stop>
                   <EmergencyBadge
-                    v-if="!isEmergencyKeyShareHolder(vault)"
-                    type="notCouncil"
-                    :title="t('emergencyAccess.badge.notCouncil.title')"
-                    :message="t('emergencyAccess.badge.notCouncil.message')"
-                    position="left"
+                    v-if="isBroken(vault)"
+                    type="broken"
+                    :title="t('emergencyAccess.badge.broken.title')"
+                    :message="t('emergencyAccess.badge.broken.message')"
                   />
 
                   <EmergencyBadge
@@ -159,6 +158,7 @@
                       type="notCouncil"
                       :title="t('emergencyAccess.badge.notCouncil.title')"
                       :message="t('emergencyAccess.badge.notCouncil.message')"
+                      position="left"
                     />
                     <EmergencyProcessButton
                       v-if="getProcessByType(vault, 'COUNCIL_CHANGE')"

--- a/frontend/src/components/emergencyaccess/EmergencyAccessVaultList.vue
+++ b/frontend/src/components/emergencyaccess/EmergencyAccessVaultList.vue
@@ -313,12 +313,15 @@ async function fetchData() {
     settings.value = await backend.settings.get();
 
     if (entitlements.emergencyAccessEnabled && settings.value.enableEmergencyAccess){
-      vaults.value = (await backend.vaults.listRecoverable())
-        .sort((a, b) => a.name.localeCompare(b.name));
+      const [fetchedVaults, allProcesses] = await Promise.all([
+        backend.vaults.listRecoverable(),
+        backend.emergencyAccess.findAllProcesses(),
+      ]);
+      vaults.value = fetchedVaults.sort((a, b) => a.name.localeCompare(b.name));
 
+      const processesByVaultId = R.groupBy(allProcesses, p => p.vaultId);
       for (const vault of vaults.value) {
-        const processes = await backend.emergencyAccess.findProcessesForVault(vault.id);
-        vaultRecoveryProcesses.value[vault.id] = processes;
+        vaultRecoveryProcesses.value[vault.id] = processesByVaultId[vault.id] ?? [];
       }
 
       const memberIdsOfAllRunningProcesses = Object.values(vaultRecoveryProcesses.value)

--- a/frontend/src/components/emergencyaccess/EmergencyAccessVaultList.vue
+++ b/frontend/src/components/emergencyaccess/EmergencyAccessVaultList.vue
@@ -319,9 +319,7 @@ async function fetchData() {
       vaults.value = fetchedVaults.sort((a, b) => a.name.localeCompare(b.name));
 
       const processesByVaultId = R.groupBy(allProcesses, p => p.vaultId);
-      for (const vault of vaults.value) {
-        vaultRecoveryProcesses.value[vault.id] = processesByVaultId[vault.id] ?? [];
-      }
+      vaultRecoveryProcesses.value = R.pullObject(vaults.value, v => v.id, v => processesByVaultId[v.id] ?? []);
 
       const memberIdsOfAllRunningProcesses = Object.values(vaultRecoveryProcesses.value)
         .flat()

--- a/frontend/src/components/emergencyaccess/EmergencyAccessVaultList.vue
+++ b/frontend/src/components/emergencyaccess/EmergencyAccessVaultList.vue
@@ -312,12 +312,15 @@ async function fetchData() {
     settings.value = await backend.settings.get();
 
     if (entitlements.emergencyAccessEnabled && settings.value.enableEmergencyAccess){
-      vaults.value = (await backend.vaults.listRecoverable())
-        .sort((a, b) => a.name.localeCompare(b.name));
+      const [fetchedVaults, allProcesses] = await Promise.all([
+        backend.vaults.listRecoverable(),
+        backend.emergencyAccess.findAllProcesses(),
+      ]);
+      vaults.value = fetchedVaults.sort((a, b) => a.name.localeCompare(b.name));
 
+      const processesByVaultId = R.groupBy(allProcesses, p => p.vaultId);
       for (const vault of vaults.value) {
-        const processes = await backend.emergencyAccess.findProcessesForVault(vault.id);
-        vaultRecoveryProcesses.value[vault.id] = processes;
+        vaultRecoveryProcesses.value[vault.id] = processesByVaultId[vault.id] ?? [];
       }
 
       const memberIdsOfAllRunningProcesses = Object.values(vaultRecoveryProcesses.value)


### PR DESCRIPTION
### Problem
When opening the Emergency Access view, the frontend made one sequential HTTP request per vault to load its recovery processes (N+1 requests total). This caused unnecessary load time, especially with many vaults.                 

Additionally, the template structure was missing a proper v-if/v-else-if chain, causing other content (license alerts, banners, etc.) to render alongside the loading indicator instead of being hidden until data is ready.    
                                                         
### Solution
A new bulk endpoint loads all recovery processes for the current user's recoverable vaults in a single backend query. On the frontend, this request runs in parallel with the vault list fetch, replacing the sequential loop.      
The template was also restructured so that loading, error, and content states are mutually exclusive.  