### PR TITLE
OpenTelemetry

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -128,11 +128,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-micrometer</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+            <artifactId>quarkus-opentelemetry</artifactId>
         </dependency>
     </dependencies>
 

--- a/backend/src/main/java/org/cryptomator/hub/api/AuditLogResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/AuditLogResource.java
@@ -3,6 +3,7 @@ package org.cryptomator.hub.api;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import jakarta.annotation.security.RolesAllowed;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.BadRequestException;
@@ -74,6 +75,7 @@ public class AuditLogResource {
 	@APIResponse(responseCode = "400", description = "startDate or endDate not specified, startDate > endDate, order specified and not in ['asc','desc'], pageSize not in [1 .. 100] or type is not valid")
 	@APIResponse(responseCode = "402", description = "Community license used or license expired")
 	@APIResponse(responseCode = "403", description = "requesting user does not have admin role")
+	@WithSpan("AuditLogResource.getAllEvents")
 	public List<AuditEventDto> getAllEvents(@QueryParam("startDate") Instant startDate, @QueryParam("endDate") Instant endDate, @QueryParam("type") List<String> type, @QueryParam("paginationId") Long paginationId, @QueryParam("order") @DefaultValue("desc") String order, @QueryParam("pageSize") @DefaultValue("20") int pageSize) {
 		if (license.getEntitlements().auditLogRetentionDays() == 0 || license.isExpired()) {
 			throw new PaymentRequiredException("Community license used or license expired");

--- a/backend/src/main/java/org/cryptomator/hub/entities/EffectiveGroupMembership.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/EffectiveGroupMembership.java
@@ -1,5 +1,6 @@
 package org.cryptomator.hub.entities;
 
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 import io.quarkus.panache.common.Parameters;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -87,6 +88,7 @@ public class EffectiveGroupMembership {
 					.executeUpdate();
 		}
 
+		@WithSpan("EffectiveGroupMembership.Repository.updateGroups")
 		public void updateGroups(Collection<String> groupIds) {
 			Batch.of(200).run(groupIds, batch -> {
 				getEntityManager()
@@ -100,6 +102,7 @@ public class EffectiveGroupMembership {
 			});
 		}
 
+		@WithSpan("EffectiveGroupMembership.Repository.updateUsers")
 		public void updateUsers(Collection<String> userIds) {
 			Batch.of(200).run(userIds, batch -> {
 				delete("#EffectiveGroupMembership.deleteUsers", Parameters.with("userIds", batch));

--- a/backend/src/main/java/org/cryptomator/hub/entities/EffectiveVaultAccess.java
+++ b/backend/src/main/java/org/cryptomator/hub/entities/EffectiveVaultAccess.java
@@ -1,5 +1,6 @@
 package org.cryptomator.hub.entities;
 
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
 import io.quarkus.panache.common.Parameters;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -131,6 +132,7 @@ public class EffectiveVaultAccess {
 			return count("#EffectiveVaultAccess.countSeatOccupyingUsers");
 		}
 
+		@WithSpan("EffectiveVaultAccess.Repository.countSeatOccupyingUsersWithAccessToken")
 		public long countSeatOccupyingUsersWithAccessToken() {
 			return count("#EffectiveVaultAccess.countSeatOccupyingUsersWithAccessToken");
 		}

--- a/backend/src/main/java/org/cryptomator/hub/keycloak/KeycloakAdminService.java
+++ b/backend/src/main/java/org/cryptomator/hub/keycloak/KeycloakAdminService.java
@@ -1,5 +1,6 @@
 package org.cryptomator.hub.keycloak;
 
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -61,6 +62,7 @@ public class KeycloakAdminService {
 		this.realm = keycloak.realm(keycloakRealm);
 	}
 
+	@WithSpan("KeycloakAdminService.createUser")
 	public UserRepresentation createUser(String username, String email, String firstName, String lastName, String password, String pictureUrl, Set<String> groupIds) {
 		UserRepresentation user = new UserRepresentation();
 		user.setUsername(username);
@@ -199,6 +201,7 @@ public class KeycloakAdminService {
 
 	// TODO deduplicate with KeycloakAuthorityPuller
 	@Transactional
+	@WithSpan("KeycloakAdminService.syncUser")
 	public User syncUser(String userId) {
 		UserResource userResource = realm.users().get(userId);
 		UserRepresentation keycloakUser = userResource.toRepresentation();
@@ -230,6 +233,7 @@ public class KeycloakAdminService {
 
 	// TODO deduplicate with KeycloakAuthorityPuller
 	@Transactional
+	@WithSpan("KeycloakAdminService.syncGroup")
 	public Group syncGroup(String groupId) {
 		GroupResource groupResource = realm.groups().group(groupId);
 		GroupRepresentation keycloakGroup = groupResource.toRepresentation();
@@ -285,6 +289,7 @@ public class KeycloakAdminService {
 	}
 
 	@Transactional
+	@WithSpan("KeycloakAdminService.updateUserRoles")
 	public void updateUserRoles(String userId, Set<RealmRole> roles) {
 		// remove roles that are not in the provided set:
 		var rolesToRemove = EnumSet.allOf(RealmRole.class);

--- a/backend/src/main/java/org/cryptomator/hub/keycloak/KeycloakAuthorityPuller.java
+++ b/backend/src/main/java/org/cryptomator/hub/keycloak/KeycloakAuthorityPuller.java
@@ -1,5 +1,6 @@
 package org.cryptomator.hub.keycloak;
 
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.quarkus.scheduler.Scheduled;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -30,6 +31,7 @@ public class KeycloakAuthorityPuller {
 	EffectiveGroupMembership.Repository effectiveGroupMembershipRepo;
 
 	@Scheduled(every = "{hub.keycloak.syncer-period}")
+	@WithSpan("KeycloakAuthorityPuller.sync")
 	void sync() {
 		var keycloakGroups = remoteUserProvider.groups().stream().collect(Collectors.toMap(KeycloakGroupDto::id, Function.identity()));
 		var keycloakUsers = remoteUserProvider.users().stream().collect(Collectors.toMap(KeycloakUserDto::id, Function.identity()));

--- a/backend/src/main/java/org/cryptomator/hub/license/LicenseHolder.java
+++ b/backend/src/main/java/org/cryptomator/hub/license/LicenseHolder.java
@@ -2,6 +2,7 @@ package org.cryptomator.hub.license;
 
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import io.quarkus.scheduler.Scheduled;
 import io.smallrye.common.annotation.RunOnVirtualThread;
 import jakarta.annotation.PostConstruct;
@@ -97,6 +98,7 @@ public class LicenseHolder {
 	 * @throws JWTVerificationException if the license is invalid
 	 */
 	@Transactional
+	@WithSpan("LicenseHolder.ensureLicenseExists")
 	DecodedJWT ensureLicenseExists() throws JWTVerificationException, WebApplicationException {
 		var settings = settingsRepo.get();
 		if (settings.getLicenseKey() != null && settings.getHubId() != null) {
@@ -136,6 +138,7 @@ public class LicenseHolder {
 	}
 
 	@Transactional(Transactional.TxType.MANDATORY)
+	@WithSpan("LicenseHolder.requestAnonTrialLicense")
 	DecodedJWT requestAnonTrialLicense(Settings settings) throws WebApplicationException {
 		LOG.info("No license found. Requesting trial license...");
 		var solution = solveChallenge();

--- a/backend/src/main/java/org/cryptomator/hub/metrics/SystemUsageMetrics.java
+++ b/backend/src/main/java/org/cryptomator/hub/metrics/SystemUsageMetrics.java
@@ -3,77 +3,71 @@ package org.cryptomator.hub.metrics;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.Meter;
-import io.quarkus.scheduler.Scheduled;
-import jakarta.annotation.PostConstruct;
+import io.opentelemetry.api.metrics.ObservableLongGauge;
+import io.opentelemetry.api.metrics.ObservableLongMeasurement;
+import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.quarkus.runtime.ShutdownEvent;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
-import jakarta.transaction.Transactional;
 import org.cryptomator.hub.entities.Device;
 import org.cryptomator.hub.entities.EffectiveVaultAccess;
 import org.cryptomator.hub.entities.Vault;
 
-import java.util.EnumMap;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicLong;
-
 @ApplicationScoped
 public class SystemUsageMetrics {
 
-	private static final String VAULTS_TOTAL_METRIC = "hub_vaults_total";
-	private static final String ACTIVE_USERS_TOTAL_METRIC = "hub_active_users_total";
-	private static final String DEVICES_TOTAL_METRIC = "hub_devices_total";
+	private static final String VAULTS_METRIC = "hub_vaults";
+	private static final String ACTIVE_USERS_METRIC = "hub_active_users";
+	private static final String DEVICES_METRIC = "hub_devices";
 	private static final AttributeKey<String> DEVICE_TYPE_KEY = AttributeKey.stringKey("type");
 
-	@Inject
-	Meter meter;
+	private final Vault.Repository vaultRepo;
+	private final EffectiveVaultAccess.Repository effectiveVaultAccessRepo;
+	private final Device.Repository deviceRepo;
+	private final ObservableLongGauge vaultsGauge;
+	private final ObservableLongGauge activeUsersGauge;
+	private final ObservableLongGauge devicesGauge;
 
 	@Inject
-	Vault.Repository vaultRepo;
-
-	@Inject
-	EffectiveVaultAccess.Repository effectiveVaultAccessRepo;
-
-	@Inject
-	Device.Repository deviceRepo;
-
-	private final AtomicLong vaultsTotal = new AtomicLong(0);
-	private final AtomicLong activeUsersTotal = new AtomicLong(0);
-	private final Map<Device.Type, AtomicLong> devicesPerType = new EnumMap<>(Device.Type.class);
-
-	@PostConstruct
-	void registerMetrics() {
-		for (var deviceType : Device.Type.values()) {
-			devicesPerType.put(deviceType, new AtomicLong(0));
-		}
-
-		meter.gaugeBuilder(VAULTS_TOTAL_METRIC)
+	SystemUsageMetrics(Meter meter, Vault.Repository vaultRepo, EffectiveVaultAccess.Repository effectiveVaultAccessRepo, Device.Repository deviceRepo) {
+		this.vaultRepo = vaultRepo;
+		this.effectiveVaultAccessRepo = effectiveVaultAccessRepo;
+		this.deviceRepo = deviceRepo;
+		this.vaultsGauge = meter.gaugeBuilder(VAULTS_METRIC)
 				.ofLongs()
 				.setDescription("Number of vaults")
-				.buildWithCallback(measurement -> measurement.record(vaultsTotal.get()));
-
-		meter.gaugeBuilder(ACTIVE_USERS_TOTAL_METRIC)
+				.buildWithCallback(this::recordVaultCount);
+		this.activeUsersGauge = meter.gaugeBuilder(ACTIVE_USERS_METRIC)
 				.ofLongs()
 				.setDescription("Number of unique users with access to any non-archived vault")
-				.buildWithCallback(measurement -> measurement.record(activeUsersTotal.get()));
-
-		meter.gaugeBuilder(DEVICES_TOTAL_METRIC)
+				.buildWithCallback(this::recordSeatCount);
+		this.devicesGauge = meter.gaugeBuilder(DEVICES_METRIC)
 				.ofLongs()
 				.setDescription("Number of devices grouped by type")
-				.buildWithCallback(measurement -> {
-					for (var entry : devicesPerType.entrySet()) {
-						measurement.record(entry.getValue().get(), Attributes.of(DEVICE_TYPE_KEY, entry.getKey().name()));
-					}
-				});
+				.buildWithCallback(this::recordDeviceCount);
 	}
 
-	@Scheduled(every = "24h", delayed = "10s")
-	@Transactional
-	void collect() {
-		vaultsTotal.set(vaultRepo.count());
-		activeUsersTotal.set(effectiveVaultAccessRepo.countSeatOccupyingUsers());
-		for (var deviceType : Device.Type.values()) {
-			var count = deviceRepo.count("type", deviceType);
-			devicesPerType.get(deviceType).set(count);
-		}
+	private void recordVaultCount(ObservableLongMeasurement measurement) {
+		measurement.record(QuarkusTransaction.requiringNew().call(vaultRepo::count));
 	}
+
+	private void recordSeatCount(ObservableLongMeasurement measurement) {
+		measurement.record(QuarkusTransaction.requiringNew().call(effectiveVaultAccessRepo::countSeatOccupyingUsers));
+	}
+
+	private void recordDeviceCount(ObservableLongMeasurement measurement) {
+		QuarkusTransaction.requiringNew().run(() -> {
+			for (var type : Device.Type.values()) {
+				measurement.record(deviceRepo.count("type", type), Attributes.of(DEVICE_TYPE_KEY, type.name()));
+			}
+		});
+	}
+
+	void onStop(@Observes ShutdownEvent event) {
+		vaultsGauge.close();
+		activeUsersGauge.close();
+		devicesGauge.close();
+	}
+
 }

--- a/backend/src/main/java/org/cryptomator/hub/metrics/SystemUsageMetrics.java
+++ b/backend/src/main/java/org/cryptomator/hub/metrics/SystemUsageMetrics.java
@@ -1,7 +1,8 @@
 package org.cryptomator.hub.metrics;
 
-import io.micrometer.core.instrument.Gauge;
-import io.micrometer.core.instrument.MeterRegistry;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.Meter;
 import io.quarkus.scheduler.Scheduled;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -21,9 +22,10 @@ public class SystemUsageMetrics {
 	private static final String VAULTS_TOTAL_METRIC = "hub_vaults_total";
 	private static final String ACTIVE_USERS_TOTAL_METRIC = "hub_active_users_total";
 	private static final String DEVICES_TOTAL_METRIC = "hub_devices_total";
+	private static final AttributeKey<String> DEVICE_TYPE_KEY = AttributeKey.stringKey("type");
 
 	@Inject
-	MeterRegistry meterRegistry;
+	Meter meter;
 
 	@Inject
 	Vault.Repository vaultRepo;
@@ -40,22 +42,28 @@ public class SystemUsageMetrics {
 
 	@PostConstruct
 	void registerMetrics() {
-		Gauge.builder(VAULTS_TOTAL_METRIC, vaultsTotal, AtomicLong::get)
-				.description("Number of vaults")
-				.register(meterRegistry);
-
-		Gauge.builder(ACTIVE_USERS_TOTAL_METRIC, activeUsersTotal, AtomicLong::get)
-				.description("Number of unique users with access to any non-archived vault")
-				.register(meterRegistry);
-
 		for (var deviceType : Device.Type.values()) {
-			var value = new AtomicLong(0);
-			devicesPerType.put(deviceType, value);
-			Gauge.builder(DEVICES_TOTAL_METRIC, value, AtomicLong::get)
-					.description("Number of devices grouped by type")
-					.tag("type", deviceType.name())
-					.register(meterRegistry);
+			devicesPerType.put(deviceType, new AtomicLong(0));
 		}
+
+		meter.gaugeBuilder(VAULTS_TOTAL_METRIC)
+				.ofLongs()
+				.setDescription("Number of vaults")
+				.buildWithCallback(measurement -> measurement.record(vaultsTotal.get()));
+
+		meter.gaugeBuilder(ACTIVE_USERS_TOTAL_METRIC)
+				.ofLongs()
+				.setDescription("Number of unique users with access to any non-archived vault")
+				.buildWithCallback(measurement -> measurement.record(activeUsersTotal.get()));
+
+		meter.gaugeBuilder(DEVICES_TOTAL_METRIC)
+				.ofLongs()
+				.setDescription("Number of devices grouped by type")
+				.buildWithCallback(measurement -> {
+					for (var entry : devicesPerType.entrySet()) {
+						measurement.record(entry.getValue().get(), Attributes.of(DEVICE_TYPE_KEY, entry.getKey().name()));
+					}
+				});
 	}
 
 	@Scheduled(every = "24h", delayed = "10s")

--- a/backend/src/main/java/org/cryptomator/hub/metrics/VaultUnlockMetrics.java
+++ b/backend/src/main/java/org/cryptomator/hub/metrics/VaultUnlockMetrics.java
@@ -1,8 +1,7 @@
 package org.cryptomator.hub.metrics;
 
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.Gauge;
-import io.micrometer.core.instrument.MeterRegistry;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.Meter;
 import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -17,27 +16,29 @@ public class VaultUnlockMetrics {
 	private static final String LAST_FAILURE_METRIC = "hub_vault_unlock_last_failure_epoch_seconds";
 
 	@Inject
-	MeterRegistry meterRegistry;
+	Meter meter;
 
 	private final AtomicLong lastSuccessEpochSeconds = new AtomicLong(0);
 	private final AtomicLong lastFailureEpochSeconds = new AtomicLong(0);
-	private Counter unlockCounter;
+	private LongCounter unlockCounter;
 
 	@PostConstruct
-	void registerGauges() {
-		unlockCounter = Counter.builder(UNLOCKS_TOTAL_METRIC)
-				.description("Total number of vault unlock attempts")
-				.register(meterRegistry);
-		Gauge.builder(LAST_SUCCESS_METRIC, lastSuccessEpochSeconds, AtomicLong::get)
-				.description("Epoch timestamp in seconds of the last successful vault unlock")
-				.register(meterRegistry);
-		Gauge.builder(LAST_FAILURE_METRIC, lastFailureEpochSeconds, AtomicLong::get)
-				.description("Epoch timestamp in seconds of the last failed vault unlock")
-				.register(meterRegistry);
+	void registerInstruments() {
+		unlockCounter = meter.counterBuilder(UNLOCKS_TOTAL_METRIC)
+				.setDescription("Total number of vault unlock attempts")
+				.build();
+		meter.gaugeBuilder(LAST_SUCCESS_METRIC)
+				.ofLongs()
+				.setDescription("Epoch timestamp in seconds of the last successful vault unlock")
+				.buildWithCallback(measurement -> measurement.record(lastSuccessEpochSeconds.get()));
+		meter.gaugeBuilder(LAST_FAILURE_METRIC)
+				.ofLongs()
+				.setDescription("Epoch timestamp in seconds of the last failed vault unlock")
+				.buildWithCallback(measurement -> measurement.record(lastFailureEpochSeconds.get()));
 	}
 
 	public void recordUnlock() {
-		unlockCounter.increment();
+		unlockCounter.add(1);
 	}
 
 	public void recordSuccess() {

--- a/backend/src/main/java/org/cryptomator/hub/metrics/VaultUnlockMetrics.java
+++ b/backend/src/main/java/org/cryptomator/hub/metrics/VaultUnlockMetrics.java
@@ -1,12 +1,10 @@
 package org.cryptomator.hub.metrics;
 
 import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongGauge;
 import io.opentelemetry.api.metrics.Meter;
-import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-
-import java.util.concurrent.atomic.AtomicLong;
 
 @ApplicationScoped
 public class VaultUnlockMetrics {
@@ -15,26 +13,23 @@ public class VaultUnlockMetrics {
 	private static final String LAST_SUCCESS_METRIC = "hub_vault_unlock_last_success_epoch_seconds";
 	private static final String LAST_FAILURE_METRIC = "hub_vault_unlock_last_failure_epoch_seconds";
 
+	private final LongCounter unlockCounter;
+	private final LongGauge lastSuccessGauge;
+	private final LongGauge lastFailureGauge;
+
 	@Inject
-	Meter meter;
-
-	private final AtomicLong lastSuccessEpochSeconds = new AtomicLong(0);
-	private final AtomicLong lastFailureEpochSeconds = new AtomicLong(0);
-	private LongCounter unlockCounter;
-
-	@PostConstruct
-	void registerInstruments() {
-		unlockCounter = meter.counterBuilder(UNLOCKS_TOTAL_METRIC)
+	VaultUnlockMetrics(Meter meter) {
+		this.unlockCounter = meter.counterBuilder(UNLOCKS_TOTAL_METRIC)
 				.setDescription("Total number of vault unlock attempts")
 				.build();
-		meter.gaugeBuilder(LAST_SUCCESS_METRIC)
+		this.lastSuccessGauge = meter.gaugeBuilder(LAST_SUCCESS_METRIC)
 				.ofLongs()
 				.setDescription("Epoch timestamp in seconds of the last successful vault unlock")
-				.buildWithCallback(measurement -> measurement.record(lastSuccessEpochSeconds.get()));
-		meter.gaugeBuilder(LAST_FAILURE_METRIC)
+				.build();
+		this.lastFailureGauge = meter.gaugeBuilder(LAST_FAILURE_METRIC)
 				.ofLongs()
 				.setDescription("Epoch timestamp in seconds of the last failed vault unlock")
-				.buildWithCallback(measurement -> measurement.record(lastFailureEpochSeconds.get()));
+				.build();
 	}
 
 	public void recordUnlock() {
@@ -42,11 +37,11 @@ public class VaultUnlockMetrics {
 	}
 
 	public void recordSuccess() {
-		lastSuccessEpochSeconds.set(currentEpochSeconds());
+		lastSuccessGauge.set(currentEpochSeconds());
 	}
 
 	public void recordFailure() {
-		lastFailureEpochSeconds.set(currentEpochSeconds());
+		lastFailureGauge.set(currentEpochSeconds());
 	}
 
 	private long currentEpochSeconds() {

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -55,9 +55,11 @@ quarkus.swagger-ui.enabled=false
 %dev.quarkus.swagger-ui.enabled=true
 %dev.quarkus.swagger-ui.title=Hub API
 %dev.quarkus.swagger-ui.oauth-use-pkce-with-authorization-code-grant=true
-# Metrics endpoint
-quarkus.micrometer.export.prometheus.enabled=false
-%dev.quarkus.micrometer.export.prometheus.enabled=true
+# OpenTelemetry. Tracing is on by default; metrics and logs are opt-in.
+# OTLP endpoint defaults to http://localhost:4317; override per deployment.
+quarkus.otel.metrics.enabled=true
+quarkus.otel.logs.enabled=true
+%test.quarkus.otel.sdk.disabled=true
 # Database
 quarkus.datasource.db-kind=postgresql
 quarkus.datasource.jdbc.driver=org.postgresql.Driver

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -60,7 +60,6 @@ quarkus.swagger-ui.enabled=false
 quarkus.management.enabled=true
 quarkus.management.port=9000
 # OpenTelemetry. Tracing is on by default; metrics and logs are opt-in.
-# OTLP endpoint defaults to http://localhost:4317; override per deployment.
 quarkus.otel.metrics.enabled=true
 quarkus.otel.logs.enabled=true
 %test.quarkus.otel.sdk.disabled=true

--- a/charts/cryptomator-hub/Chart.yaml
+++ b/charts/cryptomator-hub/Chart.yaml
@@ -5,7 +5,7 @@ icon: https://cryptomator.org/img/logo.png
 description: Helm chart for deploying Cryptomator Hub with optional Keycloak and PostgreSQL
 type: application
 version: 0.1.3
-appVersion: "1.5.0-alpha3"
+appVersion: "63024bb"
 kubeVersion: ">=1.27.0-0"
 sources:
   - https://github.com/cryptomator/hub

--- a/charts/cryptomator-hub/README.md
+++ b/charts/cryptomator-hub/README.md
@@ -29,7 +29,7 @@ helm install hub charts/cryptomator-hub \
   --wait --timeout 5m \
   --set urls.hub.public=http://localhost:9090/hub \
   --set urls.kc.public=http://localhost:9090/kc \
-  --set ingress.controller=contour \
+  --set ingress.controller=nginx \
   --set hub.admin.password=password
 ```
 
@@ -42,19 +42,16 @@ The Keycloak realm import is rendered from a dedicated template using:
 - `hub.secrets.systemClientSecret` (optional; auto-generated when chart-managed Hub secret is used)
 - `hub.admin.*` (realm-level Hub admin user; separate from `keycloak.admin.*` bootstrap user)
 
-## Metrics Endpoint
+## Telemetry (OpenTelemetry)
 
-Hub metrics are configured via:
+Hub exports metrics, traces and logs via OpenTelemetry / OTLP. Telemetry is **off by default**; enable it via:
 
-- `hub.metrics.enabled`
-- `hub.metrics.username`
-- `hub.metrics.password` (optional; auto-generated if unset)
+- `hub.metrics.enabled` (default `false`)
+- `hub.metrics.endpoint` — OTLP/gRPC endpoint, default `http://otel-collector:4317`
+- `hub.metrics.resourceAttributes` — extra OTel resource attributes merged into the chart defaults (`service.name`, `service.version`). Setting a key with the same name overrides the default.
+- `hub.metrics.otlp.username` / `hub.metrics.otlp.password` — Credentials used to add `QUARKUS_OTEL_EXPORTER_OTLP_HEADERS` header `Authorization: Basic <base64(user:pass)>`.
 
-When metrics are enabled, the chart creates:
-
-- Secret `<release>-secrets-hub-metrics` of type `kubernetes.io/basic-auth`
-- Metrics ingress route on Hub management endpoint path `/q/metrics`
-- Basic-auth protection for metrics ingress on `nginx` and `traefik` controllers
+When disabled, the chart sets `QUARKUS_OTEL_SDK_DISABLED=true` so the SDK does not start. When enabled, the chart sets `QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT` and Hub pushes to your collector — there is no `/q/metrics` scrape endpoint anymore. To bridge to Prometheus, run an OpenTelemetry Collector with `prometheus` or `prometheusremotewrite` exporter.
 
 ## Hub with External PostgreSQL and Keycloak
 

--- a/charts/cryptomator-hub/README.md
+++ b/charts/cryptomator-hub/README.md
@@ -47,7 +47,8 @@ The Keycloak realm import is rendered from a dedicated template using:
 Hub exports metrics, traces and logs via OpenTelemetry / OTLP. Telemetry is **off by default**; enable it via:
 
 - `hub.metrics.enabled` (default `false`)
-- `hub.metrics.endpoint` — OTLP/gRPC endpoint, default `http://otel-collector:4317`
+- `hub.metrics.endpoint` — OTLP endpoint, default `https://otel-collector:443`
+- `hub.metrics.protocol` — OTLP wire protocol: `http/protobuf` (default) or `grpc`
 - `hub.metrics.resourceAttributes` — extra OTel resource attributes merged into the chart defaults (`service.name`, `service.version`). Setting a key with the same name overrides the default.
 - `hub.metrics.otlp.username` / `hub.metrics.otlp.password` — Credentials used to add `QUARKUS_OTEL_EXPORTER_OTLP_HEADERS` header `Authorization: Basic <base64(user:pass)>`.
 

--- a/charts/cryptomator-hub/README.md
+++ b/charts/cryptomator-hub/README.md
@@ -20,7 +20,7 @@ Supported ingress controller templates:
 
 ## Quick Start (Full Internal Stack)
 
-Assuming you have a local KIND cluster, e.g. via [Podman Desktop](https://podman-desktop.io/) with contour ingress on port 9090:
+Assuming you have a local Minikube cluster, e.g. via [Podman Desktop](https://podman-desktop.io/) with nginx ingress on port 9090:
 
 ```bash
 helm install hub charts/cryptomator-hub \

--- a/charts/cryptomator-hub/templates/NOTES.txt
+++ b/charts/cryptomator-hub/templates/NOTES.txt
@@ -4,7 +4,6 @@
 {{- $kcSvc := printf "%s-service-kc" (include "cryptomator-hub.fullname" .) }}
 {{- $pgSvc := printf "%s-service-pg" (include "cryptomator-hub.fullname" .) }}
 {{- $hubSecret := printf "%s-secrets-hub" (include "cryptomator-hub.fullname" .) }}
-{{- $hubMetricsSecret := printf "%s-secrets-hub-metrics" (include "cryptomator-hub.fullname" .) }}
 {{- $kcSecret := printf "%s-secrets-kc" (include "cryptomator-hub.fullname" .) }}
 {{- $pgSecret := printf "%s-secrets-pg" (include "cryptomator-hub.fullname" .) }}
 {{- $cTitle := ternary "\033[1;36m" "" $useColor }}
@@ -25,9 +24,6 @@
 {{ printf "%s🌐 Ingress%s" $cSection $cReset }}
 {{- if .Values.ingress.controller }}
 - Hub: {{ .Values.urls.hub.public }}
-{{- if .Values.hub.metrics.enabled }}
-- Hub metrics: {{ .Values.urls.hub.public }}/q/metrics
-{{- end }}
 {{- if .Values.keycloak.enabled }}
 - Keycloak: {{ .Values.urls.kc.public }}
 {{- end }}
@@ -40,10 +36,6 @@ Ingress is disabled. Configure ingress manually to the services above.
 - Hub admin password (realm user): `kubectl get secret -n {{ $ns }} {{ $hubSecret }} -o jsonpath='{.data.hub_admin_password}' | base64 -d && echo`
 - Hub DB password: `kubectl get secret -n {{ $ns }} {{ $hubSecret }} -o jsonpath='{.data.hub_db_password}' | base64 -d && echo`
 {{- end }}
-{{- if .Values.hub.metrics.enabled }}
-- Hub metrics username: `kubectl get secret -n {{ $ns }} {{ $hubMetricsSecret }} -o jsonpath='{.data.username}' | base64 -d && echo`
-- Hub metrics password: `kubectl get secret -n {{ $ns }} {{ $hubMetricsSecret }} -o jsonpath='{.data.password}' | base64 -d && echo`
-{{- end }}
 {{- if .Values.keycloak.enabled }}
 - Keycloak admin password: `kubectl get secret -n {{ $ns }} {{ $kcSecret }} -o jsonpath='{.data.kc_admin_password}' | base64 -d && echo`
 - Keycloak DB password: `kubectl get secret -n {{ $ns }} {{ $kcSecret }} -o jsonpath='{.data.kc_db_password}' | base64 -d && echo`
@@ -52,8 +44,9 @@ Ingress is disabled. Configure ingress manually to the services above.
 - PostgreSQL admin password: `kubectl get secret -n {{ $ns }} {{ $pgSecret }} -o jsonpath='{.data.pg_admin_password}' | base64 -d && echo`
 {{- end }}
 
-{{ if and .Values.hub.metrics.enabled (eq .Values.ingress.controller "contour") }}
-⚠️ Contour doesn't support authentication, so the metrics endpoint isn't protected. Please secure it manually or set `hub.metrics.enabled` to `false` to avoid exposing it.
+{{ if .Values.hub.metrics.enabled }}
+{{ printf "%s📈 Telemetry%s" $cSection $cReset }}
+- Exporting OTLP/gRPC to `{{ .Values.hub.metrics.endpoint }}` (metrics, traces, logs).
 {{ end }}
 
 {{ if not .Values.keycloak.enabled }}

--- a/charts/cryptomator-hub/templates/NOTES.txt
+++ b/charts/cryptomator-hub/templates/NOTES.txt
@@ -46,7 +46,7 @@ Ingress is disabled. Configure ingress manually to the services above.
 
 {{ if .Values.hub.metrics.enabled }}
 {{ printf "%s📈 Telemetry%s" $cSection $cReset }}
-- Exporting OTLP/gRPC to `{{ .Values.hub.metrics.endpoint }}` (metrics, traces, logs).
+- Exporting to `{{ .Values.hub.metrics.endpoint }}` (metrics, traces, logs).
 {{ end }}
 
 {{ if not .Values.keycloak.enabled }}

--- a/charts/cryptomator-hub/templates/_helpers.tpl
+++ b/charts/cryptomator-hub/templates/_helpers.tpl
@@ -143,24 +143,6 @@ Auto-generated secrets below:
 {{- end -}}
 {{- end -}}
 
-{{- define "cryptomator-hub.resolvedHubMetricsPassword" -}}
-{{- if hasKey .Values "_resolvedHubMetricsPassword" -}}
-{{- index .Values "_resolvedHubMetricsPassword" -}}
-{{- else if .Values.hub.metrics.password -}}
-{{- $_ := set .Values "_resolvedHubMetricsPassword" .Values.hub.metrics.password -}}
-{{- index .Values "_resolvedHubMetricsPassword" -}}
-{{- else -}}
-{{- $secretName := print (include "cryptomator-hub.fullname" .) "-secrets-hub-metrics" -}}
-{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
-{{- if and $existing (hasKey $existing.data "password") -}}
-{{- $_ := set .Values "_resolvedHubMetricsPassword" (index $existing.data "password" | b64dec) -}}
-{{- else -}}
-{{- $_ := set .Values "_resolvedHubMetricsPassword" (randAlphaNum 32) -}}
-{{- end -}}
-{{- index .Values "_resolvedHubMetricsPassword" -}}
-{{- end -}}
-{{- end -}}
-
 {{- define "cryptomator-hub.resolvedKeycloakDbPassword" -}}
 {{- if hasKey .Values "_resolvedKeycloakDbPassword" -}}
 {{- index .Values "_resolvedKeycloakDbPassword" -}}

--- a/charts/cryptomator-hub/templates/hub-configmap.yaml
+++ b/charts/cryptomator-hub/templates/hub-configmap.yaml
@@ -32,6 +32,7 @@ data:
   QUARKUS_SMALLRYE_HEALTH_MANAGEMENT_ENABLED: "true"
   {{- if .Values.hub.metrics.enabled }}
   QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.hub.metrics.endpoint | required "hub.metrics.endpoint must be set when hub.metrics.enabled=true" | quote }}
+  QUARKUS_OTEL_EXPORTER_OTLP_PROTOCOL: {{ .Values.hub.metrics.protocol | required "hub.metrics.protocol must be set when hub.metrics.enabled=true" | quote }}
   {{- $attrs := dict "service.name" (include "cryptomator-hub.fullname" .) "service.version" .Chart.AppVersion -}}
   {{- range $k, $v := .Values.hub.metrics.resourceAttributes }}{{- $_ := set $attrs $k $v }}{{- end }}
   {{- $pairs := list }}

--- a/charts/cryptomator-hub/templates/hub-configmap.yaml
+++ b/charts/cryptomator-hub/templates/hub-configmap.yaml
@@ -30,4 +30,13 @@ data:
   QUARKUS_MANAGEMENT_HOST: "0.0.0.0"
   QUARKUS_MANAGEMENT_PORT: "9000"
   QUARKUS_SMALLRYE_HEALTH_MANAGEMENT_ENABLED: "true"
-  QUARKUS_MICROMETER_EXPORT_PROMETHEUS_ENABLED: {{ .Values.hub.metrics.enabled | quote }}
+  {{- if .Values.hub.metrics.enabled }}
+  QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT: {{ .Values.hub.metrics.endpoint | required "hub.metrics.endpoint must be set when hub.metrics.enabled=true" | quote }}
+  {{- $attrs := dict "service.name" (include "cryptomator-hub.fullname" .) "service.version" .Chart.AppVersion -}}
+  {{- range $k, $v := .Values.hub.metrics.resourceAttributes }}{{- $_ := set $attrs $k $v }}{{- end }}
+  {{- $pairs := list }}
+  {{- range $k, $v := $attrs }}{{- $pairs = append $pairs (printf "%s=%v" $k $v) }}{{- end }}
+  QUARKUS_OTEL_RESOURCE_ATTRIBUTES: {{ join "," $pairs | quote }}
+  {{- else }}
+  QUARKUS_OTEL_SDK_DISABLED: "true"
+  {{- end }}

--- a/charts/cryptomator-hub/templates/hub-configmap.yaml
+++ b/charts/cryptomator-hub/templates/hub-configmap.yaml
@@ -36,7 +36,7 @@ data:
   {{- $attrs := dict "service.name" (include "cryptomator-hub.fullname" .) "service.version" .Chart.AppVersion -}}
   {{- range $k, $v := .Values.hub.metrics.resourceAttributes }}{{- $_ := set $attrs $k $v }}{{- end }}
   {{- $pairs := list }}
-  {{- range $k, $v := $attrs }}{{- $pairs = append $pairs (printf "%s=%v" $k $v) }}{{- end }}
+  {{- range $k := keys $attrs | sortAlpha }}{{- $pairs = append $pairs (printf "%s=%v" $k (index $attrs $k)) }}{{- end }}
   QUARKUS_OTEL_RESOURCE_ATTRIBUTES: {{ join "," $pairs | quote }}
   {{- else }}
   QUARKUS_OTEL_SDK_DISABLED: "true"

--- a/charts/cryptomator-hub/templates/hub-deployment.yaml
+++ b/charts/cryptomator-hub/templates/hub-deployment.yaml
@@ -20,6 +20,9 @@ spec:
       annotations:
         checksum/hub-config: {{ include (print $.Template.BasePath "/hub-configmap.yaml") . | sha256sum }}
         checksum/hub-secret: {{ if .Values.hub.secrets.create }}{{ include (print $.Template.BasePath "/hub-secret.yaml") . | sha256sum }}{{ else }}{{ print (include "cryptomator-hub.fullname" .) "-secrets-hub" | sha256sum }}{{ end }}
+        {{- if and .Values.hub.metrics.enabled .Values.hub.metrics.otlp.username .Values.hub.metrics.otlp.password }}
+        checksum/hub-metrics-secret: {{ include (print $.Template.BasePath "/hub-metrics-secret.yaml") . | sha256sum }}
+        {{- end }}
     spec:
       securityContext:
         runAsNonRoot: true
@@ -126,6 +129,13 @@ spec:
                   name: {{ include "cryptomator-hub.fullname" . }}-secrets-hub
                   key: hub_initial_license
                   optional: true
+            {{- if and .Values.hub.metrics.enabled .Values.hub.metrics.otlp.username .Values.hub.metrics.otlp.password }}
+            - name: QUARKUS_OTEL_EXPORTER_OTLP_HEADERS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "cryptomator-hub.fullname" . }}-secrets-hub-metrics
+                  key: otlp_authorization
+            {{- end }}
           resources:
             {{- toYaml .Values.hub.resources | nindent 12 }}
           securityContext:

--- a/charts/cryptomator-hub/templates/hub-metrics-secret.yaml
+++ b/charts/cryptomator-hub/templates/hub-metrics-secret.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.hub.metrics.enabled }}
+{{- if and .Values.hub.metrics.enabled .Values.hub.metrics.otlp.username .Values.hub.metrics.otlp.password }}
+{{- $auth := printf "%s:%s" .Values.hub.metrics.otlp.username .Values.hub.metrics.otlp.password | b64enc }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,8 +7,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cryptomator-hub.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
 type: kubernetes.io/basic-auth
 stringData:
-  username: {{ .Values.hub.metrics.username | quote }}
-  password: {{ include "cryptomator-hub.resolvedHubMetricsPassword" . | quote }}
+  username: {{ .Values.hub.metrics.otlp.username | quote }}
+  password: {{ .Values.hub.metrics.otlp.password | quote }}
+  otlp_authorization: {{ printf "Authorization=Basic %s" $auth | quote }}
 {{- end }}

--- a/charts/cryptomator-hub/templates/hub-metrics-secret.yaml
+++ b/charts/cryptomator-hub/templates/hub-metrics-secret.yaml
@@ -7,8 +7,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cryptomator-hub.labels" . | nindent 4 }}
+  {{- if .Values.secrets.keepOnUninstall }}
   annotations:
     helm.sh/resource-policy: keep
+  {{- end }}
 type: kubernetes.io/basic-auth
 stringData:
   username: {{ .Values.hub.metrics.otlp.username | quote }}

--- a/charts/cryptomator-hub/templates/hub-secret.yaml
+++ b/charts/cryptomator-hub/templates/hub-secret.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cryptomator-hub.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
 type: Opaque
 stringData:
   hub_system_client_secret: {{ include "cryptomator-hub.resolvedSystemClientSecret" . | quote }}

--- a/charts/cryptomator-hub/templates/hub-secret.yaml
+++ b/charts/cryptomator-hub/templates/hub-secret.yaml
@@ -6,8 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cryptomator-hub.labels" . | nindent 4 }}
+  {{- if .Values.secrets.keepOnUninstall }}
   annotations:
     helm.sh/resource-policy: keep
+  {{- end }}
 type: Opaque
 stringData:
   hub_system_client_secret: {{ include "cryptomator-hub.resolvedSystemClientSecret" . | quote }}

--- a/charts/cryptomator-hub/templates/ingress-contour.yaml
+++ b/charts/cryptomator-hub/templates/ingress-contour.yaml
@@ -1,7 +1,6 @@
 {{- if eq .Values.ingress.controller "contour" }}
 {{- $hubHost := regexReplaceAll "^https?://([^:/]+).*" (required "urls.hub.public must be set" .Values.urls.hub.public) "${1}" -}}
 {{- $hubPath := include "cryptomator-hub.hubRelativePath" . -}}
-{{- $hubMetricsPath := printf "%s/q/metrics" $hubPath -}}
 {{- $kcHost := regexReplaceAll "^https?://([^:/]+).*" (required "urls.kc.public must be set" .Values.urls.kc.public) "${1}" -}}
 {{- $kcPath := include "cryptomator-hub.keycloakRelativePath" . -}}
 {{- $sameHost := and .Values.keycloak.enabled (eq $hubHost $kcHost) -}}
@@ -21,19 +20,6 @@ spec:
       secretName: {{ .Values.ingress.tls.secretName | required "ingress.tls.secretName must be set when ingress.tls.enabled=true" }}
     {{- end }}
   routes:
-    {{- if .Values.hub.metrics.enabled }}
-    - conditions:
-        - prefix: {{ $hubMetricsPath | quote }}
-      {{- if ne $hubPath "/" }}
-      pathRewritePolicy:
-        replacePrefix:
-          - prefix: {{ $hubMetricsPath | quote }}
-            replacement: "/q/metrics"
-      {{- end }}
-      services:
-        - name: {{ include "cryptomator-hub.fullname" . }}-service-hub
-          port: {{ .Values.hub.service.managementPort }}
-    {{- end }}
     - conditions:
         - prefix: {{ $hubPath | quote }}
       {{- if ne $hubPath "/" }}

--- a/charts/cryptomator-hub/templates/ingress-nginx.yaml
+++ b/charts/cryptomator-hub/templates/ingress-nginx.yaml
@@ -1,7 +1,6 @@
 {{- if eq .Values.ingress.controller "nginx" }}
 {{- $hubHost := regexReplaceAll "^https?://([^:/]+).*" (required "urls.hub.public must be set" .Values.urls.hub.public) "${1}" -}}
 {{- $hubPath := include "cryptomator-hub.hubRelativePath" . -}}
-{{- $hubMetricsPath := printf "%s/q/metrics" $hubPath -}}
 {{- $kcHost := regexReplaceAll "^https?://([^:/]+).*" (required "urls.kc.public must be set" .Values.urls.kc.public) "${1}" -}}
 {{- $kcPath := include "cryptomator-hub.keycloakRelativePath" . -}}
 ---
@@ -41,48 +40,6 @@ spec:
         - {{ $hubHost | quote }}
       secretName: {{ .Values.ingress.tls.secretName | required "ingress.tls.secretName must be set when ingress.tls.enabled=true" }}
   {{- end }}
-{{- if .Values.hub.metrics.enabled }}
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: {{ include "cryptomator-hub.fullname" . }}-ingress-hub-metrics
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "cryptomator-hub.labels" . | nindent 4 }}
-  annotations:
-    {{- with .Values.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-    nginx.ingress.kubernetes.io/auth-type: "basic"
-    nginx.ingress.kubernetes.io/auth-secret: {{ printf "%s-secrets-hub-metrics" (include "cryptomator-hub.fullname" .) | quote }}
-    nginx.ingress.kubernetes.io/auth-realm: "Authentication Required"
-    {{- if ne $hubPath "/" }}
-    nginx.ingress.kubernetes.io/use-regex: "true"
-    nginx.ingress.kubernetes.io/rewrite-target: "/q/metrics$1$2"
-    {{- end }}
-spec:
-  {{- if .Values.ingress.className }}
-  ingressClassName: {{ .Values.ingress.className }}
-  {{- end }}
-  rules:
-    - host: {{ $hubHost | quote }}
-      http:
-        paths:
-          - path: {{ if eq $hubPath "/" }}{{ $hubMetricsPath | quote }}{{ else }}{{ printf "%s(/|$)(.*)" $hubMetricsPath | quote }}{{ end }}
-            pathType: {{ if eq $hubPath "/" }}Prefix{{ else }}ImplementationSpecific{{ end }}
-            backend:
-              service:
-                name: {{ include "cryptomator-hub.fullname" . }}-service-hub
-                port:
-                  number: {{ .Values.hub.service.managementPort }}
-  {{- if .Values.ingress.tls.enabled }}
-  tls:
-    - hosts:
-        - {{ $hubHost | quote }}
-      secretName: {{ .Values.ingress.tls.secretName | required "ingress.tls.secretName must be set when ingress.tls.enabled=true" }}
-  {{- end }}
-{{- end }}
 {{- if .Values.keycloak.enabled }}
 ---
 apiVersion: networking.k8s.io/v1

--- a/charts/cryptomator-hub/templates/ingress-traefik.yaml
+++ b/charts/cryptomator-hub/templates/ingress-traefik.yaml
@@ -1,7 +1,6 @@
 {{- if eq .Values.ingress.controller "traefik" }}
 {{- $hubHost := regexReplaceAll "^https?://([^:/]+).*" (required "urls.hub.public must be set" .Values.urls.hub.public) "${1}" -}}
 {{- $hubPath := include "cryptomator-hub.hubRelativePath" . -}}
-{{- $hubMetricsPath := printf "%s/q/metrics" $hubPath -}}
 {{- $kcHost := regexReplaceAll "^https?://([^:/]+).*" (required "urls.kc.public must be set" .Values.urls.kc.public) "${1}" -}}
 {{- $kcPath := include "cryptomator-hub.keycloakRelativePath" . -}}
 {{- if ne $hubPath "/" }}
@@ -54,57 +53,6 @@ spec:
         - {{ $hubHost | quote }}
       secretName: {{ .Values.ingress.tls.secretName | required "ingress.tls.secretName must be set when ingress.tls.enabled=true" }}
   {{- end }}
-{{- if .Values.hub.metrics.enabled }}
----
-apiVersion: traefik.io/v1alpha1
-kind: Middleware
-metadata:
-  name: {{ include "cryptomator-hub.fullname" . }}-metrics-auth
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "cryptomator-hub.labels" . | nindent 4 }}
-spec:
-  basicAuth:
-    secret: {{ include "cryptomator-hub.fullname" . }}-secrets-hub-metrics
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: {{ include "cryptomator-hub.fullname" . }}-ingress-hub-metrics
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "cryptomator-hub.labels" . | nindent 4 }}
-  {{- $metricsMiddleware := printf "%s-%s-metrics-auth@kubernetescrd" .Release.Namespace (include "cryptomator-hub.fullname" .) -}}
-  {{- if ne $hubPath "/" -}}
-    {{- $metricsMiddleware = printf "%[1]s-%[2]s-stripprefix@kubernetescrd,%[1]s-%[2]s-metrics-auth@kubernetescrd" .Release.Namespace (include "cryptomator-hub.fullname" .) -}}
-  {{- end }}
-  annotations:
-    traefik.ingress.kubernetes.io/router.middlewares: {{ $metricsMiddleware | quote }}
-    {{- with .Values.ingress.annotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-spec:
-  {{- if .Values.ingress.className }}
-  ingressClassName: {{ .Values.ingress.className }}
-  {{- end }}
-  rules:
-    - host: {{ $hubHost | quote }}
-      http:
-        paths:
-          - path: {{ $hubMetricsPath | quote }}
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "cryptomator-hub.fullname" . }}-service-hub
-                port:
-                  number: {{ .Values.hub.service.managementPort }}
-  {{- if .Values.ingress.tls.enabled }}
-  tls:
-    - hosts:
-        - {{ $hubHost | quote }}
-      secretName: {{ .Values.ingress.tls.secretName | required "ingress.tls.secretName must be set when ingress.tls.enabled=true" }}
-  {{- end }}
-{{- end }}
 {{- if .Values.keycloak.enabled }}
 ---
 apiVersion: networking.k8s.io/v1

--- a/charts/cryptomator-hub/templates/keycloak-secret.yaml
+++ b/charts/cryptomator-hub/templates/keycloak-secret.yaml
@@ -5,8 +5,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cryptomator-hub.labels" . | nindent 4 }}
+  {{- if .Values.secrets.keepOnUninstall }}
   annotations:
     helm.sh/resource-policy: keep
+  {{- end }}
 type: Opaque
 stringData:
   {{- if .Values.keycloak.enabled }}

--- a/charts/cryptomator-hub/templates/keycloak-secret.yaml
+++ b/charts/cryptomator-hub/templates/keycloak-secret.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cryptomator-hub.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
 type: Opaque
 stringData:
   {{- if .Values.keycloak.enabled }}

--- a/charts/cryptomator-hub/templates/postgres-secret.yaml
+++ b/charts/cryptomator-hub/templates/postgres-secret.yaml
@@ -6,8 +6,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cryptomator-hub.labels" . | nindent 4 }}
+  {{- if .Values.secrets.keepOnUninstall }}
   annotations:
     helm.sh/resource-policy: keep
+  {{- end }}
 type: Opaque
 stringData:
   pg_admin_password: {{ include "cryptomator-hub.resolvedPostgresAdminPassword" . | quote }}

--- a/charts/cryptomator-hub/templates/postgres-secret.yaml
+++ b/charts/cryptomator-hub/templates/postgres-secret.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cryptomator-hub.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/resource-policy: keep
 type: Opaque
 stringData:
   pg_admin_password: {{ include "cryptomator-hub.resolvedPostgresAdminPassword" . | quote }}

--- a/charts/cryptomator-hub/values-dev.yaml
+++ b/charts/cryptomator-hub/values-dev.yaml
@@ -1,6 +1,9 @@
 global:
   host: ""
 
+secrets:
+  keepOnUninstall: true
+
 hub:
   database:
     password: top-secret

--- a/charts/cryptomator-hub/values-dev.yaml
+++ b/charts/cryptomator-hub/values-dev.yaml
@@ -22,7 +22,3 @@ postgres:
     adminPassword: top-secret
   storage:
     size: 1Gi
-  resources:
-    requests:
-      cpu: 25m
-      memory: 128Mi

--- a/charts/cryptomator-hub/values-prod.yaml
+++ b/charts/cryptomator-hub/values-prod.yaml
@@ -11,10 +11,9 @@ hub:
   resources:
     requests:
       cpu: 50m
-      memory: 32Mi
+      memory: 16Mi
     limits:
-      cpu: 1000m
-      memory: 128Mi
+      memory: 32Mi
 
 keycloak:
   enabled: true
@@ -24,10 +23,9 @@ keycloak:
     password: replace-me
   resources:
     requests:
-      cpu: 100m
+      cpu: 200m
       memory: 512Mi
     limits:
-      cpu: 500m
       memory: 1Gi
 
 postgres:
@@ -38,8 +36,7 @@ postgres:
     size: 20Gi
   resources:
     requests:
-      cpu: 100m
+      cpu: 200m
       memory: 64Mi
     limits:
-      cpu: 2000m
       memory: 1Gi

--- a/charts/cryptomator-hub/values.yaml
+++ b/charts/cryptomator-hub/values.yaml
@@ -10,6 +10,11 @@ urls:
 notes:
   useColor: true
 
+secrets:
+  # When true, all chart-managed Secrets are annotated `helm.sh/resource-policy: keep` so they survive `helm uninstall`.
+  # Convenient for development (passwords stay stable across reinstalls) but a security risk in production
+  keepOnUninstall: false
+
 ingress:
   # supported: nginx, traefik, contour
   controller: ""

--- a/charts/cryptomator-hub/values.yaml
+++ b/charts/cryptomator-hub/values.yaml
@@ -38,17 +38,14 @@ hub:
     keycloakPublicUrl: ""
     keycloakLocalUrl: ""
   metrics:
-    # Hub ships metrics, traces and logs via OpenTelemetry / OTLP. When enabled,
-    # the deployment exports to `endpoint` (gRPC, port 4317 by default).
+    # Hub ships metrics, traces and logs via OpenTelemetry / OTLP.
     enabled: false
-    endpoint: "http://otel-collector:4317"
+    endpoint: "https://otel-collector:443"
+    protocol: "http/protobuf"
     # Extra resource attributes merged into the defaults (service.name, service.version).
     # Example: { deployment.environment: production, team: platform }
     resourceAttributes: {}
-    # Optional HTTP Basic auth credentials for the OTLP collector. When both are set,
-    # the chart creates a kubernetes.io/basic-auth Secret and the hub container picks
-    # up `Authorization: Basic <base64(username:password)>` via QUARKUS_OTEL_EXPORTER_OTLP_HEADERS.
-    otlp:
+    otlp: # Optional Basic Authentication for OTLP endpoint
       username: ""
       password: ""
   oidc:

--- a/charts/cryptomator-hub/values.yaml
+++ b/charts/cryptomator-hub/values.yaml
@@ -27,10 +27,9 @@ hub:
     managementPort: 9000
   resources:
     requests:
-      cpu: 10m
+      cpu: 50m
       memory: 16Mi
     limits:
-      cpu: 500m
       memory: 256Mi
   config:
     keycloakRealm: cryptomator
@@ -80,10 +79,9 @@ keycloak:
     managementPort: 9000
   resources:
     requests:
-      cpu: 20m
+      cpu: 200m
       memory: 128Mi
     limits:
-      cpu: 1000m
       memory: 640Mi
   admin:
     username: admin
@@ -110,10 +108,9 @@ postgres:
     accessMode: ReadWriteOnce
   resources:
     requests:
-      cpu: 10m
+      cpu: 200m
       memory: 32Mi
     limits:
-      cpu: 1000m
       memory: 256Mi
   auth:
     adminUsername: postgres

--- a/charts/cryptomator-hub/values.yaml
+++ b/charts/cryptomator-hub/values.yaml
@@ -38,9 +38,19 @@ hub:
     keycloakPublicUrl: ""
     keycloakLocalUrl: ""
   metrics:
-    enabled: true
-    username: metrics
-    password: ""
+    # Hub ships metrics, traces and logs via OpenTelemetry / OTLP. When enabled,
+    # the deployment exports to `endpoint` (gRPC, port 4317 by default).
+    enabled: false
+    endpoint: "http://otel-collector:4317"
+    # Extra resource attributes merged into the defaults (service.name, service.version).
+    # Example: { deployment.environment: production, team: platform }
+    resourceAttributes: {}
+    # Optional HTTP Basic auth credentials for the OTLP collector. When both are set,
+    # the chart creates a kubernetes.io/basic-auth Secret and the hub container picks
+    # up `Authorization: Basic <base64(username:password)>` via QUARKUS_OTEL_EXPORTER_OTLP_HEADERS.
+    otlp:
+      username: ""
+      password: ""
   oidc:
     clientId: cryptomatorhub
   database:


### PR DESCRIPTION
This pull request migrates the Cryptomator Hub backend and Helm chart from Micrometer/Prometheus metrics to OpenTelemetry (OTel) for metrics, traces, and logs. It removes the `/q/metrics` scrape endpoint and all related configuration, replacing it with OTLP push-based telemetry. The Helm chart and documentation are updated to reflect these changes, including new configuration options for OTLP endpoints and authentication.

**Backend migration to OpenTelemetry:**

* Replaced Micrometer dependencies with OpenTelemetry (`quarkus-opentelemetry`) in `pom.xml` and updated all metric instrumentation in `SystemUsageMetrics` and `VaultUnlockMetrics` to use the OTel API instead of Micrometer. [[1]](diffhunk://#diff-34049c3bc6deee4bbf269544338e0450399140da63fec684096d1ae0ce70b4bbL131-R131) [[2]](diffhunk://#diff-bfb4cefcbb51e0d7b44240e33ded6a9c32a59fe941f8c58ec3b6375e77d0687eL3-R5) [[3]](diffhunk://#diff-bfb4cefcbb51e0d7b44240e33ded6a9c32a59fe941f8c58ec3b6375e77d0687eR25-R28) [[4]](diffhunk://#diff-bfb4cefcbb51e0d7b44240e33ded6a9c32a59fe941f8c58ec3b6375e77d0687eL43-R66) [[5]](diffhunk://#diff-2360d302a3ecf99f2e49f688edc3b2c83469352cb738a5e542aadf063cfeae3fL3-R4) [[6]](diffhunk://#diff-2360d302a3ecf99f2e49f688edc3b2c83469352cb738a5e542aadf063cfeae3fL20-R41)
* Updated `application.properties` to remove Micrometer/Prometheus settings and enable OTel metrics/logs.

**Helm chart and deployment changes:**

* Removed all `/q/metrics` endpoint, ingress, and secret management for Prometheus scraping; added configuration for OTLP endpoint, protocol, resource attributes, and authentication headers. [[1]](diffhunk://#diff-80eaf460a75dceb11b14949b33993eb48d63f03cfc3187ac93f7357be3a58d2dL1-R16) [[2]](diffhunk://#diff-58158134d1a9765757cf0c3172883cc91f3fa22dc6a2ddb1450fff1fd82049f8L7) [[3]](diffhunk://#diff-58158134d1a9765757cf0c3172883cc91f3fa22dc6a2ddb1450fff1fd82049f8L28-L30) [[4]](diffhunk://#diff-58158134d1a9765757cf0c3172883cc91f3fa22dc6a2ddb1450fff1fd82049f8L43-L46) [[5]](diffhunk://#diff-24b14f47e84eb29ce59f47e6645ec65d03b38b096c4d7f815d5ccca8f8fc8f89L146-L163) [[6]](diffhunk://#diff-7774fcbaee50b25b196723ad123d200d0a94c5ed11189d70956c68f484d1c7a3L33-R43) [[7]](diffhunk://#diff-ff33760399642bbb711b65f396bb69eae0fdf15cf873fb13f58a94020415fd45R23-R25) [[8]](diffhunk://#diff-ff33760399642bbb711b65f396bb69eae0fdf15cf873fb13f58a94020415fd45R132-R138) [[9]](diffhunk://#diff-6946fd0cfc9e16c77302feb42bd397a6e0587a1b7ff8da470220028b0deeaaf7L4) [[10]](diffhunk://#diff-6946fd0cfc9e16c77302feb42bd397a6e0587a1b7ff8da470220028b0deeaaf7L24-L36) [[11]](diffhunk://#diff-f0d4ca518176c7ae5fb96231bc609e72c795b715131c02ad78645eff1e19992aL4) [[12]](diffhunk://#diff-649165f08aa9fccb8dfe615dc4fe1c7beb07974442f3cbe2d27c801fd7bf1489R9-R10)
* Updated deployment to inject OTel configuration and authentication headers when enabled. [[1]](diffhunk://#diff-ff33760399642bbb711b65f396bb69eae0fdf15cf873fb13f58a94020415fd45R23-R25) [[2]](diffhunk://#diff-ff33760399642bbb711b65f396bb69eae0fdf15cf873fb13f58a94020415fd45R132-R138) [[3]](diffhunk://#diff-80eaf460a75dceb11b14949b33993eb48d63f03cfc3187ac93f7357be3a58d2dL1-R16)

**Documentation updates:**

* Updated `README.md` to document the migration from metrics scraping to push-based OTel telemetry, including new configuration options and removal of legacy endpoints. [[1]](diffhunk://#diff-716fa0501e60626774f9dc4f7241f82ad71cdf6415b3350fe8016ac40d022debL32-R32) [[2]](diffhunk://#diff-716fa0501e60626774f9dc4f7241f82ad71cdf6415b3350fe8016ac40d022debL45-R55)

**Other:**

* Changed default ingress controller in example from `contour` to `nginx`.
* Added `helm.sh/resource-policy: keep` annotation to secrets for improved resource management. [[1]](diffhunk://#diff-649165f08aa9fccb8dfe615dc4fe1c7beb07974442f3cbe2d27c801fd7bf1489R9-R10) [[2]](diffhunk://#diff-80eaf460a75dceb11b14949b33993eb48d63f03cfc3187ac93f7357be3a58d2dL1-R16)

These changes modernize telemetry support, improve compatibility with observability platforms, and simplify metrics configuration and deployment.