### PR TITLE
Feature: Global banners

### DIFF
--- a/frontend/src/common/globalBanners.ts
+++ b/frontend/src/common/globalBanners.ts
@@ -1,0 +1,52 @@
+import { ref } from 'vue';
+import authPromise from './auth';
+import backend, { LicenseUserInfoDto } from './backend';
+import userdata from './userdata';
+
+/**
+ * Instance-wide state that is announced on top of every view, independent of the currently shown view.
+ *
+ * @see GlobalBanners.vue
+ */
+class GlobalBanners {
+
+  public readonly isAdmin = ref(false);
+  public readonly licenseStatus = ref<LicenseUserInfoDto>();
+
+  /** @deprecated since version 1.3.0, to be removed in https://github.com/cryptomator/hub/issues/333 */
+  public readonly hasLegacyDevices = ref(false);
+  /** @deprecated since version 1.3.0, to be removed in https://github.com/cryptomator/hub/issues/333 */
+  public readonly anyUserHasLegacyDevices = ref(false);
+
+  /**
+   * Reloads all instance-wide state from the backend.
+   */
+  public async refresh(): Promise<void> {
+    this.isAdmin.value = (await authPromise).hasRole('admin');
+    await Promise.all([
+      this.refreshLicenseStatus(),
+      this.refreshLegacyDevices()
+    ]);
+  }
+
+  /**
+   * Reloads the license status of the instance.
+   */
+  public async refreshLicenseStatus(): Promise<void> {
+    this.licenseStatus.value = await backend.license.getUserInfo();
+  }
+
+  /**
+   * Reloads whether the current user (or, for admins, any user) still has legacy devices.
+   * @deprecated since version 1.3.0, to be removed in https://github.com/cryptomator/hub/issues/333
+   */
+  public async refreshLegacyDevices(): Promise<void> {
+    const me = await userdata.meWithLegacyDevicesAndLastAccess;
+    this.hasLegacyDevices.value = (me.devices?.length ?? 0) > 0;
+    this.anyUserHasLegacyDevices.value = this.isAdmin.value && await backend.devices.hasLegacyDevices();
+  }
+
+}
+
+const instance = new GlobalBanners();
+export default instance;

--- a/frontend/src/components/AdminSettings.vue
+++ b/frontend/src/components/AdminSettings.vue
@@ -16,10 +16,6 @@
       </h2>
     </div>
 
-    <ContentBanner v-if="hasLegacyDevices" type="warning" :title="t('legacyDeviceBanner.title')" class="mt-5">
-      {{ t('legacyDeviceBanner.admin.description') }}
-    </ContentBanner>
-
     <div class="space-y-6 mt-5">
       <!-- Server Information Section -->
       <section class="bg-white px-4 py-5 shadow-sm sm:rounded-lg sm:p-6">
@@ -250,7 +246,6 @@ import { FetchUpdateError, LatestVersionDto, updateChecker } from '../common/upd
 import { debounce } from '../common/util';
 import FetchError from './FetchError.vue';
 import AdminSettingsEmergencyAccess from './AdminSettingsEmergencyAccess.vue';
-import ContentBanner from './ContentBanner.vue';
 import EnterLicenseDialog from './EnterLicenseDialog.vue';
 
 const { t, d } = useI18n({ useScope: 'global' });
@@ -266,7 +261,6 @@ const form = ref<HTMLFormElement>();
 const processing = ref(false);
 const onFetchError = ref<Error>();
 const errorOnFetchingUpdates = ref<boolean>(false);
