### PR TITLE
Add mobile tap support for EmergencyBadge tooltip

### DIFF
--- a/frontend/src/components/emergencyaccess/EmergencyBadge.vue
+++ b/frontend/src/components/emergencyaccess/EmergencyBadge.vue
@@ -61,12 +61,32 @@ function openTooltip() {
   const rect = badgeRef.value.getBoundingClientRect();
   const margin = 8;
   const maxWidth = Math.min(320, window.innerWidth - 2 * margin);
-  const overflowRight = rect.left + maxWidth - (window.innerWidth - margin);
-  const tooltipShift = overflowRight > 0 ? overflowRight : 0;
-  mobileTooltipStyle.value = { left: `-${tooltipShift}px`, maxWidth: `${maxWidth}px` };
-  // arrow: badge center relative to tooltip left edge, minus half arrow width (4px)
-  const badgeCenterRelative = rect.width / 2 + tooltipShift - 4;
-  mobileArrowStyle.value = { left: `${badgeCenterRelative}px`, right: 'auto' };
+  const arrowHalf = 4;
+  const position = props.position ?? 'center';
+
+  if (position === 'left') {
+    const overflowRight = rect.left + maxWidth - (window.innerWidth - margin);
+    const shift = overflowRight > 0 ? overflowRight : 0;
+    mobileTooltipStyle.value = { left: `-${shift}px`, maxWidth: `${maxWidth}px` };
+    mobileArrowStyle.value = { left: `${rect.width / 2 + shift - arrowHalf}px` };
+  } else if (position === 'right') {
+    const overflowLeft = margin - (rect.right - maxWidth);
+    const shift = overflowLeft > 0 ? overflowLeft : 0;
+    mobileTooltipStyle.value = { right: `-${shift}px`, maxWidth: `${maxWidth}px` };
+    mobileArrowStyle.value = { right: `${rect.width / 2 + shift - arrowHalf}px` };
+  } else {
+    const badgeCenter = rect.left + rect.width / 2;
+    const tooltipLeft = badgeCenter - maxWidth / 2;
+    const tooltipRight = badgeCenter + maxWidth / 2;
+    let shift = 0;
+    if (tooltipRight > window.innerWidth - margin) shift = window.innerWidth - margin - tooltipRight;
+    else if (tooltipLeft < margin) shift = margin - tooltipLeft;
+    const sign = shift >= 0 ? '+' : '-';
+    const abs = Math.abs(shift);
+    mobileTooltipStyle.value = { left: `calc(50% ${sign} ${abs}px)`, maxWidth: `${maxWidth}px` };
+    mobileArrowStyle.value = { left: `calc(50% ${shift >= 0 ? '-' : '+'} ${abs}px)` };
+  }
+
   window.addEventListener('resize', closeTooltip);
   window.addEventListener('scroll', closeTooltip, { passive: true, capture: true });
 }

--- a/frontend/src/components/emergencyaccess/EmergencyBadge.vue
+++ b/frontend/src/components/emergencyaccess/EmergencyBadge.vue
@@ -2,17 +2,25 @@
   <div v-if="type !== 'none'" ref="badgeRef" class="relative mr-3 group/badge">
     <!-- Badge -->
     <span
-      class="inline-flex items-center gap-2 rounded-full px-2 py-2 text-xs font-medium cursor-default ring-1"
+      class="inline-flex items-center gap-2 rounded-full px-2 py-2 text-xs font-medium cursor-default ring-1 outline-none focus-visible:ring-2"
       :class="badgeClasses"
-      @click.stop="toggle"
+      role="button"
+      tabindex="0"
+      :aria-describedby="tooltipId"
+      @click.stop="handleClick"
+      @keydown.enter.prevent="toggle"
+      @keydown.space.prevent="toggle"
+      @keydown.esc="closeOnEscape"
     >
       <ExclamationTriangleIcon class="h-4 w-4" :class="iconColor" />
     </span>
 
     <!-- Tooltip -->
     <div
