### PR TITLE
Feature: No raw JSON in auditlog UI

### DIFF
--- a/frontend/src/common/auditlog.ts
+++ b/frontend/src/common/auditlog.ts
@@ -164,6 +164,14 @@ export type AuditEventEmergencyAccessRecoveryAbortedDto = AuditEventDtoBase & {
 
 export type AuditEventDto = AuditEventDeviceRegisterDto | AuditEventDeviceRemoveDto | AuditEventSettingWotUpdateDto | AuditEventSignedWotIdDto | AuditEventUserAccountResetDto | AuditEventUserKeysChangeDto | AuditEventUserSetupCodeChangeDto | AuditEventVaultCreateDto | AuditEventVaultUpdateDto | AuditEventVaultAccessGrantDto | AuditEventVaultKeyRetrieveDto | AuditEventVaultMemberAddDto | AuditEventVaultMemberRemoveDto | AuditEventVaultMemberUpdateDto | AuditEventVaultOwnershipClaimDto | AuditEventEmergencyAccessSetupDto | AuditEventEmergencyAccessSettingsChangedDto | AuditEventEmergencyAccessRecoveryStartedDto | AuditEventEmergencyAccessRecoveryApprovedDto | AuditEventEmergencyAccessRecoveryCompletedDto | AuditEventEmergencyAccessRecoveryAbortedDto;
 
+/* Authority-ID resolution */
+
+/**
+ * Keys within a raw-JSON audit event payload (e.g. the `details` of an emergency access event)
+ * whose value(s) are authority ids that should be resolved to names in the audit log UI.
+ */
+export const AUTHORITY_ID_KEYS: ReadonlySet<string> = new Set(['newOwnerIds', 'newMemberIds']);
+
 /* Entity Cache */
 
 export class AuditLogEntityCache {

--- a/frontend/src/common/auditlog.ts
+++ b/frontend/src/common/auditlog.ts
@@ -170,7 +170,7 @@ export type AuditEventDto = AuditEventDeviceRegisterDto | AuditEventDeviceRemove
  * Keys within a raw-JSON audit event payload (e.g. the `details` of an emergency access event)
  * whose value(s) are authority ids that should be resolved to names in the audit log UI.
  */
-export const AUTHORITY_ID_KEYS: ReadonlySet<string> = new Set(['newOwnerIds', 'newMemberIds']);
+export const AUTHORITY_ID_KEYS: ReadonlySet<string> = new Set(['newOwnerIds', 'newMemberIds', 'emergencyCouncilMemberIds']);
 
 /* Entity Cache */
 

--- a/frontend/src/components/AuditLogDetailsEmergencyAccessRecoveryStarted.vue
+++ b/frontend/src/components/AuditLogDetailsEmergencyAccessRecoveryStarted.vue
@@ -45,8 +45,8 @@
             <ChevronRightIcon class="h-3.5 w-3.5 transition-transform" :class="{ 'rotate-90': detailsExpanded }" aria-hidden="true" />
           </button>
         </dt>
-        <dd v-if="detailsExpanded" class="text-xs text-gray-900">
-          <pre class="max-w-[48rem] overflow-x-auto whitespace-pre-wrap break-words bg-gray-50 rounded p-2 ring-1 ring-inset ring-gray-200">{{ prettyDetails }}</pre>
+        <dd v-if="detailsExpanded" class="text-sm text-gray-900 pl-3 border-l border-gray-100">
+          <AuditLogJsonView :value="parsedDetails" />
         </dd>
       </div>
     </dl>
@@ -59,6 +59,7 @@ import { onMounted, ref, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import auditlog, { AuditEventEmergencyAccessRecoveryStartedDto } from '../common/auditlog';
 import type { AuthorityDto, VaultDto } from '../common/backend';
+import AuditLogJsonView from './AuditLogJsonView.vue';
 
 const { t } = useI18n({ useScope: 'global' });
 
@@ -70,12 +71,13 @@ const resolvedVault = ref<VaultDto>();
 const resolvedCouncilMember = ref<AuthorityDto>();
 const detailsExpanded = ref(false);
 
-const prettyDetails = computed(() => {
+const parsedDetails = computed<unknown>(() => {
   const raw = props.event.details ?? '';
-  if (!raw) return '';
+  if (!raw) {
+    return null;
+  }
   try {
-    const obj = JSON.parse(raw);
-    return JSON.stringify(obj, null, 2);
+    return JSON.parse(raw);
   } catch {
     return raw;
   }

--- a/frontend/src/components/AuditLogDetailsEmergencyAccessRecoveryStarted.vue
+++ b/frontend/src/components/AuditLogDetailsEmergencyAccessRecoveryStarted.vue
@@ -38,11 +38,14 @@
           <code class="text-xs">{{ event.recoveryType }}</code>
         </dd>
       </div>
-      <div v-if="event.details" class="flex items-start gap-2">
-        <dt class="text-xs text-gray-500 mt-1">
-          <code>details</code>
+      <div v-if="event.details" class="flex flex-col gap-1">
+        <dt>
+          <button type="button" class="flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700 focus:outline-hidden" :aria-expanded="detailsExpanded" @click="detailsExpanded = !detailsExpanded">
+            <code>details</code>
+            <ChevronRightIcon class="h-3.5 w-3.5 transition-transform" :class="{ 'rotate-90': detailsExpanded }" aria-hidden="true" />
+          </button>
         </dt>
-        <dd class="text-xs text-gray-900">
+        <dd v-if="detailsExpanded" class="text-xs text-gray-900">
           <pre class="max-w-[48rem] overflow-x-auto whitespace-pre-wrap break-words bg-gray-50 rounded p-2 ring-1 ring-inset ring-gray-200">{{ prettyDetails }}</pre>
         </dd>
       </div>
@@ -51,6 +54,7 @@
 </template>
 
 <script setup lang="ts">
+import { ChevronRightIcon } from '@heroicons/vue/20/solid';
 import { onMounted, ref, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import auditlog, { AuditEventEmergencyAccessRecoveryStartedDto } from '../common/auditlog';
@@ -64,6 +68,7 @@ const props = defineProps<{
 
 const resolvedVault = ref<VaultDto>();
 const resolvedCouncilMember = ref<AuthorityDto>();
+const detailsExpanded = ref(false);
 
 const prettyDetails = computed(() => {
   const raw = props.event.details ?? '';

--- a/frontend/src/components/AuditLogDetailsEmergencyAccessSettingsUpdated.vue
+++ b/frontend/src/components/AuditLogDetailsEmergencyAccessSettingsUpdated.vue
@@ -53,7 +53,7 @@
           </button>
         </dt>
         <dd v-if="councilMembersExpanded" class="text-sm text-gray-900 pl-3 border-l border-gray-100">
-          <AuditLogJsonView :value="councilMembers" :force-id="true" />
+          <AuditLogJsonView :value="councilMembers" :force-id="Array.isArray(councilMembers)" />
         </dd>
       </div>
     </dl>
@@ -77,12 +77,16 @@ const props = defineProps<{
 const resolvedAdmin = ref<AuthorityDto | undefined>();
 const councilMembersExpanded = ref(false);
 
-const councilMembers = computed<string[]>(() => {
+const councilMembers = computed<unknown>(() => {
+  const raw = props.event.councilMemberIds ?? '';
+  if (raw === '') {
+    return '';
+  }
   try {
-    const parsed = JSON.parse(props.event.councilMemberIds ?? '[]');
-    return Array.isArray(parsed) ? parsed : [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : raw; // fall back to the raw value on unexpected shape
   } catch {
-    return [];
+    return raw; // visible fallback on malformed input
   }
 });
 

--- a/frontend/src/components/AuditLogDetailsEmergencyAccessSettingsUpdated.vue
+++ b/frontend/src/components/AuditLogDetailsEmergencyAccessSettingsUpdated.vue
@@ -45,14 +45,15 @@
           <code class="text-xs">{{ String(event.allowChoosingCouncil) }}</code>
         </dd>
       </div>
-      <div v-if="councilIds.length > 0" class="flex items-baseline gap-2">
-        <dt class="text-xs text-gray-500">
-          <code>councilMembers</code>
+      <div class="flex flex-col gap-1">
+        <dt>
+          <button type="button" class="flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700 focus:outline-hidden" :aria-expanded="councilMembersExpanded" @click="councilMembersExpanded = !councilMembersExpanded">
+            <code>councilMembers</code>
+            <ChevronRightIcon class="h-3.5 w-3.5 transition-transform" :class="{ 'rotate-90': councilMembersExpanded }" aria-hidden="true" />
+          </button>
         </dt>
-        <dd class="flex items-center flex-wrap gap-2 text-sm text-gray-900">
-          <code v-for="id in councilIds" :key="id" class="text-xs text-gray-700">
-            {{ id }}
-          </code>
+        <dd v-if="councilMembersExpanded" class="text-sm text-gray-900 pl-3 border-l border-gray-100">
+          <AuditLogJsonView :value="councilMembers" :force-id="true" />
         </dd>
       </div>
     </dl>
@@ -60,10 +61,12 @@
 </template>
 
 <script setup lang="ts">
+import { ChevronRightIcon } from '@heroicons/vue/20/solid';
 import { onMounted, ref, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import auditlog, { AuditEventEmergencyAccessSettingsChangedDto } from '../common/auditlog';
 import type { AuthorityDto } from '../common/backend';
+import AuditLogJsonView from './AuditLogJsonView.vue';
 
 const { t } = useI18n({ useScope: 'global' });
 
@@ -72,13 +75,16 @@ const props = defineProps<{
 }>();
 
 const resolvedAdmin = ref<AuthorityDto | undefined>();
+const councilMembersExpanded = ref(false);
 
-const councilIds = computed<string[]>(() =>
-  (props.event.councilMemberIds ?? '')
-    .split(/\s+/)
-    .map(s => s.trim())
-    .filter(Boolean)
-);
+const councilMembers = computed<string[]>(() => {
+  try {
+    const parsed = JSON.parse(props.event.councilMemberIds ?? '[]');
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+});
 
 onMounted(async () => {
   resolvedAdmin.value = await auditlog.entityCache.getAuthority(props.event.adminId);

--- a/frontend/src/components/AuditLogDetailsEmergencyAccessSetup.vue
+++ b/frontend/src/components/AuditLogDetailsEmergencyAccessSetup.vue
@@ -30,12 +30,15 @@
           <code class="text-xs">{{ event.ipAddress }}</code>
         </dd>
       </div>
-      <div class="flex items-start gap-2">
-        <dt class="text-xs text-gray-500 mt-1">
-          <code>settings</code>
+      <div class="flex flex-col gap-1">
+        <dt>
+          <button type="button" class="flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700 focus:outline-hidden" :aria-expanded="settingsExpanded" @click="settingsExpanded = !settingsExpanded">
+            <code>settings</code>
+            <ChevronRightIcon class="h-3.5 w-3.5 transition-transform" :class="{ 'rotate-90': settingsExpanded }" aria-hidden="true" />
+          </button>
         </dt>
-        <dd class="text-xs text-gray-900">
-          <pre class="max-w-[48rem] overflow-x-auto whitespace-pre-wrap break-words bg-gray-50 rounded p-2 ring-1 ring-inset ring-gray-200">{{ prettySettings }}</pre>
+        <dd v-if="settingsExpanded" class="text-sm text-gray-900 pl-3 border-l border-gray-100">
+          <AuditLogJsonView :value="parsedSettings" />
         </dd>
       </div>
     </dl>
@@ -43,10 +46,12 @@
 </template>
 
 <script setup lang="ts">
+import { ChevronRightIcon } from '@heroicons/vue/20/solid';
 import { onMounted, ref, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import auditlog, { AuditEventEmergencyAccessSetupDto } from '../common/auditlog';
 import type { AuthorityDto, VaultDto } from '../common/backend';
+import AuditLogJsonView from './AuditLogJsonView.vue';
 
 const { t } = useI18n({ useScope: 'global' });
 
@@ -56,13 +61,15 @@ const props = defineProps<{
 
 const resolvedOwner = ref<AuthorityDto>();
 const resolvedVault = ref<VaultDto>();
+const settingsExpanded = ref(false);
 
-const prettySettings = computed(() => {
+const parsedSettings = computed<unknown>(() => {
   const raw = props.event.settings ?? '';
-  if (!raw) return '';
+  if (!raw) {
+    return null;
+  }
   try {
-    const obj = JSON.parse(raw);
-    return JSON.stringify(obj, null, 2);
+    return JSON.parse(raw);
   } catch {
     return raw;
   }

--- a/frontend/src/components/AuditLogJsonView.vue
+++ b/frontend/src/components/AuditLogJsonView.vue
@@ -1,0 +1,80 @@
+<template>
+  <!-- object: one row per entry; primitive values inline, nested values indented below -->
+  <dl v-if="kind === 'object'" class="flex flex-col gap-1">
+    <div v-for="([key, val], i) in objectEntries" :key="i" :class="isComplex(val) ? 'flex flex-col gap-1' : 'flex items-baseline gap-2'">
+      <dt class="text-xs text-gray-500">
+        <AuditLogResolvedId v-if="isUuid(key)" :id="key" />
+        <code v-else>{{ key }}</code>
+      </dt>
+      <dd class="text-sm text-gray-900" :class="{ 'pl-3 border-l border-gray-100': isComplex(val) }">
+        <AuditLogJsonView :value="val" :force-id="isIdKey(key)" />
+      </dd>
+    </div>
+  </dl>
+
+  <!-- array: one item per line; id-ness propagates from the enclosing key -->
+  <ul v-else-if="kind === 'array'" class="flex flex-col gap-1">
+    <li v-for="(item, i) in arrayItems" :key="i" :class="{ 'pl-3 border-l border-gray-100': isComplex(item) }">
+      <AuditLogJsonView :value="item" :force-id="forceId" />
+    </li>
+  </ul>
+
+  <!-- resolvable id (key ends with Id/Ids, or value is a uuid) -->
+  <AuditLogResolvedId v-else-if="resolvableId != null" :id="resolvableId" />
+
+  <!-- primitives -->
+  <code v-else-if="typeof value === 'number' || typeof value === 'boolean'" class="text-xs text-gray-600">{{ value }}</code>
+  <span v-else-if="value === null || value === undefined || value === ''" class="text-gray-400">&lt;empty&gt;</span>
+  <span v-else class="text-sm text-gray-900 break-words">{{ value }}</span>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import AuditLogResolvedId from './AuditLogResolvedId.vue';
+
+const props = defineProps<{
+  value: unknown,
+  forceId?: boolean
+}>();
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isUuid(v: unknown): v is string {
+  return typeof v === 'string' && UUID_RE.test(v);
+}
+
+function isIdKey(key: string): boolean {
+  return /Ids?$/.test(key);
+}
+
+function isComplex(v: unknown): boolean {
+  return v !== null && typeof v === 'object';
+}
+
+const kind = computed<'object' | 'array' | 'other'>(() => {
+  if (Array.isArray(props.value)) {
+    return 'array';
+  } else if (props.value !== null && typeof props.value === 'object') {
+    return 'object';
+  } else {
+    return 'other';
+  }
+});
+
+const objectEntries = computed<[string, unknown][]>(() =>
+  kind.value === 'object' ? Object.entries(props.value as Record<string, unknown>) : []
+);
+
+const arrayItems = computed<unknown[]>(() =>
+  Array.isArray(props.value) ? props.value : []
+);
+
+const resolvableId = computed<string | null>(() => {
+  const v = props.value;
+  if (typeof v === 'string' && v !== '' && (props.forceId || isUuid(v))) {
+    return v;
+  } else {
+    return null;
+  }
+});
+</script>

--- a/frontend/src/components/AuditLogJsonView.vue
+++ b/frontend/src/components/AuditLogJsonView.vue
@@ -1,19 +1,19 @@
 <template>
   <!-- object: one row per entry; primitive values inline, nested values indented below -->
   <dl v-if="kind === 'object'" class="flex flex-col gap-1">
-    <div v-for="([key, val]) in objectEntries" :key="key" :class="isComplex(val) ? 'flex flex-col gap-1' : 'flex items-baseline gap-2'">
+    <div v-for="([key, val]) in objectEntries" :key="key" :class="isObject(val) ? 'flex flex-col gap-1' : 'flex items-baseline gap-2'">
       <dt class="text-xs text-gray-500">
         <code>{{ key }}</code>
       </dt>
-      <dd class="text-sm text-gray-900" :class="{ 'pl-3 border-l border-gray-100': isComplex(val) }">
-        <AuditLogJsonView :value="val" :force-id="isIdKey(key)" />
+      <dd class="text-sm text-gray-900" :class="{ 'pl-3 border-l border-gray-100': isObject(val) }">
+        <AuditLogJsonView :value="val" :force-id="isAuthorityId(key)" />
       </dd>
     </div>
   </dl>
 
   <!-- array: one item per line; id-ness propagates from the enclosing key -->
   <ul v-else-if="kind === 'array'" class="flex flex-col gap-1">
-    <li v-for="(item, i) in arrayItems" :key="i" :class="{ 'pl-3 border-l border-gray-100': isComplex(item) }">
+    <li v-for="(item, i) in arrayItems" :key="i" :class="{ 'pl-3 border-l border-gray-100': isObject(item) }">
       <AuditLogJsonView :value="item" :force-id="forceId" />
     </li>
   </ul>
@@ -37,11 +37,11 @@ const props = defineProps<{
   forceId?: boolean
 }>();
 
-function isIdKey(key: string): boolean {
+function isAuthorityId(key: string): boolean {
   return AUTHORITY_ID_KEYS.has(key);
 }
 
-function isComplex(v: unknown): boolean {
+function isObject(v: unknown): boolean {
   return v !== null && typeof v === 'object';
 }
 

--- a/frontend/src/components/AuditLogJsonView.vue
+++ b/frontend/src/components/AuditLogJsonView.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- object: one row per entry; primitive values inline, nested values indented below -->
   <dl v-if="kind === 'object'" class="flex flex-col gap-1">
-    <div v-for="([key, val], i) in objectEntries" :key="i" :class="isComplex(val) ? 'flex flex-col gap-1' : 'flex items-baseline gap-2'">
+    <div v-for="([key, val]) in objectEntries" :key="key" :class="isComplex(val) ? 'flex flex-col gap-1' : 'flex items-baseline gap-2'">
       <dt class="text-xs text-gray-500">
         <code>{{ key }}</code>
       </dt>

--- a/frontend/src/components/AuditLogJsonView.vue
+++ b/frontend/src/components/AuditLogJsonView.vue
@@ -3,8 +3,7 @@
   <dl v-if="kind === 'object'" class="flex flex-col gap-1">
     <div v-for="([key, val], i) in objectEntries" :key="i" :class="isComplex(val) ? 'flex flex-col gap-1' : 'flex items-baseline gap-2'">
       <dt class="text-xs text-gray-500">
-        <AuditLogResolvedId v-if="isUuid(key)" :id="key" />
-        <code v-else>{{ key }}</code>
+        <code>{{ key }}</code>
       </dt>
       <dd class="text-sm text-gray-900" :class="{ 'pl-3 border-l border-gray-100': isComplex(val) }">
         <AuditLogJsonView :value="val" :force-id="isIdKey(key)" />
@@ -19,7 +18,7 @@
     </li>
   </ul>
 
-  <!-- resolvable id (key ends with Id/Ids, or value is a uuid) -->
+  <!-- resolvable id (enclosing key is whitelisted as id-bearing) -->
   <AuditLogResolvedId v-else-if="resolvableId != null" :id="resolvableId" />
 
   <!-- primitives -->
@@ -30,6 +29,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue';
+import { AUTHORITY_ID_KEYS } from '../common/auditlog';
 import AuditLogResolvedId from './AuditLogResolvedId.vue';
 
 const props = defineProps<{
@@ -37,14 +37,8 @@ const props = defineProps<{
   forceId?: boolean
 }>();
 
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-function isUuid(v: unknown): v is string {
-  return typeof v === 'string' && UUID_RE.test(v);
-}
-
 function isIdKey(key: string): boolean {
-  return /Ids?$/.test(key);
+  return AUTHORITY_ID_KEYS.has(key);
 }
 
 function isComplex(v: unknown): boolean {
@@ -71,7 +65,7 @@ const arrayItems = computed<unknown[]>(() =>
 
 const resolvableId = computed<string | null>(() => {
   const v = props.value;
-  if (typeof v === 'string' && v !== '' && (props.forceId || isUuid(v))) {
+  if (typeof v === 'string' && v !== '' && props.forceId) {
     return v;
   } else {
     return null;

--- a/frontend/src/components/AuditLogResolvedId.vue
+++ b/frontend/src/components/AuditLogResolvedId.vue
@@ -1,0 +1,27 @@
+<template>
+  <span class="inline-flex items-baseline gap-2">
+    <span v-if="name != null" class="text-sm text-gray-900">{{ name }}</span>
+    <code class="text-xs" :class="{ 'text-gray-600': name != null }">{{ id }}</code>
+  </span>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from 'vue';
+import auditlog from '../common/auditlog';
+import type { AuthorityDto } from '../common/backend';
+
+const props = defineProps<{
+  id: string
+}>();
+
+const name = ref<string>();
+
+onMounted(async () => {
+  try {
+    const authority: AuthorityDto = await auditlog.entityCache.getAuthority(props.id);
+    name.value = authority?.name;
+  } catch {
+    name.value = undefined;
+  }
+});
+</script>

--- a/frontend/src/components/AuditLogResolvedId.vue
+++ b/frontend/src/components/AuditLogResolvedId.vue
@@ -6,7 +6,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, ref } from 'vue';
+import { ref, watch } from 'vue';
 import auditlog from '../common/auditlog';
 import type { AuthorityDto } from '../common/backend';
 
@@ -16,12 +16,17 @@ const props = defineProps<{
 
 const name = ref<string>();
 
-onMounted(async () => {
+watch(() => props.id, async (id) => {
+  name.value = undefined;
   try {
-    const authority: AuthorityDto = await auditlog.entityCache.getAuthority(props.id);
-    name.value = authority?.name;
+    const authority: AuthorityDto = await auditlog.entityCache.getAuthority(id);
+    if (props.id === id) { // ignore out-of-order resolution if the id changed meanwhile
+      name.value = authority?.name;
+    }
   } catch {
-    name.value = undefined;
+    if (props.id === id) {
+      name.value = undefined;
+    }
   }
-});
+}, { immediate: true });
 </script>


### PR DESCRIPTION
This PR improves the audit log UI in the frontend by converting any raw JSON strings into a generic, table tree like view.

Motivation is, that displaying raw JSON is harder to read for a non-technical user (special syntax, unresolved ids).

Any raw JSON string is now a expandable section in the corresponding audit log Vue component. On expansion, the JSON is parsed and displayed in a table-tree like manner. Also, on expansion, any authority ids are resolved. Due to the limited number of key-value-pairs containing ids, these fields are chosen with a whitelist. No regex parsing or any other heuristic is used.

<img width="1092" height="871" alt="image" src="https://github.com/user-attachments/assets/ce7514c5-ccf4-4b3f-9100-ff62f40f0317" />