-const hasLegacyDevices = ref<boolean>(false);
 
 onMounted(async () => {
   keycloakAdminRealmURL.value = `${cfg.value.keycloakUrl}/admin/${cfg.value.keycloakRealm}/console/`;
@@ -288,7 +282,6 @@ async function fetchData() {
     const versionAvailable = versionDto.then(versionDto => updateChecker.get(versionDto.hubVersion));
     billing.value = await backend.billing.get();
     version.value = await versionDto;
-    hasLegacyDevices.value = await backend.devices.hasLegacyDevices();
 
     const settings = await backend.settings.get();
     wotMaxDepth.value = settings.wotMaxDepth;

--- a/frontend/src/components/AuditLog.vue
+++ b/frontend/src/components/AuditLog.vue
@@ -1,8 +1,4 @@
 <template>
-  <ContentBanner v-if="cfg.entitlements.showTrialHint" type="info" :title="t('trial.paidFeature.title')" class="mb-12">
-    {{ t('trial.paidFeature.description') }} <!-- TODO: link to feature comparison? -->
-  </ContentBanner>
-
   <div v-if="state == State.Loading">
     <div v-if="!onFetchError">
       {{ t('common.loading') }}
@@ -137,6 +133,10 @@
         </PopoverGroup>
       </div>
     </div>
+
+    <ContentBanner v-if="cfg.entitlements.showTrialHint" type="info" :title="t('trial.paidFeature.title')" class="mt-5">
+      {{ t('trial.paidFeature.description') }} <!-- TODO: link to feature comparison? -->
+    </ContentBanner>
 
     <div class="mt-5 flow-root">
       <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">

--- a/frontend/src/components/AuthenticatedMain.vue
+++ b/frontend/src/components/AuthenticatedMain.vue
@@ -11,6 +11,7 @@
 
   <AppShell v-else :me="me">
     <div class="max-w-7xl mx-auto px-4 py-12 sm:px-6 lg:px-8">
+      <GlobalBanners />
       <router-view />
     </div>
   </AppShell>
@@ -23,6 +24,7 @@ import { UserDto } from '../common/backend';
 import userdata from '../common/userdata';
 import AppShell from './AppShell.vue';
 import FetchError from './FetchError.vue';
+import GlobalBanners from './GlobalBanners.vue';
 
 const { t } = useI18n({ useScope: 'global' });
 

--- a/frontend/src/components/GlobalBanners.vue
+++ b/frontend/src/components/GlobalBanners.vue
@@ -1,0 +1,36 @@
+<template>
+  <LicenseAlert v-if="licenseStatus" :is-admin="isAdmin" :license-status="licenseStatus" />
+
+  <ContentBanner v-if="anyUserHasLegacyDevices" type="warning" :title="t('legacyDeviceBanner.title')" class="mb-4">
+    {{ t('legacyDeviceBanner.admin.description') }}
+  </ContentBanner>
+
+  <ContentBanner v-else-if="hasLegacyDevices" type="warning" :title="t('legacyDeviceBanner.title')" class="mb-4">
+    {{ t('legacyDeviceBanner.user.description') }}
+  </ContentBanner>
+</template>
+
+<script setup lang="ts">
+import { onMounted, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRoute } from 'vue-router';
+import globalBanners from '../common/globalBanners';
+import ContentBanner from './ContentBanner.vue';
+import LicenseAlert from './LicenseAlert.vue';
+
+const { t } = useI18n({ useScope: 'global' });
+const route = useRoute();
+
+const { isAdmin, licenseStatus, hasLegacyDevices, anyUserHasLegacyDevices } = globalBanners;
+
+onMounted(refresh);
+watch(() => route.path, refresh);
+
+async function refresh() {
+  try {
+    await globalBanners.refresh();
+  } catch (error) {
+    console.error('Retrieving instance-wide announcements failed.', error);
+  }
+}
+</script>

--- a/frontend/src/components/GlobalBanners.vue
+++ b/frontend/src/components/GlobalBanners.vue
@@ -5,8 +5,12 @@
     {{ t('legacyDeviceBanner.admin.description') }}
   </ContentBanner>
 
-  <ContentBanner v-else-if="hasLegacyDevices" type="warning" :title="t('legacyDeviceBanner.title')" class="mb-4">
-    {{ t('legacyDeviceBanner.user.description') }}
+  <ContentBanner v-else-if="true" type="warning" :title="t('legacyDeviceBanner.title')" class="mb-4">
+    <i18n-t keypath="legacyDeviceBanner.user.description" scope="global" tag="p">
+      <router-link to="/app/profile#legacyDeviceListTitle" class="underline hover:no-underline">
+        {{ t('legacyDeviceBanner.button') }}
+      </router-link>
+    </i18n-t>
   </ContentBanner>
 </template>
 

--- a/frontend/src/components/GlobalBanners.vue
+++ b/frontend/src/components/GlobalBanners.vue
@@ -5,7 +5,7 @@
     {{ t('legacyDeviceBanner.admin.description') }}
   </ContentBanner>
 
-  <ContentBanner v-else-if="true" type="warning" :title="t('legacyDeviceBanner.title')" class="mb-4">
+  <ContentBanner v-else-if="hasLegacyDevices" type="warning" :title="t('legacyDeviceBanner.title')" class="mb-4">
     <i18n-t keypath="legacyDeviceBanner.user.description" scope="global" tag="p">
       <router-link to="/app/profile#legacyDeviceListTitle" class="underline hover:no-underline">
         {{ t('legacyDeviceBanner.button') }}

--- a/frontend/src/components/LegacyDeviceList.vue
+++ b/frontend/src/components/LegacyDeviceList.vue
@@ -9,10 +9,6 @@
   </div>
 
   <div v-if="me?.devices && me.devices.length > 0">
-    <ContentBanner type="warning" :title="t('legacyDeviceBanner.title')" class="mb-4">
-      {{ t('legacyDeviceBanner.user.description') }}
-    </ContentBanner>
-
     <h2 id="legacyDeviceListTitle" class="text-base font-semibold leading-6 text-gray-900">
       {{ t('legacyDeviceList.title') }}
     </h2>
@@ -103,8 +99,8 @@ import { ArrowRightIcon, ComputerDesktopIcon, QuestionMarkCircleIcon } from '@he
 import { computed, onMounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import backend, { DeviceDto, NotFoundError, UserDto } from '../common/backend';
+import globalBanners from '../common/globalBanners';
 import userdata from '../common/userdata';
-import ContentBanner from './ContentBanner.vue';
 import FetchError from './FetchError.vue';
 
 const { t, d } = useI18n({ useScope: 'global' });
@@ -143,6 +139,7 @@ async function removeDevice(device: DeviceDto) {
     }
   }
   await fetchData(); // already handle errors
+  globalBanners.refreshLegacyDevices().catch(error => console.error('Refreshing legacy device banner failed.', error));
 }
 
 const sortedDevices = computed(() => {

--- a/frontend/src/components/VaultList.vue
+++ b/frontend/src/components/VaultList.vue
@@ -8,16 +8,6 @@
     </div>
   </div>
 
-  <LicenseAlert v-if="licenseStatus" :is-admin="isAdmin" :license-status="licenseStatus" />
-
-  <ContentBanner v-if="anyUserHasLegacyDevices" type="warning" :title="t('legacyDeviceBanner.title')" class="mb-4">
-    {{ t('legacyDeviceBanner.admin.description') }}
-  </ContentBanner>
-
-  <ContentBanner v-else-if="hasLegacyDevices" type="warning" :title="t('legacyDeviceBanner.title')" class="mb-4">
-    {{ t('legacyDeviceBanner.user.description') }}
-  </ContentBanner>
-
   <h2 class="text-2xl font-bold leading-9 text-gray-900 sm:text-3xl sm:truncate">
     {{ t('vaultList.title') }}
   </h2>
@@ -152,10 +142,9 @@ import { useI18n } from 'vue-i18n';
 import auth from '../common/auth';
 import backend, { LicenseUserInfoDto, SettingsDto, UserDto, VaultDto, VaultRole } from '../common/backend';
 import config from '../common/config';
+import globalBanners from '../common/globalBanners';
 import userdata from '../common/userdata';
-import ContentBanner from './ContentBanner.vue';
 import FetchError from './FetchError.vue';
-import LicenseAlert from './LicenseAlert.vue';
 import SlideOver from './SlideOver.vue';
 import VaultDetails from './VaultDetails.vue';
 import EmergencyBadge from './emergencyaccess/EmergencyBadge.vue';
@@ -186,10 +175,7 @@ const roleOfSelectedVault = computed<VaultRole | 'NONE'>(() => {
 
 const isAdmin = ref<boolean>(false);
 const canCreateVaults = ref<boolean>(false);
-const hasLegacyDevices = ref<boolean>(false);
-const anyUserHasLegacyDevices = ref<boolean>(false);
-const licenseStatus = ref<LicenseUserInfoDto>();
-const isLicenseViolated = computed(() => licenseStatus.value?.isViolated() ?? false);
+const isLicenseViolated = computed(() => globalBanners.licenseStatus.value?.isViolated() ?? false);
 
 const filterOptions = ref< {[key: string]: string} >({
   accessibleVaults: t('vaultList.filter.entry.accessibleVaults'),
@@ -213,15 +199,12 @@ async function fetchData() {
   try {
     me.value = await userdata.me;
     isAdmin.value = (await auth).hasRole('admin');
-    const meWithLegacy = await userdata.meWithLegacyDevicesAndLastAccess;
-    hasLegacyDevices.value = (meWithLegacy.devices?.length ?? 0) > 0;
     canCreateVaults.value = (await auth).hasRole('create-vaults');
 
     settings.value = await backend.settings.get();
 
     if (isAdmin.value) {
       filterOptions.value['allVaults'] = t('vaultList.filter.entry.allVaults');
-      anyUserHasLegacyDevices.value = await backend.devices.hasLegacyDevices();
     }
     accessibleVaults.value = (await backend.vaults.listAccessible()).filter(v => !v.archived).sort((a, b) => a.name.localeCompare(b.name));
     ownedVaults.value = (await backend.vaults.listAccessible('OWNER')).sort((a, b) => a.name.localeCompare(b.name));
@@ -238,7 +221,6 @@ async function fetchData() {
       default:
         throw new Error('Unknown filter');
     }
-    licenseStatus.value = await backend.license.getUserInfo();
   } catch (error) {
     console.error('Retrieving vault list failed.', error);
     onFetchError.value = error instanceof Error ? error : new Error('Unknown Error');
@@ -268,6 +250,6 @@ async function onSelectedVaultUpdate(vault: VaultDto) {
 }
 
 async function licenseUpdated(license: LicenseUserInfoDto) {
-  licenseStatus.value = license;
+  globalBanners.licenseStatus.value = license;
 }
 </script>

--- a/frontend/src/components/emergencyaccess/EmergencyAccessVaultList.vue
+++ b/frontend/src/components/emergencyaccess/EmergencyAccessVaultList.vue
@@ -3,12 +3,6 @@
     {{ t('common.loading') }}
   </div>
   <div v-else-if="!onFetchError">
-    <LicenseAlert v-if="licenseStatus" :is-admin="isAdmin" :license-status="licenseStatus" />
-
-    <ContentBanner v-if="entitlements.emergencyAccessEnabled && entitlements.showTrialHint" type="info" :title="t('trial.enterpriseFeature.title')" class="mb-6">
-      {{ t('trial.enterpriseFeature.description') }} <!-- TODO: link to feature comparison? -->
-    </ContentBanner>
-
     <div v-if="!entitlements.emergencyAccessEnabled" class="flex flex-col justify-center items-center text-center">
       <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
         <path vector-effect="non-scaling-stroke" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z" />
@@ -64,6 +58,10 @@
           </Listbox>
         </div>
       </header>
+
+      <ContentBanner v-if="entitlements.showTrialHint" type="info" :title="t('trial.enterpriseFeature.title')" class="mt-5">
+        {{ t('trial.enterpriseFeature.description') }} <!-- TODO: link to feature comparison? -->
+      </ContentBanner>
 
       <div v-if="filteredVaults.length === 0" class="mt-3 text-center">
         <h3 class="mt-2 text-sm font-medium text-gray-900">{{ t('emergencyAccess.empty.noneFound') }}</h3>
@@ -242,10 +240,9 @@ import { ref, computed, onMounted, nextTick } from 'vue';
 import { useI18n } from 'vue-i18n';
 import * as R from 'remeda';
 import auth from '../../common/auth';
-import backend, { LicenseUserInfoDto, VaultDto, RecoveryProcessDto, MemberDto, SettingsDto } from '../../common/backend';
+import backend, { VaultDto, RecoveryProcessDto, MemberDto, SettingsDto } from '../../common/backend';
 import FetchError from '../FetchError.vue';
 import { Listbox, ListboxButton, ListboxOption, ListboxOptions } from '@headlessui/vue';
-import LicenseAlert from '../LicenseAlert.vue';
 import ContentBanner from '../ContentBanner.vue';
 import { CheckIcon, ChevronDownIcon, ChevronUpDownIcon, WrenchIcon } from '@heroicons/vue/24/solid';
 import userdata from '../../common/userdata';
@@ -268,7 +265,6 @@ const onFetchError = ref<Error>();
 const isAdmin = ref<boolean>(false);
 
 const entitlements = config.get().entitlements;
-const licenseStatus = ref<LicenseUserInfoDto>();
 const settings = ref<SettingsDto>();
 
 const selectedFilter = ref<'recoverableVaults' | 'approved' | 'approvable' | 'startable'>('recoverableVaults');
@@ -298,7 +294,6 @@ async function fetchData() {
   try {
     me.value = await userdata.me;
     isAdmin.value = (await auth).hasRole('admin');
-    licenseStatus.value = await backend.license.getUserInfo();
     settings.value = await backend.settings.get();
 
     if (entitlements.emergencyAccessEnabled && settings.value.enableEmergencyAccess){

--- a/frontend/src/i18n/en-US.json
+++ b/frontend/src/i18n/en-US.json
@@ -434,7 +434,8 @@
   "legacyDeviceList.lastAccess": "Last Vault Access",
   "legacyDeviceList.lastAccess.toolTip": "May be missing for devices accessed with older versions.",
   "legacyDeviceBanner.title": "Legacy Devices Will Be Dropped",
-  "legacyDeviceBanner.user.description": "Your legacy devices will no longer be supported in the next major release. Please update Cryptomator on those devices or remove them.",
+  "legacyDeviceBanner.user.description": "Your legacy devices will no longer be supported in the next major release. Please review them in the {0} and either update Cryptomator on the listed devices or remove them.",
+  "legacyDeviceBanner.button": "User Profile",
   "legacyDeviceBanner.admin.description": "One or more users still have legacy devices. Legacy device support will be dropped in the next major release. Please ask affected users to update Cryptomator or remove their legacy devices.",
 
 


### PR DESCRIPTION
This PR refactors banner display in Hub.


It splits ContentBanners into two categories:
* global/instance wide banners:
  - license exceeded/expired
  - legacy devices exist
* local/view-dependent banners (i.e. enterprise feature)
  - audit log might be on trial
  - emergency access migh be on trial

These categories are presented differently:
* Global banners appear at the top of the all views.
* local banners are displayed beneath the header of the section/view
  
Additionally, the legacy device banner for users is improved with a link to the legacy device table.

### Note
We disscussed if some dialog should be dismissable. But that requires persisting the dismiss. To not hinder development, we postpone this decision.
  
Screenshot of audit logs with a global banner and a local one:
  
<img width="1163" height="686" alt="image" src="https://github.com/user-attachments/assets/ae69f557-df2d-42d7-b0c2-12136047cf5b" />