+      :id="tooltipId"
+      role="tooltip"
       class="transition-opacity duration-150 absolute -top-2 transform -translate-y-full w-max max-w-xs z-20"
-      :class="[positionClasses, isOpen ? 'visible opacity-100' : 'invisible opacity-0 group-hover/badge:visible group-hover/badge:opacity-100']"
+      :class="[positionClasses, isOpen ? 'visible opacity-100' : 'invisible opacity-0 group-hover/badge:visible group-hover/badge:opacity-100 group-focus-within/badge:visible group-focus-within/badge:opacity-100']"
       :style="mobileTooltipStyle"
     >
       <div class="px-2 py-1 rounded shadow-sm text-xs hyphens-auto border relative" :class="tooltipClasses">
@@ -31,8 +39,17 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, onMounted, onUnmounted } from 'vue';
+import { computed, ref, onMounted, onUnmounted, useId } from 'vue';
 import { ExclamationTriangleIcon } from '@heroicons/vue/24/solid';
+
+const props = defineProps<{
+  type: 'notCouncil' | 'broken' | 'noRedundancy' | 'insufficientCouncilMembers' | 'none';
+  title: string;
+  message: string;
+  position?: 'center' | 'left' | 'right';
+}>();
+
+const tooltipId = useId();
 
 const badgeRef = ref<HTMLElement | null>(null);
 const isOpen = ref(false);
