### PR TITLE
Feature: Allow admins to set license in the UI

### DIFF
--- a/backend/src/main/java/org/cryptomator/hub/api/BillingResource.java
+++ b/backend/src/main/java/org/cryptomator/hub/api/BillingResource.java
@@ -62,8 +62,8 @@ public class BillingResource {
 		try {
 			licenseHolder.set(token);
 			return Response.status(Response.Status.NO_CONTENT).build();
-		} catch (JWTVerificationException _) {
-			return Response.status(Response.Status.BAD_REQUEST).build();
+		} catch (JWTVerificationException e) {
+			return Response.status(Response.Status.BAD_REQUEST).entity(e.getMessage()).type(MediaType.TEXT_PLAIN).build();
 		}
 	}
 

--- a/frontend/src/common/backend.ts
+++ b/frontend/src/common/backend.ts
@@ -34,7 +34,6 @@ axiosAuth.interceptors.request.use(async request => {
   }
 });
 
-
 // #region DTOs
 
 export type VaultDto = {
@@ -643,7 +642,8 @@ class BillingService {
   }
 
   public async setToken(token: string): Promise<void> {
-    return axiosAuth.put('/billing/token', token, { headers: { 'Content-Type': 'text/plain' } });
+    await axiosAuth.put('/billing/token', token, { headers: { 'Content-Type': 'text/plain' } })
+      .catch((error) => rethrowAndConvertIfExpected(error, 400));
   }
 
 }