@@ -92,9 +109,18 @@ function openTooltip() {
 }
 
 function toggle() {
-  if (!isTouchDevice.value) return;
   if (isOpen.value) closeTooltip();
   else openTooltip();
+}
+
+function handleClick() {
+  if (!isTouchDevice.value) return;
+  toggle();
+}
+
+function closeOnEscape() {
+  closeTooltip();
+  badgeRef.value?.blur();
 }
 
 function onDocumentClick(e: MouseEvent) {
@@ -116,13 +142,6 @@ onUnmounted(() => {
   window.removeEventListener('resize', closeTooltip);
   window.removeEventListener('scroll', closeTooltip, true);
 });
-
-const props = defineProps<{
-  type: 'notCouncil' | 'broken' | 'noRedundancy' | 'insufficientCouncilMembers' | 'none';
-  title: string;
-  message: string;
-  position?: 'center' | 'left' | 'right';
-}>();
 
 const positionClasses = computed(() => {
   switch (props.position) {

--- a/frontend/src/components/emergencyaccess/EmergencyBadge.vue
+++ b/frontend/src/components/emergencyaccess/EmergencyBadge.vue
@@ -1,17 +1,19 @@
 <template>
-  <div v-if="type !== 'none'" class="relative mr-3 group/badge">
+  <div v-if="type !== 'none'" ref="badgeRef" class="relative mr-3 group/badge">
     <!-- Badge -->
-    <span 
-      class="inline-flex items-center gap-2 rounded-full px-2 py-2 text-xs font-medium cursor-default ring-1" 
+    <span
+      class="inline-flex items-center gap-2 rounded-full px-2 py-2 text-xs font-medium cursor-default ring-1"
       :class="badgeClasses"
+      @click.stop="toggle"
     >
       <ExclamationTriangleIcon class="h-4 w-4" :class="iconColor" />
     </span>
 
     <!-- Tooltip -->
-    <div 
-      class="invisible opacity-0 group-hover/badge:visible group-hover/badge:opacity-100 transition-opacity duration-150 absolute -top-2 transform -translate-y-full w-max max-w-xs z-20" 
-      :class="positionClasses"
+    <div
+      class="transition-opacity duration-150 absolute -top-2 transform -translate-y-full w-max max-w-xs z-20"
+      :class="[positionClasses, isOpen ? 'visible opacity-100' : 'invisible opacity-0 group-hover/badge:visible group-hover/badge:opacity-100']"
+      :style="mobileTooltipStyle"
     >
       <div class="px-2 py-1 rounded shadow-sm text-xs hyphens-auto border relative" :class="tooltipClasses">
         <b>{{ title }}</b><br />
@@ -20,7 +22,8 @@
         <!-- Arrow -->
         <div
           class="absolute bottom-0 transform translate-y-1/2 rotate-45 w-2 h-2 border-r border-b"
-          :class="[arrowClasses, arrowPositionClasses]"
+          :class="[arrowClasses, mobileArrowStyle ? '' : arrowPositionClasses]"
+          :style="mobileArrowStyle"
         ></div>
       </div>
     </div>
@@ -28,8 +31,46 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref, onMounted, onUnmounted } from 'vue';
 import { ExclamationTriangleIcon } from '@heroicons/vue/24/solid';
+
+const badgeRef = ref<HTMLElement | null>(null);
+const isOpen = ref(false);
+const mobileTooltipStyle = ref<Record<string, string>>({});
+const mobileArrowStyle = ref<Record<string, string>>({});
+const isTouchDevice = ref(false);
+
+onMounted(() => {
+  isTouchDevice.value = window.matchMedia('(hover: none)').matches;
+});
+
+function toggle() {
+  if (!isTouchDevice.value) return;
+  isOpen.value = !isOpen.value;
+  if (isOpen.value && badgeRef.value) {
+    const rect = badgeRef.value.getBoundingClientRect();
+    const margin = 8;
+    const maxWidth = Math.min(320, window.innerWidth - 2 * margin);
+    const overflowRight = rect.left + maxWidth - (window.innerWidth - margin);
+    const tooltipShift = overflowRight > 0 ? overflowRight : 0;
+    mobileTooltipStyle.value = { left: `-${tooltipShift}px`, maxWidth: `${maxWidth}px` };
+    // arrow: badge center relative to tooltip left edge, minus half arrow width (4px)
+    const badgeCenterRelative = rect.width / 2 + tooltipShift - 4;
+    mobileArrowStyle.value = { left: `${badgeCenterRelative}px`, right: 'auto' };
+  } else {
+    mobileTooltipStyle.value = {};
+    mobileArrowStyle.value = {};
+  }
+}
+
+function onDocumentClick(e: MouseEvent) {
+  if (badgeRef.value && !badgeRef.value.contains(e.target as Node)) {
+    isOpen.value = false;
+  }
+}
+
+onMounted(() => document.addEventListener('click', onDocumentClick));
+onUnmounted(() => document.removeEventListener('click', onDocumentClick));
 
 const props = defineProps<{
   type: 'notCouncil' | 'broken' | 'noRedundancy' | 'insufficientCouncilMembers' | 'none';

--- a/frontend/src/components/emergencyaccess/EmergencyBadge.vue
+++ b/frontend/src/components/emergencyaccess/EmergencyBadge.vue
@@ -40,37 +40,62 @@ const mobileTooltipStyle = ref<Record<string, string>>({});
 const mobileArrowStyle = ref<Record<string, string>>({});
 const isTouchDevice = ref(false);
 
-onMounted(() => {
-  isTouchDevice.value = window.matchMedia('(hover: none)').matches;
-});
+let hoverMql: MediaQueryList | null = null;
+
+function onHoverChange(e: MediaQueryListEvent) {
+  isTouchDevice.value = e.matches;
+  if (!isTouchDevice.value) closeTooltip();
+}
+
+function closeTooltip() {
+  isOpen.value = false;
+  mobileTooltipStyle.value = {};
+  mobileArrowStyle.value = {};
+  window.removeEventListener('resize', closeTooltip);
+  window.removeEventListener('scroll', closeTooltip, true);
+}
+
+function openTooltip() {
+  if (!badgeRef.value) return;
+  isOpen.value = true;
+  const rect = badgeRef.value.getBoundingClientRect();
+  const margin = 8;
+  const maxWidth = Math.min(320, window.innerWidth - 2 * margin);
+  const overflowRight = rect.left + maxWidth - (window.innerWidth - margin);
+  const tooltipShift = overflowRight > 0 ? overflowRight : 0;
+  mobileTooltipStyle.value = { left: `-${tooltipShift}px`, maxWidth: `${maxWidth}px` };
+  // arrow: badge center relative to tooltip left edge, minus half arrow width (4px)
+  const badgeCenterRelative = rect.width / 2 + tooltipShift - 4;
+  mobileArrowStyle.value = { left: `${badgeCenterRelative}px`, right: 'auto' };
+  window.addEventListener('resize', closeTooltip);
+  window.addEventListener('scroll', closeTooltip, { passive: true, capture: true });
+}
 
 function toggle() {
   if (!isTouchDevice.value) return;
-  isOpen.value = !isOpen.value;
-  if (isOpen.value && badgeRef.value) {
-    const rect = badgeRef.value.getBoundingClientRect();
-    const margin = 8;
-    const maxWidth = Math.min(320, window.innerWidth - 2 * margin);
-    const overflowRight = rect.left + maxWidth - (window.innerWidth - margin);
-    const tooltipShift = overflowRight > 0 ? overflowRight : 0;
-    mobileTooltipStyle.value = { left: `-${tooltipShift}px`, maxWidth: `${maxWidth}px` };
-    // arrow: badge center relative to tooltip left edge, minus half arrow width (4px)
-    const badgeCenterRelative = rect.width / 2 + tooltipShift - 4;
-    mobileArrowStyle.value = { left: `${badgeCenterRelative}px`, right: 'auto' };
-  } else {
-    mobileTooltipStyle.value = {};
-    mobileArrowStyle.value = {};
-  }
+  if (isOpen.value) closeTooltip();
+  else openTooltip();
 }
 
 function onDocumentClick(e: MouseEvent) {
   if (badgeRef.value && !badgeRef.value.contains(e.target as Node)) {
-    isOpen.value = false;
+    closeTooltip();
   }
 }
 
-onMounted(() => document.addEventListener('click', onDocumentClick));
-onUnmounted(() => document.removeEventListener('click', onDocumentClick));
+onMounted(() => {
+  hoverMql = window.matchMedia('(hover: none)');
+  isTouchDevice.value = hoverMql.matches;
+  hoverMql.addEventListener('change', onHoverChange);
+  document.addEventListener('click', onDocumentClick);
+});
+
+onUnmounted(() => {
+  hoverMql?.removeEventListener('change', onHoverChange);
+  document.removeEventListener('click', onDocumentClick);
+  window.removeEventListener('resize', closeTooltip);
+  window.removeEventListener('scroll', closeTooltip, true);
+});
 
 const props = defineProps<{
   type: 'notCouncil' | 'broken' | 'noRedundancy' | 'insufficientCouncilMembers' | 'none';

--- a/frontend/src/components/emergencyaccess/EmergencyBadge.vue
+++ b/frontend/src/components/emergencyaccess/EmergencyBadge.vue
@@ -22,7 +22,7 @@
         <!-- Arrow -->
         <div
           class="absolute bottom-0 transform translate-y-1/2 rotate-45 w-2 h-2 border-r border-b"
-          :class="[arrowClasses, mobileArrowStyle ? '' : arrowPositionClasses]"
+          :class="[arrowClasses, arrowPositionClasses]"
           :style="mobileArrowStyle"
         ></div>
       </div>
@@ -133,9 +133,9 @@ const arrowClasses = computed(() => {
 const arrowPositionClasses = computed(() => {
   switch (props.position) {
     case 'left':
-      return 'left-2';
+      return 'left-2.5';
     case 'right':
-      return 'right-2';
+      return 'right-2.5';
     case 'center':
     default:
       return 'left-1/2 -translate-x-1/2';


### PR DESCRIPTION
Adds tap interaction for EmergencyBadge tooltip on touch devices (previously only hover worked, so mobile users couldn't see the tooltip content). The tooltip now stays within the viewport regardless of where the badge sits on the page, and the arrow remains aligned with the badge even when the tooltip has been shifted. The tooltip also closes automatically if the viewport changes (e.g. rotation, scroll, resize).

In addition, the badge is now keyboard- and screen-reader-accessible: it can be focused and activated via keyboard, the tooltip appears on focus, Escape dismisses it, and assistive technologies announce the tooltip content together with the badge.