@@ -748,6 +748,8 @@ export default services;
 
 function convertExpectedToBackendError(status: number): BackendError {
   switch (status) {
+    case 400:
+      return new BadRequestError();
     case 402:
       return new PaymentRequiredError();
     case 403:
@@ -781,6 +783,14 @@ export function asError(error: unknown): Error {
 }
 
 export class BackendError extends Error { }
+
+export class BadRequestError extends BackendError {
+
+  constructor() {
+    super('Bad request');
+  }
+
+}
 
 export class UnauthorizedError extends BackendError {
 

--- a/frontend/src/common/backend.ts
+++ b/frontend/src/common/backend.ts
@@ -746,10 +746,10 @@ export default services;
 // #endregion Services
 // #region Error handling
 
-function convertExpectedToBackendError(status: number): BackendError {
+function convertExpectedToBackendError(status: number, errorMessage?: string): BackendError {
   switch (status) {
     case 400:
-      return new BadRequestError();
+      return new BadRequestError(errorMessage);
     case 402:
       return new PaymentRequiredError();
     case 403:
@@ -765,7 +765,7 @@ function convertExpectedToBackendError(status: number): BackendError {
 
 export function rethrowAndConvertIfExpected(error: unknown, ...expectedStatusCodes: number[]): never {
   if (AxiosStatic.isAxiosError(error) && error.response != null && expectedStatusCodes.includes(error.response.status)) {
-    throw convertExpectedToBackendError(error.response.status);
+    throw convertExpectedToBackendError(error.response.status, typeof error.response.data === 'string' ? error.response.data : undefined);
   }
   throw error;
 }
@@ -786,8 +786,8 @@ export class BackendError extends Error { }
 
 export class BadRequestError extends BackendError {
 
-  constructor() {
-    super('Bad request');
+  constructor(message?: string) {
+    super(message ?? 'Bad request');
   }
 
 }

--- a/frontend/src/components/AdminSettings.vue
+++ b/frontend/src/components/AdminSettings.vue
@@ -86,7 +86,7 @@
           </h3>
           <div class="flex items-center gap-1">
             <button type="button" class="p-1 cursor-pointer text-gray-400 hover:text-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-primary rounded-full" :title="t('admin.licenseInfo.enterLicense')" @click="showEnterLicenseDialog()">
-              <PencilSquareIcon class="h-5 w-5" aria-hidden="true" />
+              <WrenchIcon class="h-5 w-5" aria-hidden="true" />
             </button>
             <button type="button" class="p-1 cursor-pointer text-gray-400 hover:text-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-primary rounded-full disabled:opacity-50 disabled:hover:text-gray-400 disabled:cursor-not-allowed" :title="t('common.refresh')" :disabled="!isRegistered" @click="refreshLicense()">
               <ArrowPathIcon class="h-5 w-5" aria-hidden="true" />
@@ -240,7 +240,7 @@
 </template>
 
 <script setup lang="ts">
-import { ArrowPathIcon, ArrowRightIcon, ArrowTopRightOnSquareIcon, CheckIcon, ExclamationTriangleIcon, InformationCircleIcon, LinkIcon, PencilSquareIcon, XMarkIcon } from '@heroicons/vue/20/solid';
+import { ArrowPathIcon, ArrowRightIcon, ArrowTopRightOnSquareIcon, CheckIcon, ExclamationTriangleIcon, InformationCircleIcon, LinkIcon, WrenchIcon, XMarkIcon } from '@heroicons/vue/20/solid';
 import semver from 'semver';
 import { computed, nextTick, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';

--- a/frontend/src/components/AdminSettings.vue
+++ b/frontend/src/components/AdminSettings.vue
@@ -84,9 +84,14 @@
           <h3 class="text-lg font-medium leading-6 text-gray-900">
             {{ t('admin.licenseInfo.title') }}
           </h3>
-          <button type="button" class="p-1 cursor-pointer text-gray-400 hover:text-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-primary rounded-full disabled:opacity-50 disabled:hover:text-gray-400 disabled:cursor-not-allowed" :title="t('common.refresh')" :disabled="!isRegistered" @click="refreshLicense()">
-            <ArrowPathIcon class="h-5 w-5" aria-hidden="true" />
-          </button>
+          <div class="flex items-center gap-1">
+            <button type="button" class="p-1 cursor-pointer text-gray-400 hover:text-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-primary rounded-full" :title="t('admin.licenseInfo.enterLicense')" @click="showEnterLicenseDialog()">
+              <PencilSquareIcon class="h-5 w-5" aria-hidden="true" />
+            </button>
+            <button type="button" class="p-1 cursor-pointer text-gray-400 hover:text-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-primary rounded-full disabled:opacity-50 disabled:hover:text-gray-400 disabled:cursor-not-allowed" :title="t('common.refresh')" :disabled="!isRegistered" @click="refreshLicense()">
+              <ArrowPathIcon class="h-5 w-5" aria-hidden="true" />
+            </button>
+          </div>
         </div>
         <p class="mt-1 text-sm text-gray-500 w-full">
           {{ t('admin.licenseInfo.description') }}
@@ -229,13 +234,15 @@
 
       <AdminSettingsEmergencyAccess />
     </div>
+
+    <EnterLicenseDialog v-if="enteringLicense" ref="enterLicenseDialog" @close="enteringLicense = false" @saved="onLicenseEntered()" />
   </div>
 </template>
 
 <script setup lang="ts">
-import { ArrowPathIcon, ArrowRightIcon, ArrowTopRightOnSquareIcon, CheckIcon, ExclamationTriangleIcon, InformationCircleIcon, LinkIcon, XMarkIcon } from '@heroicons/vue/20/solid';
+import { ArrowPathIcon, ArrowRightIcon, ArrowTopRightOnSquareIcon, CheckIcon, ExclamationTriangleIcon, InformationCircleIcon, LinkIcon, PencilSquareIcon, XMarkIcon } from '@heroicons/vue/20/solid';
 import semver from 'semver';
-import { computed, onMounted, ref } from 'vue';
+import { computed, nextTick, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import backend, { BillingDto, VersionDto } from '../common/backend';
 import config, { absFrontendBaseURL, ConfigDto } from '../common/config';
@@ -244,6 +251,7 @@ import { debounce } from '../common/util';
 import FetchError from './FetchError.vue';
 import AdminSettingsEmergencyAccess from './AdminSettingsEmergencyAccess.vue';
 import ContentBanner from './ContentBanner.vue';
+import EnterLicenseDialog from './EnterLicenseDialog.vue';
 
 const { t, d } = useI18n({ useScope: 'global' });
 const props = defineProps<{
@@ -343,6 +351,23 @@ const manageSubscriptionUrl = computed(() => {
 async function refreshLicense() {
   try {
     await backend.license.refresh();
+    billing.value = await backend.billing.get();
+    cfg.value = await config.reload();
+  } catch (error) {
+    console.error('Refreshing license info failed.', error);
+  }
+}
+
+const enteringLicense = ref(false);
+const enterLicenseDialog = ref<typeof EnterLicenseDialog>();
+
+function showEnterLicenseDialog() {
+  enteringLicense.value = true;
+  nextTick(() => enterLicenseDialog.value?.show());
+}
+
+async function onLicenseEntered() {
+  try {
     billing.value = await backend.billing.get();
     cfg.value = await config.reload();
   } catch (error) {

--- a/frontend/src/components/AdminSettings.vue
+++ b/frontend/src/components/AdminSettings.vue
@@ -86,7 +86,7 @@
           </h3>
           <div class="flex items-center gap-1">
             <button type="button" class="p-1 cursor-pointer text-gray-400 hover:text-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-primary rounded-full" :title="t('admin.licenseInfo.enterLicense')" @click="showEnterLicenseDialog()">
-              <WrenchIcon class="h-5 w-5" aria-hidden="true" />
+              <PencilIcon class="h-5 w-5" aria-hidden="true" />
             </button>
             <button type="button" class="p-1 cursor-pointer text-gray-400 hover:text-gray-600 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-primary rounded-full disabled:opacity-50 disabled:hover:text-gray-400 disabled:cursor-not-allowed" :title="t('common.refresh')" :disabled="!isRegistered" @click="refreshLicense()">
               <ArrowPathIcon class="h-5 w-5" aria-hidden="true" />
@@ -240,7 +240,7 @@
 </template>
 
 <script setup lang="ts">
-import { ArrowPathIcon, ArrowRightIcon, ArrowTopRightOnSquareIcon, CheckIcon, ExclamationTriangleIcon, InformationCircleIcon, LinkIcon, WrenchIcon, XMarkIcon } from '@heroicons/vue/20/solid';
+import { ArrowPathIcon, ArrowRightIcon, ArrowTopRightOnSquareIcon, CheckIcon, ExclamationTriangleIcon, InformationCircleIcon, LinkIcon, PencilIcon, XMarkIcon } from '@heroicons/vue/20/solid';
 import semver from 'semver';
 import { computed, nextTick, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';

--- a/frontend/src/components/EnterLicenseDialog.vue
+++ b/frontend/src/components/EnterLicenseDialog.vue
@@ -9,11 +9,11 @@
         <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
           <TransitionChild as="template" enter="ease-out duration-300" enter-from="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95" enter-to="opacity-100 translate-y-0 sm:scale-100" leave="ease-in duration-200" leave-from="opacity-100 translate-y-0 sm:scale-100" leave-to="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95">
             <DialogPanel class="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
-              <form novalidate @submit.prevent="setToken()">
+              <form novalidate @submit.prevent="setLicenseKey()">
                 <div class="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
                   <div class="sm:flex sm:items-start">
                     <div class="mx-auto shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-gray-100 sm:mx-0 sm:h-10 sm:w-10">
-                      <WrenchIcon class="h-6 w-6 text-gray-600" aria-hidden="true" />
+                      <PencilIcon class="h-6 w-6 text-gray-600" aria-hidden="true" />
                     </div>
                     <div class="mt-3 grow text-center sm:mt-0 sm:ml-4 sm:text-left">
                       <DialogTitle as="h3" class="text-lg leading-6 font-medium text-gray-900">
@@ -25,28 +25,28 @@
                         </p>
                       </div>
                       <div class="mt-5 sm:mt-6 text-left">
-                        <label for="licenseToken" class="block text-sm font-medium text-gray-700">{{ t('enterLicenseDialog.token') }}</label>
-                        <textarea id="licenseToken" v-model="token" rows="6" name="licenseToken" :aria-invalid="showFormatError" class="mt-1 focus:ring-primary focus:border-primary block w-full resize-none shadow-xs sm:text-sm border-gray-300 rounded-md font-mono break-all disabled:bg-gray-200" :class="{ 'border-red-300 text-red-900 focus:ring-red-500 focus:border-red-500': showFormatError }" :disabled="processing" />
+                        <label for="licenseKey" class="block text-sm font-medium text-gray-700">{{ t('enterLicenseDialog.licenseKey') }}</label>
+                        <textarea id="licenseKey" v-model="licenseKey" rows="6" name="licenseKey" :aria-invalid="showFormatError" class="mt-1 focus:ring-primary focus:border-primary block w-full resize-none shadow-xs sm:text-sm border-gray-300 rounded-md font-mono break-all disabled:bg-gray-200" :class="{ 'border-red-300 text-red-900 focus:ring-red-500 focus:border-red-500': showFormatError }" :disabled="processing" />
                         <p v-if="showFormatError" class="mt-2 text-sm text-red-900">
-                          {{ t('enterLicenseDialog.error.invalidToken') }}
+                          {{ t('enterLicenseDialog.error.invalidLicenseKey') }}
                         </p>
                       </div>
                     </div>
                   </div>
                 </div>
                 <div class="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse items-baseline">
-                  <button type="submit" :disabled="processing || !isTokenValid" class="w-full inline-flex justify-center rounded-md border border-transparent shadow-xs px-4 py-2 bg-primary text-base font-medium text-white hover:bg-primary-d1 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-primary disabled:opacity-50 disabled:hover:bg-primary disabled:cursor-not-allowed sm:ml-3 sm:w-auto sm:text-sm">
+                  <button type="submit" :disabled="processing || !isLicenseKeyValid" class="w-full inline-flex justify-center rounded-md border border-transparent shadow-xs px-4 py-2 bg-primary text-base font-medium text-white hover:bg-primary-d1 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-primary disabled:opacity-50 disabled:hover:bg-primary disabled:cursor-not-allowed sm:ml-3 sm:w-auto sm:text-sm">
                     {{ t('common.save') }}
                   </button>
                   <button type="button" :disabled="processing" class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-xs px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-primary disabled:opacity-50 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm" @click="open = false">
                     {{ t('common.cancel') }}
                   </button>
-                  <div v-if="onSetTokenError">
-                    <p v-if="onSetTokenError instanceof BadRequestError" class="text-sm text-red-900">
-                      {{ t('enterLicenseDialog.error.rejected', [onSetTokenError.message]) }}
+                  <div v-if="onSetLicenseKeyError">
+                    <p v-if="onSetLicenseKeyError instanceof BadRequestError" class="text-sm text-red-900">
+                      {{ t('enterLicenseDialog.error.rejected', [onSetLicenseKeyError.message]) }}
                     </p>
                     <p v-else class="text-sm text-red-900">
-                      {{ t('common.unexpectedError', [onSetTokenError.message]) }}
+                      {{ t('common.unexpectedError', [onSetLicenseKeyError.message]) }}
                     </p>
                   </div>
                 </div>
@@ -61,7 +61,7 @@
 
 <script setup lang="ts">
 import { Dialog, DialogOverlay, DialogPanel, DialogTitle, TransitionChild, TransitionRoot } from '@headlessui/vue';
-import { WrenchIcon } from '@heroicons/vue/24/outline';
+import { PencilIcon } from '@heroicons/vue/24/outline';
 import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import backend, { BadRequestError } from '../common/backend';
@@ -73,16 +73,16 @@ const { t } = useI18n({ useScope: 'global' });
 
 const open = ref(false);
 const processing = ref(false);
-const token = ref('');
-const onSetTokenError = ref<Error>();
+const licenseKey = ref('');
+const onSetLicenseKeyError = ref<Error>();
 
-// Immediate, field-level validation: the token must look like a JWT before it can be submitted.
-const isTokenValid = computed(() => JWT_PATTERN.test(token.value.trim()));
+// Immediate, field-level validation: the license key must look like a JWT before it can be submitted.
+const isLicenseKeyValid = computed(() => JWT_PATTERN.test(licenseKey.value.trim()));
 // Only flag the field once the user has actually entered something.
-const showFormatError = computed(() => token.value.trim().length > 0 && !isTokenValid.value);
+const showFormatError = computed(() => licenseKey.value.trim().length > 0 && !isLicenseKeyValid.value);
 
-// Editing the token invalidates any previous server verdict.
-watch(token, () => onSetTokenError.value = undefined);
+// Editing the license key invalidates any previous server verdict.
+watch(licenseKey, () => onSetLicenseKeyError.value = undefined);
 
 const emit = defineEmits<{
   close: []
@@ -94,24 +94,24 @@ defineExpose({
 });
 
 function show() {
-  token.value = '';
-  onSetTokenError.value = undefined;
+  licenseKey.value = '';
+  onSetLicenseKeyError.value = undefined;
   open.value = true;
 }
 
-async function setToken() {
-  if (!isTokenValid.value) {
+async function setLicenseKey() {
+  if (!isLicenseKeyValid.value) {
     return;
   }
-  onSetTokenError.value = undefined;
+  onSetLicenseKeyError.value = undefined;
   try {
     processing.value = true;
-    await backend.billing.setToken(token.value.trim());
+    await backend.billing.setToken(licenseKey.value.trim());
     emit('saved');
     open.value = false;
   } catch (error) {
-    console.error('Setting license token failed.', error);
-    onSetTokenError.value = error instanceof Error ? error : new Error('Unknown Error');
+    console.error('Setting license key failed.', error);
+    onSetLicenseKeyError.value = error instanceof Error ? error : new Error('Unknown Error');
   } finally {
     processing.value = false;
   }

--- a/frontend/src/components/EnterLicenseDialog.vue
+++ b/frontend/src/components/EnterLicenseDialog.vue
@@ -1,0 +1,119 @@
+<template>
+  <TransitionRoot as="template" :show="open" @after-leave="$emit('close')">
+    <Dialog as="div" class="fixed z-10 inset-0 overflow-y-auto" @close="open = false">
+      <TransitionChild as="template" enter="ease-out duration-300" enter-from="opacity-0" enter-to="opacity-100" leave="ease-in duration-200" leave-from="opacity-100" leave-to="opacity-0">
+        <DialogOverlay class="fixed inset-0 bg-gray-500/75 transition-opacity" />
+      </TransitionChild>
+
+      <div class="fixed inset-0 z-10 overflow-y-auto">
+        <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
+          <TransitionChild as="template" enter="ease-out duration-300" enter-from="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95" enter-to="opacity-100 translate-y-0 sm:scale-100" leave="ease-in duration-200" leave-from="opacity-100 translate-y-0 sm:scale-100" leave-to="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95">
+            <DialogPanel class="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
+              <form novalidate @submit.prevent="setToken()">
+                <div class="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+                  <div class="sm:flex sm:items-start">
+                    <div class="mx-auto shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-gray-100 sm:mx-0 sm:h-10 sm:w-10">
+                      <PercentBadgeIcon class="h-6 w-6 text-gray-600" aria-hidden="true" />
+                    </div>
+                    <div class="mt-3 grow text-center sm:mt-0 sm:ml-4 sm:text-left">
+                      <DialogTitle as="h3" class="text-lg leading-6 font-medium text-gray-900">
+                        {{ t('enterLicenseDialog.title') }}
+                      </DialogTitle>
+                      <div class="mt-2">
+                        <p class="text-sm text-gray-500">
+                          {{ t('enterLicenseDialog.description') }}
+                        </p>
+                      </div>
+                      <div class="mt-5 sm:mt-6 text-left">
+                        <label for="licenseToken" class="block text-sm font-medium text-gray-700">{{ t('enterLicenseDialog.token') }}</label>
+                        <textarea id="licenseToken" v-model="token" rows="6" name="licenseToken" :aria-invalid="showFormatError" class="mt-1 focus:ring-primary focus:border-primary block w-full resize-none shadow-xs sm:text-sm border-gray-300 rounded-md font-mono break-all disabled:bg-gray-200" :class="{ 'border-red-300 text-red-900 focus:ring-red-500 focus:border-red-500': showFormatError }" :disabled="processing" />
+                        <p v-if="showFormatError" class="mt-2 text-sm text-red-900">
+                          {{ t('enterLicenseDialog.error.invalidToken') }}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse items-baseline">
+                  <button type="submit" :disabled="processing || !isTokenValid" class="w-full inline-flex justify-center rounded-md border border-transparent shadow-xs px-4 py-2 bg-primary text-base font-medium text-white hover:bg-primary-d1 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-primary disabled:opacity-50 disabled:hover:bg-primary disabled:cursor-not-allowed sm:ml-3 sm:w-auto sm:text-sm">
+                    {{ t('common.save') }}
+                  </button>
+                  <button type="button" :disabled="processing" class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-xs px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-primary disabled:opacity-50 sm:mt-0 sm:ml-3 sm:w-auto sm:text-sm" @click="open = false">
+                    {{ t('common.cancel') }}
+                  </button>
+                  <div v-if="onSetTokenError">
+                    <p v-if="onSetTokenError instanceof BadRequestError" class="text-sm text-red-900">
+                      {{ t('enterLicenseDialog.error.rejected') }}
+                    </p>
+                    <p v-else class="text-sm text-red-900">
+                      {{ t('common.unexpectedError', [onSetTokenError.message]) }}
+                    </p>
+                  </div>
+                </div>
+              </form>
+            </DialogPanel>
+          </TransitionChild>
+        </div>
+      </div>
+    </Dialog>
+  </TransitionRoot>
+</template>
+
+<script setup lang="ts">
+import { Dialog, DialogOverlay, DialogPanel, DialogTitle, TransitionChild, TransitionRoot } from '@headlessui/vue';
+import { PercentBadgeIcon } from '@heroicons/vue/24/outline';
+import { computed, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import backend, { BadRequestError } from '../common/backend';
+
+// A JWS in compact serialization: three base64url-encoded segments separated by dots.
+const JWT_PATTERN = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
+
+const { t } = useI18n({ useScope: 'global' });
+
+const open = ref(false);
+const processing = ref(false);
+const token = ref('');
+const onSetTokenError = ref<Error>();
+
+// Immediate, field-level validation: the token must look like a JWT before it can be submitted.
+const isTokenValid = computed(() => JWT_PATTERN.test(token.value.trim()));
+// Only flag the field once the user has actually entered something.
+const showFormatError = computed(() => token.value.trim().length > 0 && !isTokenValid.value);
+
+// Editing the token invalidates any previous server verdict.
+watch(token, () => onSetTokenError.value = undefined);
+
+const emit = defineEmits<{
+  close: []
+  saved: []
+}>();
+
+defineExpose({
+  show
+});
+
+function show() {
+  token.value = '';
+  onSetTokenError.value = undefined;
+  open.value = true;
+}
+
+async function setToken() {
+  if (!isTokenValid.value) {
+    return;
+  }
+  onSetTokenError.value = undefined;
+  try {
+    processing.value = true;
+    await backend.billing.setToken(token.value.trim());
+    emit('saved');
+    open.value = false;
+  } catch (error) {
+    console.error('Setting license token failed.', error);
+    onSetTokenError.value = error instanceof Error ? error : new Error('Unknown Error');
+  } finally {
+    processing.value = false;
+  }
+}
+</script>

--- a/frontend/src/components/EnterLicenseDialog.vue
+++ b/frontend/src/components/EnterLicenseDialog.vue
@@ -13,7 +13,7 @@
                 <div class="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
                   <div class="sm:flex sm:items-start">
                     <div class="mx-auto shrink-0 flex items-center justify-center h-12 w-12 rounded-full bg-gray-100 sm:mx-0 sm:h-10 sm:w-10">
-                      <PercentBadgeIcon class="h-6 w-6 text-gray-600" aria-hidden="true" />
+                      <WrenchIcon class="h-6 w-6 text-gray-600" aria-hidden="true" />
                     </div>
                     <div class="mt-3 grow text-center sm:mt-0 sm:ml-4 sm:text-left">
                       <DialogTitle as="h3" class="text-lg leading-6 font-medium text-gray-900">
@@ -43,7 +43,7 @@
                   </button>
                   <div v-if="onSetTokenError">
                     <p v-if="onSetTokenError instanceof BadRequestError" class="text-sm text-red-900">
-                      {{ t('enterLicenseDialog.error.rejected') }}
+                      {{ t('enterLicenseDialog.error.rejected', [onSetTokenError.message]) }}
                     </p>
                     <p v-else class="text-sm text-red-900">
                       {{ t('common.unexpectedError', [onSetTokenError.message]) }}
@@ -61,7 +61,7 @@
 
 <script setup lang="ts">
 import { Dialog, DialogOverlay, DialogPanel, DialogTitle, TransitionChild, TransitionRoot } from '@headlessui/vue';
-import { PercentBadgeIcon } from '@heroicons/vue/24/outline';
+import { WrenchIcon } from '@heroicons/vue/24/outline';
 import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import backend, { BadRequestError } from '../common/backend';

--- a/frontend/src/i18n/en-US.json
+++ b/frontend/src/i18n/en-US.json
@@ -79,12 +79,12 @@
   "admin.licenseInfo.manageSubscription": "Manage Subscription",
   "admin.licenseInfo.type.title": "Type",
   "admin.licenseInfo.getLicense": "Get License",
-  "admin.licenseInfo.enterLicense": "Enter License Manually",
+  "admin.licenseInfo.enterLicense": "Change License Manually",
 
-  "enterLicenseDialog.title": "Enter License",
+  "enterLicenseDialog.title": "Change License",
   "enterLicenseDialog.description": "Paste your license token below.",
   "enterLicenseDialog.token": "License Token",
-  "enterLicenseDialog.error.invalidToken": "Wrong license format.",
+  "enterLicenseDialog.error.invalidToken": "Bad license format.",
   "enterLicenseDialog.error.rejected": "License rejected: {0}",
 
   "admin.webOfTrust.title": "Web of Trust",

--- a/frontend/src/i18n/en-US.json
+++ b/frontend/src/i18n/en-US.json
@@ -79,12 +79,12 @@
   "admin.licenseInfo.manageSubscription": "Manage Subscription",
   "admin.licenseInfo.type.title": "Type",
   "admin.licenseInfo.getLicense": "Get License",
-  "admin.licenseInfo.enterLicense": "Change License Manually",
+  "admin.licenseInfo.enterLicense": "Update License Manually",
 
-  "enterLicenseDialog.title": "Change License",
-  "enterLicenseDialog.description": "Paste your license token below.",
-  "enterLicenseDialog.token": "License Token",
-  "enterLicenseDialog.error.invalidToken": "Bad license format.",
+  "enterLicenseDialog.title": "Update License",
+  "enterLicenseDialog.description": "License keys are normally updated automatically. If Cryptomator Support has provided you with a key, you can enter it here.",
+  "enterLicenseDialog.licenseKey": "License Key",
+  "enterLicenseDialog.error.invalidLicenseKey": "Invalid license key format.",
   "enterLicenseDialog.error.rejected": "License rejected: {0}",
 
   "admin.webOfTrust.title": "Web of Trust",

--- a/frontend/src/i18n/en-US.json
+++ b/frontend/src/i18n/en-US.json
@@ -79,6 +79,13 @@
   "admin.licenseInfo.manageSubscription": "Manage Subscription",
   "admin.licenseInfo.type.title": "Type",
   "admin.licenseInfo.getLicense": "Get License",
+  "admin.licenseInfo.enterLicense": "Enter License Manually",
+
+  "enterLicenseDialog.title": "Enter License",
+  "enterLicenseDialog.description": "Paste your license token below.",
+  "enterLicenseDialog.token": "License Token",
+  "enterLicenseDialog.error.invalidToken": "Wrong license format.",
+  "enterLicenseDialog.error.rejected": "License rejected: Expired or invalid content.",
 
   "admin.webOfTrust.title": "Web of Trust",
   "admin.webOfTrust.description": "Configure the Web of Trust settings to manage how trust is established between users in the system. These settings affect the verification of user identities and key signatures.",
@@ -450,7 +457,7 @@
   "recoverVaultDialog.submit": "Recover Vault",
   "recoverVaultDialog.error.formValidationFailed": "Recovery Key must not be empty",
   "recoverVaultDialog.error.invalidRecoveryKey": "Invalid Recovery Key",
-  
+
   "regenerateAccountKeyDialog.confirmRegenerateAccountKey.title": "Regenerate Account Key",
   "regenerateAccountKeyDialog.confirmRegenerateAccountKey.description": "If you suspect that your old Account Key has been compromised, you can regenerate it. You will then only be able to add new devices with the new Account Key. Your existing devices will remain intact.",
   "regenerateAccountKeyDialog.saveAccountKey.title": "Save Account Key",

--- a/frontend/src/i18n/en-US.json
+++ b/frontend/src/i18n/en-US.json
@@ -85,7 +85,7 @@
   "enterLicenseDialog.description": "Paste your license token below.",
   "enterLicenseDialog.token": "License Token",
   "enterLicenseDialog.error.invalidToken": "Wrong license format.",
-  "enterLicenseDialog.error.rejected": "License rejected: Expired or invalid content.",
+  "enterLicenseDialog.error.rejected": "License rejected: {0}",
 
   "admin.webOfTrust.title": "Web of Trust",
   "admin.webOfTrust.description": "Configure the Web of Trust settings to manage how trust is established between users in the system. These settings affect the verification of user identities and key signatures.",


### PR DESCRIPTION
This PR adds the use case to set the license manuall in the frontend.

By default, the license is set/refreshed automatically. If the user has a (old) licensen token, there is no way to apply it. This is changed by the PR. A button in the admin view opens a dialog to change the license. The license is validated on the server and on error the reason for license rejected is displayed.

<img width="904" height="335" alt="image" src="https://github.com/user-attachments/assets/9c0b9515-212e-4b19-bb01-15740ab5dd3e" />
<img width="700" height="487" alt="image" src="https://github.com/user-attachments/assets/ccfbcec0-c30c-42ea-acc0-b1501d604bc1" />
